### PR TITLE
chore(mixins): Export hideText mixin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,12 +5,14 @@ import stripUnit from './helpers/stripUnit'
 // Mixins
 import clearFix from './mixins/clearFix'
 import ellipsis from './mixins/ellipsis'
+import hideText from './mixins/hideText'
 
 const polished = {
   clearFix,
   ellipsis,
   stripUnit,
+  hideText,
 }
 
 export default polished
-export { clearFix, ellipsis, stripUnit }
+export { clearFix, ellipsis, stripUnit, hideText }


### PR DESCRIPTION
Somebody forgot to export the hideText mixin, meaning people couldn't
actually import it.