### PR TITLE
Add missing flow type references

### DIFF
--- a/.documentation.json
+++ b/.documentation.json
@@ -52,6 +52,19 @@
     "em",
     "modularScale",
     "rem",
-    "stripUnit"
+    "stripUnit",
+    {
+      "name": "Types",
+      "description": "Types used within the library."
+    },
+    "Ratio",
+    "RgbColor",
+    "RgbaColor",
+    "FontFaceConfiguration",
+    "RadialGradientConfiguration",
+    "TimingFunction",
+    "AnimationProperty",
+    "ButtonState",
+    "InputState"
   ]
 }

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -394,6 +394,106 @@
               
               </li>
             
+              
+              <li><a
+                href='#types'
+                class="h5 bold black caps">
+                Types
+                
+              </a>
+              
+              </li>
+            
+              
+              <li><a
+                href='#ratio'
+                class="">
+                Ratio
+                
+              </a>
+              
+              </li>
+            
+              
+              <li><a
+                href='#rgbcolor'
+                class="">
+                RgbColor
+                
+              </a>
+              
+              </li>
+            
+              
+              <li><a
+                href='#rgbacolor'
+                class="">
+                RgbaColor
+                
+              </a>
+              
+              </li>
+            
+              
+              <li><a
+                href='#fontfaceconfiguration'
+                class="">
+                FontFaceConfiguration
+                
+              </a>
+              
+              </li>
+            
+              
+              <li><a
+                href='#radialgradientconfiguration'
+                class="">
+                RadialGradientConfiguration
+                
+              </a>
+              
+              </li>
+            
+              
+              <li><a
+                href='#timingfunction'
+                class="">
+                TimingFunction
+                
+              </a>
+              
+              </li>
+            
+              
+              <li><a
+                href='#animationproperty'
+                class="">
+                AnimationProperty
+                
+              </a>
+              
+              </li>
+            
+              
+              <li><a
+                href='#buttonstate'
+                class="">
+                ButtonState
+                
+              </a>
+              
+              </li>
+            
+              
+              <li><a
+                href='#inputstate'
+                class="">
+                InputState
+                
+              </a>
+              
+              </li>
+            
           </ul>
         </div>
         <div class='mt1 h6 quiet'>
@@ -429,7 +529,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/mixins/clearFix.js#L26-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/mixins/clearFix.js#L26-L35'>
       <span>src/mixins/clearFix.js</span>
       </a>
     
@@ -515,7 +615,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/mixins/ellipsis.js#L29-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/mixins/ellipsis.js#L29-L38'>
       <span>src/mixins/ellipsis.js</span>
       </a>
     
@@ -604,7 +704,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/mixins/fontFace.js#L60-L91'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/mixins/fontFace.js#L61-L92'>
       <span>src/mixins/fontFace.js</span>
       </a>
     
@@ -766,7 +866,7 @@ injectGlobals`${
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/mixins/hiDPI.js#L32-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/mixins/hiDPI.js#L32-L40'>
       <span>src/mixins/hiDPI.js</span>
       </a>
     
@@ -858,7 +958,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/mixins/hideText.js#L29-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/mixins/hideText.js#L29-L35'>
       <span>src/mixins/hideText.js</span>
       </a>
     
@@ -933,7 +1033,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/mixins/normalize.js#L293-L296'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/mixins/normalize.js#L293-L296'>
       <span>src/mixins/normalize.js</span>
       </a>
     
@@ -1017,7 +1117,7 @@ html {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/mixins/placeholder.js#L35-L50'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/mixins/placeholder.js#L35-L50'>
       <span>src/mixins/placeholder.js</span>
       </a>
     
@@ -1120,7 +1220,7 @@ const div = styled.input`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/mixins/radialGradient.js#L66-L78'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/mixins/radialGradient.js#L67-L79'>
       <span>src/mixins/radialGradient.js</span>
       </a>
     
@@ -1260,7 +1360,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/mixins/retinaImage.js#L33-L48'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/mixins/retinaImage.js#L33-L48'>
       <span>src/mixins/retinaImage.js</span>
       </a>
     
@@ -1385,7 +1485,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/mixins/selection.js#L31-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/mixins/selection.js#L31-L40'>
       <span>src/mixins/selection.js</span>
       </a>
     
@@ -1484,7 +1584,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/mixins/timingFunctions.js#L81-L83'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/mixins/timingFunctions.js#L82-L84'>
       <span>src/mixins/timingFunctions.js</span>
       </a>
     
@@ -1494,7 +1594,7 @@ const div = styled.div`
   <p>String to represent commong easing functions as demonstrated here: (github.com/jaukia/easie).</p>
 
 
-  <div class='pre p1 fill-light mt0'>timingFunctions(timingFunction: TimingFunctions)</div>
+  <div class='pre p1 fill-light mt0'>timingFunctions(timingFunction: <a href="#timingfunction">TimingFunction</a>)</div>
   
   
 
@@ -1510,7 +1610,7 @@ const div = styled.div`
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>timingFunction</span> <code class='quiet'>(TimingFunctions)</code>
+            <span class='code bold'>timingFunction</span> <code class='quiet'>(<a href="#timingfunction">TimingFunction</a>)</code>
 	    
           </div>
           
@@ -1567,7 +1667,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/mixins/wordWrap.js#L26-L33'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/mixins/wordWrap.js#L26-L33'>
       <span>src/mixins/wordWrap.js</span>
       </a>
     
@@ -1668,7 +1768,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/helpers/rgb.js#L35-L43'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/helpers/rgb.js#L36-L44'>
       <span>src/helpers/rgb.js</span>
       </a>
     
@@ -1678,7 +1778,7 @@ const div = styled.div`
   <p>Returns a string value for the color. The returned result is the smallest possible hex notation.</p>
 
 
-  <div class='pre p1 fill-light mt0'>rgb(value: (RgbColor | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>), green: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, blue: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
+  <div class='pre p1 fill-light mt0'>rgb(value: (<a href="#rgbcolor">RgbColor</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>), green: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, blue: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
   
   
 
@@ -1694,7 +1794,7 @@ const div = styled.div`
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>value</span> <code class='quiet'>((RgbColor | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>))</code>
+            <span class='code bold'>value</span> <code class='quiet'>((<a href="#rgbcolor">RgbColor</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>))</code>
 	    
           </div>
           
@@ -1775,7 +1875,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/helpers/rgba.js#L38-L51'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/helpers/rgba.js#L39-L52'>
       <span>src/helpers/rgba.js</span>
       </a>
     
@@ -1785,7 +1885,7 @@ element {
   <p>Returns a string value for the color. The returned result is the smallest possible rgba or hex notation.</p>
 
 
-  <div class='pre p1 fill-light mt0'>rgba(value: (RgbaColor | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>), green: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, blue: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, alpha: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
+  <div class='pre p1 fill-light mt0'>rgba(value: (<a href="#rgbacolor">RgbaColor</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>), green: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, blue: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, alpha: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
   
   
 
@@ -1801,7 +1901,7 @@ element {
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>value</span> <code class='quiet'>((RgbaColor | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>))</code>
+            <span class='code bold'>value</span> <code class='quiet'>((<a href="#rgbacolor">RgbaColor</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>))</code>
 	    
           </div>
           
@@ -1893,7 +1993,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/helpers/hsl.js#L34-L42'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/helpers/hsl.js#L34-L42'>
       <span>src/helpers/hsl.js</span>
       </a>
     
@@ -2000,7 +2100,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/helpers/hsla.js#L39-L61'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/helpers/hsla.js#L39-L61'>
       <span>src/helpers/hsla.js</span>
       </a>
     
@@ -2133,7 +2233,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/shorthands/animation.js#L41-L61'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/shorthands/animation.js#L42-L62'>
       <span>src/shorthands/animation.js</span>
       </a>
     
@@ -2144,7 +2244,7 @@ element {
 or a single animation spread over the arguments.</p>
 
 
-  <div class='pre p1 fill-light mt0'>animation(args: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;AnimationProperty&gt; | AnimationProperty)&gt;)</div>
+  <div class='pre p1 fill-light mt0'>animation(args: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="#animationproperty">AnimationProperty</a>&gt; | <a href="#animationproperty">AnimationProperty</a>)&gt;)</div>
   
   
 
@@ -2160,7 +2260,7 @@ or a single animation spread over the arguments.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>args</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;AnimationProperty&gt; | AnimationProperty)&gt;)</code>
+            <span class='code bold'>args</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="#animationproperty">AnimationProperty</a>&gt; | <a href="#animationproperty">AnimationProperty</a>)&gt;)</code>
 	    
           </div>
           
@@ -2234,7 +2334,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/shorthands/backgroundImages.js#L23-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/shorthands/backgroundImages.js#L23-L27'>
       <span>src/shorthands/backgroundImages.js</span>
       </a>
     
@@ -2317,7 +2417,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/shorthands/backgrounds.js#L22-L26'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/shorthands/backgrounds.js#L22-L26'>
       <span>src/shorthands/backgrounds.js</span>
       </a>
     
@@ -2400,7 +2500,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/shorthands/borderColor.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/shorthands/borderColor.js#L27-L29'>
       <span>src/shorthands/borderColor.js</span>
       </a>
     
@@ -2486,7 +2586,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/shorthands/borderStyle.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/shorthands/borderStyle.js#L27-L29'>
       <span>src/shorthands/borderStyle.js</span>
       </a>
     
@@ -2572,7 +2672,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/shorthands/borderWidth.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/shorthands/borderWidth.js#L27-L29'>
       <span>src/shorthands/borderWidth.js</span>
       </a>
     
@@ -2658,7 +2758,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/shorthands/buttons.js#L47-L49'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/shorthands/buttons.js#L48-L50'>
       <span>src/shorthands/buttons.js</span>
       </a>
     
@@ -2668,7 +2768,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
   <p>Populates selectors that target all buttons. You can pass optional states to append to the selectors.</p>
 
 
-  <div class='pre p1 fill-light mt0'>buttons(states: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;State&gt;)</div>
+  <div class='pre p1 fill-light mt0'>buttons(states: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="#buttonstate">ButtonState</a>&gt;)</div>
   
   
 
@@ -2684,7 +2784,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>states</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;State&gt;)</code>
+            <span class='code bold'>states</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="#buttonstate">ButtonState</a>&gt;)</code>
 	    
           </div>
           
@@ -2748,7 +2848,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/shorthands/margin.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/shorthands/margin.js#L27-L29'>
       <span>src/shorthands/margin.js</span>
       </a>
     
@@ -2834,7 +2934,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/shorthands/padding.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/shorthands/padding.js#L27-L29'>
       <span>src/shorthands/padding.js</span>
       </a>
     
@@ -2920,7 +3020,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/shorthands/position.js#L49-L59'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/shorthands/position.js#L49-L59'>
       <span>src/shorthands/position.js</span>
       </a>
     
@@ -3034,7 +3134,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/shorthands/size.js#L24-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/shorthands/size.js#L24-L29'>
       <span>src/shorthands/size.js</span>
       </a>
     
@@ -3127,7 +3227,7 @@ const <span class="hljs-keyword">div</span> = styled.<span class="hljs-keyword">
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/shorthands/textInputs.js#L71-L73'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/shorthands/textInputs.js#L72-L74'>
       <span>src/shorthands/textInputs.js</span>
       </a>
     
@@ -3137,7 +3237,7 @@ const <span class="hljs-keyword">div</span> = styled.<span class="hljs-keyword">
   <p>Populates selectors that target all text inputs. You can pass optional states to append to the selectors.</p>
 
 
-  <div class='pre p1 fill-light mt0'>textInputs(states: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;State&gt;)</div>
+  <div class='pre p1 fill-light mt0'>textInputs(states: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="#inputstate">InputState</a>&gt;)</div>
   
   
 
@@ -3153,7 +3253,7 @@ const <span class="hljs-keyword">div</span> = styled.<span class="hljs-keyword">
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>states</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;State&gt;)</code>
+            <span class='code bold'>states</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="#inputstate">InputState</a>&gt;)</code>
 	    
           </div>
           
@@ -3244,7 +3344,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/helpers/directionalProperty.js#L44-L49'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/helpers/directionalProperty.js#L44-L49'>
       <span>src/helpers/directionalProperty.js</span>
       </a>
     
@@ -3338,7 +3438,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/helpers/em.js#L29-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/helpers/em.js#L29-L29'>
       <span>src/helpers/em.js</span>
       </a>
     
@@ -3431,7 +3531,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/helpers/modularScale.js#L66-L82'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/helpers/modularScale.js#L67-L83'>
       <span>src/helpers/modularScale.js</span>
       </a>
     
@@ -3441,7 +3541,7 @@ element {
   <p>Establish consistent measurements and spacial relationships throughout your projects by incrementing up or down a defined scale. We provide a list of commonly used scales as pre-defined variables, see below.</p>
 
 
-  <div class='pre p1 fill-light mt0'>modularScale(steps: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, base: [(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)], ratio: [Ratio])</div>
+  <div class='pre p1 fill-light mt0'>modularScale(steps: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, base: [(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)], ratio: [<a href="#ratio">Ratio</a>])</div>
   
   
 
@@ -3474,7 +3574,7 @@ element {
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>ratio</span> <code class='quiet'>([Ratio]
+            <span class='code bold'>ratio</span> <code class='quiet'>([<a href="#ratio">Ratio</a>]
             = <code>&#39;perfectFourth&#39;</code>)</code>
 	    
           </div>
@@ -3534,7 +3634,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/helpers/rem.js#L28-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/helpers/rem.js#L28-L28'>
       <span>src/helpers/rem.js</span>
       </a>
     
@@ -3627,7 +3727,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/4a2ece1bb28cd53dff024e075193ab37b8608521/src/helpers/stripUnit.js#L24-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/helpers/stripUnit.js#L24-L28'>
       <span>src/helpers/stripUnit.js</span>
       </a>
     
@@ -3693,6 +3793,608 @@ element {
   <span class="hljs-string">'--dimension'</span>: <span class="hljs-number">100</span>
 }</pre>
     
+  
+
+  
+
+  
+
+  
+</section>
+
+        
+      
+        
+          <div class='keyline-top-not py2'><section class='py2 clearfix'>
+
+  <h2 id='Types' class='mt0'>
+    Types
+  </h2>
+
+  
+    <p>Types used within the library.</p>
+
+  
+</section>
+</div>
+        
+      
+        
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='ratio'>
+      Ratio
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/helpers/modularScale.js#L26-L44'>
+      <span>src/helpers/modularScale.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+
+  <div class='pre p1 fill-light mt0'>Ratio</div>
+  
+  
+
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+        
+      
+        
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='rgbcolor'>
+      RgbColor
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/helpers/rgb.js#L7-L11'>
+      <span>src/helpers/rgb.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+
+  <div class='pre p1 fill-light mt0'>RgbColor</div>
+  
+  
+
+  
+  
+  
+  
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Properties</div>
+    <div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>red</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>green</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>blue</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
+          
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+        
+      
+        
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='rgbacolor'>
+      RgbaColor
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/helpers/rgba.js#L6-L11'>
+      <span>src/helpers/rgba.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+
+  <div class='pre p1 fill-light mt0'>RgbaColor</div>
+  
+  
+
+  
+  
+  
+  
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Properties</div>
+    <div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>red</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>green</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>blue</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>alpha</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
+          
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+        
+      
+        
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='fontfaceconfiguration'>
+      FontFaceConfiguration
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/mixins/fontFace.js#L4-L14'>
+      <span>src/mixins/fontFace.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+
+  <div class='pre p1 fill-light mt0'>FontFaceConfiguration</div>
+  
+  
+
+  
+  
+  
+  
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Properties</div>
+    <div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>fontFamily</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>fontFilePath</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>fontStretch</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>fontStyle</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>fontVariant</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>fontWeight</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>fileFormats</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>&gt;)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>localFonts</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>&gt;)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>unicodeRange</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+        
+      
+        
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='radialgradientconfiguration'>
+      RadialGradientConfiguration
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/mixins/radialGradient.js#L4-L10'>
+      <span>src/mixins/radialGradient.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+
+  <div class='pre p1 fill-light mt0'>RadialGradientConfiguration</div>
+  
+  
+
+  
+  
+  
+  
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Properties</div>
+    <div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>colorStops</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>&gt;)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>extent</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>fallback</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>position</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>shape</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+        
+      
+        
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='timingfunction'>
+      TimingFunction
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/mixins/timingFunctions.js#L35-L59'>
+      <span>src/mixins/timingFunctions.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+
+  <div class='pre p1 fill-light mt0'>TimingFunction</div>
+  
+  
+
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+        
+      
+        
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='animationproperty'>
+      AnimationProperty
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/shorthands/animation.js#L4-L4'>
+      <span>src/shorthands/animation.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+
+  <div class='pre p1 fill-light mt0'>AnimationProperty</div>
+  
+  
+
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+        
+      
+        
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='buttonstate'>
+      ButtonState
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/shorthands/buttons.js#L14-L19'>
+      <span>src/shorthands/buttons.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+
+  <div class='pre p1 fill-light mt0'>ButtonState</div>
+  
+  
+
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+        
+      
+        
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='inputstate'>
+      InputState
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e812e1223fb04bb6584b3213b538bcf344dbb6ff/src/shorthands/textInputs.js#L26-L31'>
+      <span>src/shorthands/textInputs.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+
+  <div class='pre p1 fill-light mt0'>InputState</div>
+  
+  
+
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
   
 
   

--- a/src/helpers/modularScale.js
+++ b/src/helpers/modularScale.js
@@ -22,6 +22,7 @@ const ratioNames = {
   doubleOctave: 4,
 }
 
+/** */
 type Ratio =
   | number
   | 'minorSecond'

--- a/src/helpers/rgb.js
+++ b/src/helpers/rgb.js
@@ -3,6 +3,7 @@
 import reduceHexValue from '../internalHelpers/_reduceHexValue'
 import toHex from '../internalHelpers/_numberToHex'
 
+/** */
 type RgbColor = {
   red: number,
   green: number,

--- a/src/helpers/rgba.js
+++ b/src/helpers/rgba.js
@@ -2,6 +2,7 @@
 
 import rgb from './rgb'
 
+/** */
 type RgbaColor = {
   red: number,
   green: number,

--- a/src/mixins/fontFace.js
+++ b/src/mixins/fontFace.js
@@ -1,6 +1,7 @@
 // @flow
 
-type ConfigurationType = {
+/** */
+type FontFaceConfiguration = {
   fontFamily: string;
   fontFilePath?: string;
   fontStretch?: string;
@@ -67,7 +68,7 @@ function fontFace({
     fileFormats = ['eot', 'woff2', 'woff', 'ttf', 'svg'],
     localFonts,
     unicodeRange,
-  }: ConfigurationType) {
+  }: FontFaceConfiguration) {
   // Error Handling
   if (!fontFamily) throw new Error('fontFace expects a name of a font-family.')
   if (!fontFilePath && !localFonts) throw new Error('fontFace expects either the path to the font file(s) or a name of a local copy.')

--- a/src/mixins/radialGradient.js
+++ b/src/mixins/radialGradient.js
@@ -1,6 +1,7 @@
 // @flow
 
-type radialGradientConfiguration = {
+/** */
+type RadialGradientConfiguration = {
   colorStops: Array<string>;
   extent?: string;
   fallback?: string;
@@ -69,7 +70,7 @@ function radialGradient({
   fallback,
   position,
   shape,
-}: radialGradientConfiguration) {
+}: RadialGradientConfiguration) {
   if (!colorStops || colorStops.length < 2) throw new Error('radialGradient requries at least 2 color-stops to properly render.')
   return {
     'background-color': fallback || parseFallback(colorStops),

--- a/src/mixins/timingFunctions.js
+++ b/src/mixins/timingFunctions.js
@@ -31,7 +31,8 @@ const functionsMap = {
 }
 /* eslint-enable key-spacing */
 
-type TimingFunctions =
+/** */
+type TimingFunction =
   | 'easeInBack'
   | 'easeInCirc'
   | 'easeInCubic'
@@ -78,7 +79,7 @@ type TimingFunctions =
  * }
  */
 
-function timingFunctions(timingFunction: TimingFunctions) {
+function timingFunctions(timingFunction: TimingFunction) {
   return functionsMap[timingFunction]
 }
 

--- a/src/shorthands/animation.js
+++ b/src/shorthands/animation.js
@@ -1,5 +1,6 @@
 // @flow
 
+/** */
 type AnimationProperty = string|number
 
 /**

--- a/src/shorthands/buttons.js
+++ b/src/shorthands/buttons.js
@@ -10,7 +10,8 @@ function template(state) {
   input[type="submit"]${state}`
 }
 
-type State =
+/** */
+type ButtonState =
   | typeof(undefined)
   | null
   | 'active'
@@ -44,7 +45,7 @@ type State =
  * }
  */
 
-function buttons(...states: Array<State>) {
+function buttons(...states: Array<ButtonState>) {
   return statefulSelectors(states, template, stateMap)
 }
 

--- a/src/shorthands/textInputs.js
+++ b/src/shorthands/textInputs.js
@@ -22,7 +22,8 @@ function template(state) {
     textarea${state}`
 }
 
-type State =
+/** */
+type InputState =
   | typeof(undefined)
   | null
   | 'active'
@@ -68,7 +69,7 @@ type State =
  * }
  */
 
-function textInputs(...states: Array<State>) {
+function textInputs(...states: Array<InputState>) {
   return statefulSelectors(states, template, stateMap)
 }
 


### PR DESCRIPTION
For some reason, adding a doc block to the type solves this. I did change some names for consistency and to avoid location hash conflicts (the `TimingFunctions` type and `timingFunctions` method had the same id, so I changed type to `TimingFunction`).

Also, `documentation` still does not recognize some complex types like `Ratio` but it links to the actual code, so it's ok.

Closes #71 