### PR TITLE
applyTransform function

### DIFF
--- a/src/helpers/applyTransform.js
+++ b/src/helpers/applyTransform.js
@@ -1,0 +1,82 @@
+// @flow
+
+import contains from '../internalHelpers/_contains'
+import omit from '../internalHelpers/_omit'
+import pick from '../internalHelpers/_pick'
+
+// NOTE: Due to conflict with an actual CSS property, the `perspective`
+// transform function is not included.
+const transformFunctions = [
+  'matrix',
+  'matrix3d',
+  'rotate',
+  'rotate3d',
+  'rotateX',
+  'rotateY',
+  'rotateZ',
+  'scale',
+  'scale3d',
+  'scaleX',
+  'scaleY',
+  'scaleZ',
+  'skew',
+  'skewX',
+  'skewY',
+  'translate',
+  'translate3d',
+  'translateX',
+  'translateY',
+  'translateZ',
+]
+
+// Transform functions which have implicit px units.
+const pxUnits = [
+  'translateX',
+  'translateY',
+  'translateZ',
+]
+
+ /**
+ * Merged transform function properties into the `transform` property. Any
+ * properties on the style object that match css transform functions are removed
+ * from the style and appended to the `transform` property.
+  *
+  * @example
+  * // Styles as object usage
+  * const styles = {
+  *   ...applyTransform({
+  *     translate: 10,
+  *     rotate: '15deg',
+  *   }),
+  * }
+  *
+  * // styled-components usage
+  * const div = styled.div`
+  *   ${applyTransform({
+  *     translate: 10,
+  *     rotate: '15deg',
+  *   })}
+  * `
+  *
+  * // CSS in JS Output
+  * element {
+  *   transform: translate(10px) rotate(15deg);
+  * }
+  */
+export default (base: Object) => {
+  const styles = omit(transformFunctions, base)
+  const transforms = pick(transformFunctions, base)
+
+  const initial = styles.transform && !/^\s*?none\s*?$/.test(styles.transform)
+    ? [styles.transform]
+    : []
+
+  return {
+    ...styles,
+    transform: Object.keys(transforms).reduce((result, key) => {
+      const val = transforms[key]
+      const transform = `${key}(${contains(key, pxUnits) ? `${val}px` : val})`
+      return result.concat([transform])
+    }, initial).join(' '),
+  }
+}

--- a/src/helpers/test/__snapshots__/applyTransform.test.js.snap
+++ b/src/helpers/test/__snapshots__/applyTransform.test.js.snap
@@ -1,0 +1,27 @@
+exports[`applyTransform should format a transform style object to a string 1`] = `
+Object {
+  "color": "red",
+  "perspective": "17px",
+  "transform": "matrix(1.0, 2.0, 3.0, 4.0, 5.0, 6.0) translate(12px, 50%) translateX(2px) translateY(2px) scale(2, 0.5) scaleX(2) scaleY(0.5) rotate(0.5turn) skew(30deg, 20deg) skewX(30deg) skewY(1.07rad) matrix3d(1.0, ..., 16.0) translate3d(12px, 50%, 3em) translateZ(2px) scale3d(2.5, 1.2, 0.3) scaleZ(0.3) rotate3d(1, 2.0, 3.0, 10deg) rotateX(10deg) rotateY(10deg) rotateZ(10deg)",
+}
+`;
+
+exports[`applyTransform should merge with an existing \`transform\` property 1`] = `
+Object {
+  "transform": "scale(1) translate(12px, 50%)",
+}
+`;
+
+exports[`applyTransform should overwrite an empty \`transform\` property 1`] = `
+Object {
+  "color": "red",
+  "transform": "translate(12px, 50%)",
+}
+`;
+
+exports[`applyTransform should overwrite an empty \`transform\` property 2`] = `
+Object {
+  "color": "red",
+  "transform": "translate(12px, 50%)",
+}
+`;

--- a/src/helpers/test/applyTransform.test.js
+++ b/src/helpers/test/applyTransform.test.js
@@ -1,0 +1,62 @@
+// @flow
+import applyTransform from '../applyTransform'
+
+describe('applyTransform', function() {
+  it('should format a transform style object to a string', function() {
+    const style = {
+      // CSS properties.
+      color: 'red',
+      perspective: '17px',
+
+      // Transform properties.
+      matrix: '1.0, 2.0, 3.0, 4.0, 5.0, 6.0',
+      translate: '12px, 50%',
+      translateX: 2,
+      translateY: 2,
+      scale: '2, 0.5',
+      scaleX: '2',
+      scaleY: '0.5',
+      rotate: '0.5turn',
+      skew: '30deg, 20deg',
+      skewX: '30deg',
+      skewY: '1.07rad',
+      matrix3d: '1.0, ..., 16.0',
+      translate3d: '12px, 50%, 3em',
+      translateZ: 2,
+      scale3d: '2.5, 1.2, 0.3',
+      scaleZ: '0.3',
+      rotate3d: '1, 2.0, 3.0, 10deg',
+      rotateX: '10deg',
+      rotateY: '10deg',
+      rotateZ: '10deg',
+    };
+
+    expect(applyTransform(style)).toMatchSnapshot();
+  });
+
+  it('should merge with an existing `transform` property', ()=> {
+    const style = {
+      transform: 'scale(1)',
+      translate: '12px, 50%',
+    };
+
+    expect(applyTransform(style)).toMatchSnapshot();
+  });
+
+  it('should overwrite an empty `transform` property', ()=> {
+    const styleA = {
+      transform: 'none',
+      color: 'red',
+      translate: '12px, 50%',
+    };
+
+    const styleB = {
+      transform: '',
+      color: 'red',
+      translate: '12px, 50%',
+    };
+
+    expect(applyTransform(styleA)).toMatchSnapshot();
+    expect(applyTransform(styleB)).toMatchSnapshot();
+  });
+})

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 // @flow
 // Helpers
+import applyTransform from './helpers/applyTransform'
 import directionalProperty from './helpers/directionalProperty'
 import em from './helpers/em'
 import modularScale from './helpers/modularScale'
@@ -48,6 +49,7 @@ import transitions from './shorthands/transitions'
 
 export {
   animation,
+  applyTransform,
   backgroundImages,
   backgrounds,
   borderColor,

--- a/src/internalHelpers/_contains.js
+++ b/src/internalHelpers/_contains.js
@@ -1,0 +1,5 @@
+// @flow
+
+export default function (item: any, array: [any]): boolean {
+  return array.indexOf(item) !== -1
+}

--- a/src/internalHelpers/_omit.js
+++ b/src/internalHelpers/_omit.js
@@ -1,0 +1,17 @@
+// @flow
+
+import contains from '../internalHelpers/_contains'
+
+export default (omitted: [string], object: Object): Object => {
+  const result = {}
+  const keys = Object.keys(object)
+
+  for (let i = 0, len = keys.length; i < len; i += 1) {
+    const key = keys[i]
+    if (!contains(key, omitted)) {
+      result[key] = object[key]
+    }
+  }
+
+  return result
+}

--- a/src/internalHelpers/_pick.js
+++ b/src/internalHelpers/_pick.js
@@ -1,0 +1,17 @@
+// @flow
+
+import contains from '../internalHelpers/_contains'
+
+export default (picked: [string], object: Object): Object => {
+  const result = {}
+  const keys = Object.keys(object)
+
+  for (let i = 0, len = keys.length; i < len; i += 1) {
+    const key = keys[i]
+    if (contains(key, picked)) {
+      result[key] = object[key]
+    }
+  }
+
+  return result
+}

--- a/src/internalHelpers/test/__snapshots__/_contains.test.js.snap
+++ b/src/internalHelpers/test/__snapshots__/_contains.test.js.snap
@@ -1,0 +1,3 @@
+exports[`contains should return \`false\` if the array contains the value 1`] = `false`;
+
+exports[`contains should return \`true\` if the array contains the value 1`] = `true`;

--- a/src/internalHelpers/test/__snapshots__/_omit.test.js.snap
+++ b/src/internalHelpers/test/__snapshots__/_omit.test.js.snap
@@ -1,0 +1,6 @@
+exports[`omit return an object with properites omitted 1`] = `
+Object {
+  "b": 2,
+  "d": 4,
+}
+`;

--- a/src/internalHelpers/test/__snapshots__/_pick.test.js.snap
+++ b/src/internalHelpers/test/__snapshots__/_pick.test.js.snap
@@ -1,0 +1,6 @@
+exports[`pick return an object with properites picked 1`] = `
+Object {
+  "a": 1,
+  "c": 3,
+}
+`;

--- a/src/internalHelpers/test/_contains.test.js
+++ b/src/internalHelpers/test/_contains.test.js
@@ -1,0 +1,13 @@
+// @flow
+
+import contains from '../_contains'
+
+describe('contains', () => {
+  it('should return `true` if the array contains the value', () => {
+    expect(contains(1, [1, 2, 3])).toMatchSnapshot()
+  })
+
+  it('should return `false` if the array contains the value', () => {
+    expect(contains(4, [1, 2, 3])).toMatchSnapshot()
+  })
+})

--- a/src/internalHelpers/test/_omit.test.js
+++ b/src/internalHelpers/test/_omit.test.js
@@ -1,0 +1,9 @@
+// @flow
+
+import omit from '../_omit'
+
+describe('omit', () => {
+  it('return an object with properites omitted', () => {
+    expect(omit(['a', 'c'], { a: 1, b: 2, c: 3, d: 4 })).toMatchSnapshot()
+  })
+})

--- a/src/internalHelpers/test/_pick.test.js
+++ b/src/internalHelpers/test/_pick.test.js
@@ -1,0 +1,9 @@
+// @flow
+
+import pick from '../_pick'
+
+describe('pick', () => {
+  it('return an object with properites picked', () => {
+    expect(pick(['a', 'c'], { a: 1, b: 2, c: 3, d: 4 })).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
Add `applyTransform` helper function to allow shorthand definition of transform property functions. 

Properties that match transform function names are removed from the style and moved into the `transform` property.

It works as a helper to transform an entire block of styles or as a mixin.

Example use:

```js
applyTransform({
  color: red,
  translateX: 10,
  rotate: '15deg',
})
```

Yields:

```css
element {
  color: red;
  transform: translateX(10px) rotate(15deg);
}
```

### TODO:
 - [ ] Rebuild docs