### PR TITLE
feat(align): added align shorthands

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,7 @@ import toColorString from './color/toColorString'
 import transparentize from './color/transparentize'
 
 // Shorthands
+import align from './shorthands/align'
 import animation from './shorthands/animation'
 import backgroundImages from './shorthands/backgroundImages'
 import backgrounds from './shorthands/backgrounds'
@@ -63,6 +64,7 @@ import transitions from './shorthands/transitions'
 
 export {
   adjustHue,
+  align,
   animation,
   backgroundImages,
   backgrounds,

--- a/src/shorthands/align.js
+++ b/src/shorthands/align.js
@@ -1,0 +1,164 @@
+// @flow
+
+/**
+ * CSS to represent object in any position.
+ *
+ * @example
+ * // Styles as object usage
+ *
+ * const styles = {
+ *   ...align('right', '-10px')
+ * }
+ *
+ *
+ * // styled-components usage
+ * const div = styled.div`
+ *   ${align('right', '-10px')}
+ *
+ *
+ * // CSS as JS Output
+ *
+ * div: {
+ *  'position': 'absolute',
+ *  'top': '50%',
+ *  'right': '-10px',
+ *  'transform': 'translateY(-50%)',
+ * }
+ *
+ * @example
+ * // Styles as object usage
+ *
+ * const styles = {
+ *   ...align('vertical')
+ * }
+ *
+ *
+ * // styled-components usage
+ * const div = styled.div`
+ *   ${align('vertical')}
+ *
+ *
+ * // CSS as JS Output
+ *
+ * div: {
+ *  'position': 'absolute',
+ *  'top': '50%',
+ *  'transform': 'translateY(-50%)',
+ *  'margin-top': '0',
+ * }
+ */
+
+type Position = 'center' | 'horizontal' | 'vertical' | 'top' | 'topRight' | 'right' | 'bottomRight' | 'bottom' | 'bottomLeft' | 'left' | 'topLeft'
+
+type AlignWithArgs = {
+  position: Position,
+  offset: string,
+}
+
+const getAlignProperties = ({ position, offset } : AlignWithArgs) => {
+  switch (position) {
+    case 'center': {
+      return {
+        'position': 'absolute',
+        'top': '50%',
+        'left': '50%',
+        'transform': 'translate(-50%, -50%)',
+        'margin-top': offset,
+      }
+    }
+
+    case 'horizontal': {
+      return {
+        'position': 'absolute',
+        'left': '50%',
+        'transform': 'translateX(-50%)',
+        'margin-top': offset,
+      }
+    }
+
+    case 'vertical': {
+      return {
+        'position': 'absolute',
+        'top': '50%',
+        'transform': 'translateY(-50%)',
+        'margin-top': offset,
+      }
+    }
+
+    case 'top': {
+      return {
+        'position': 'absolute',
+        'top': offset,
+        'left': '50%',
+        'transform': 'translateX(-50%)',
+      }
+    }
+
+    case 'topRight': {
+      return {
+        'position': 'absolute',
+        'top': offset,
+        'right': offset,
+      }
+    }
+
+    case 'right': {
+      return {
+        'position': 'absolute',
+        'top': '50%',
+        'right': offset,
+        'transform': 'translateY(-50%)',
+      }
+    }
+
+    case 'bottomRight': {
+      return {
+        'position': 'absolute',
+        'bottom': offset,
+        'right': offset,
+      }
+    }
+
+    case 'bottom': {
+      return {
+        'position': 'absolute',
+        'bottom': offset,
+        'left': '50%',
+        'transform': 'translateX(-50%)',
+      }
+    }
+
+    case 'bottomLeft': {
+      return {
+        'position': 'absolute',
+        'bottom': offset,
+        'left': offset,
+      }
+    }
+
+    case 'left': {
+      return {
+        'position': 'absolute',
+        'top': '50%',
+        'left': offset,
+        'transform': 'translateY(-50%)',
+      }
+    }
+
+    case 'topLeft': {
+      return {
+        'position': 'absolute',
+        'top': offset,
+        'left': offset,
+      }
+    }
+
+    default: throw new Error('align expects one of "center", "horizontal", "vertical", "top", "topRight", "right", "bottomRight", "bottom", "bottomLeft", "left", "topLeft" as the first argument.')
+  }
+}
+
+function align(position: string, offset: string = '0') {
+  return getAlignProperties({ position, offset })
+}
+
+export default align

--- a/src/shorthands/test/__snapshots__/align.test.js.snap
+++ b/src/shorthands/test/__snapshots__/align.test.js.snap
@@ -1,0 +1,105 @@
+exports[`align should align object horizontally 1`] = `
+Object {
+  "left": "50%",
+  "margin-top": "0",
+  "position": "absolute",
+  "transform": "translateX(-50%)",
+}
+`;
+
+exports[`align should align object to bottom 1`] = `
+Object {
+  "bottom": "0",
+  "left": "50%",
+  "position": "absolute",
+  "transform": "translateX(-50%)",
+}
+`;
+
+exports[`align should align object to bottom left corner 1`] = `
+Object {
+  "bottom": "0",
+  "left": "0",
+  "position": "absolute",
+}
+`;
+
+exports[`align should align object to bottom right corner 1`] = `
+Object {
+  "bottom": "0",
+  "position": "absolute",
+  "right": "0",
+}
+`;
+
+exports[`align should align object to center with -10px offset 1`] = `
+Object {
+  "left": "50%",
+  "margin-top": "-10px",
+  "position": "absolute",
+  "top": "50%",
+  "transform": "translate(-50%, -50%)",
+}
+`;
+
+exports[`align should align object to center without offset 1`] = `
+Object {
+  "left": "50%",
+  "margin-top": "0",
+  "position": "absolute",
+  "top": "50%",
+  "transform": "translate(-50%, -50%)",
+}
+`;
+
+exports[`align should align object to left with -10px offset 1`] = `
+Object {
+  "left": "-10px",
+  "position": "absolute",
+  "top": "50%",
+  "transform": "translateY(-50%)",
+}
+`;
+
+exports[`align should align object to right 1`] = `
+Object {
+  "position": "absolute",
+  "right": "0",
+  "top": "50%",
+  "transform": "translateY(-50%)",
+}
+`;
+
+exports[`align should align object to top left corner with -10px offset 1`] = `
+Object {
+  "left": "-10px",
+  "position": "absolute",
+  "top": "-10px",
+}
+`;
+
+exports[`align should align object to top with 1rem offset 1`] = `
+Object {
+  "left": "50%",
+  "position": "absolute",
+  "top": "1rem",
+  "transform": "translateX(-50%)",
+}
+`;
+
+exports[`align should align object to topRight corner with -15px offset 1`] = `
+Object {
+  "position": "absolute",
+  "right": "-15px",
+  "top": "-15px",
+}
+`;
+
+exports[`align should align object vertically 1`] = `
+Object {
+  "margin-top": "0",
+  "position": "absolute",
+  "top": "50%",
+  "transform": "translateY(-50%)",
+}
+`;

--- a/src/shorthands/test/align.test.js
+++ b/src/shorthands/test/align.test.js
@@ -1,0 +1,60 @@
+// @flow
+import align from '../align'
+
+describe('align', () => {
+  it('should align object to center without offset', () => {
+    expect({ ...align('center') }).toMatchSnapshot()
+  })
+
+  it('should not allow when doesnt have parameter', () => {
+    expect(() => { align() }).toThrow()
+  })
+
+  it('should not allow when first parameter is not one of type', () => {
+    expect(() => { align('wrongPosition') }).toThrow()
+  })
+
+  it('should align object to center with -10px offset', () => {
+    expect({ ...align('center', '-10px') }).toMatchSnapshot()
+  })
+
+  it('should align object vertically', () => {
+    expect({ ...align('vertical') }).toMatchSnapshot()
+  })
+
+  it('should align object horizontally', () => {
+    expect({ ...align('horizontal') }).toMatchSnapshot()
+  })
+
+  it('should align object to top with 1rem offset', () => {
+    expect({ ...align('top', '1rem') }).toMatchSnapshot()
+  })
+
+  it('should align object to topRight corner with -15px offset', () => {
+    expect({ ...align('topRight', '-15px') }).toMatchSnapshot()
+  })
+
+  it('should align object to right', () => {
+    expect({ ...align('right') }).toMatchSnapshot()
+  })
+
+  it('should align object to bottom right corner', () => {
+    expect({ ...align('bottomRight') }).toMatchSnapshot()
+  })
+
+  it('should align object to bottom', () => {
+    expect({ ...align('bottom') }).toMatchSnapshot()
+  })
+
+  it('should align object to bottom left corner', () => {
+    expect({ ...align('bottomLeft') }).toMatchSnapshot()
+  })
+
+  it('should align object to left with -10px offset', () => {
+    expect({ ...align('left', '-10px') }).toMatchSnapshot()
+  })
+
+  it('should align object to top left corner with -10px offset', () => {
+    expect({ ...align('topLeft', '-10px') }).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
Alignment shorthand helps when position element absolutely. For instance;

1)
```javascript
// it puts object to top right corner with -10px margin offset
const Header = styled.div `
  ${align('right', '-10px')}
`
```

it will generate this css
```css
.header {
  position: absolute;
  top: 50%;
  right: -10px;
  transform: translateY(-50%);
}
```

2) 
```javascript
// it puts object to top center
const Header = styled.div `
  ${align('center')}
`
```

it will generate this css
```css
.header {
  position: absolute;
  top: 50%;
  left: 50%;
  transform: translate(-50%, -50%);
  margin-top: 0;
}
```

3)
```javascript
// it puts object to top bottomLeft with 10px margin offset 
const Header = styled.div `
  ${align('bottomLeft', '10px')}
`
```
it will generate this css

```css
.header {
  position: absolute;
  left: 10px;
  bottom: 10px;
}
```

![Alignment in styled-components](https://www.tolga.is/testing/styled-components/1.jpg)
![Alignment in styled-components](https://www.tolga.is/testing/styled-components/2.jpg)
![Alignment in styled-components](https://www.tolga.is/testing/styled-components/3.jpg)
![Alignment in styled-components](https://www.tolga.is/testing/styled-components/4.jpg)