### PR TITLE
zIndex helper

### DIFF
--- a/src/helpers/test/__snapshots__/zIndex.test.js.snap
+++ b/src/helpers/test/__snapshots__/zIndex.test.js.snap
@@ -1,0 +1,24 @@
+exports[`stripUnit should properly add rules when block has existing rules 1`] = `
+Object {
+  "background": "red",
+  "z-index": 0,
+}
+`;
+
+exports[`stripUnit should return correct z-index value in array 1`] = `
+Object {
+  "z-index": 4,
+}
+`;
+
+exports[`stripUnit should return correct z-index value in array with base value 1`] = `
+Object {
+  "z-index": 104,
+}
+`;
+
+exports[`stripUnit should return correct z-index value in object 1`] = `
+Object {
+  "z-index": 23,
+}
+`;

--- a/src/helpers/test/zIndex.test.js
+++ b/src/helpers/test/zIndex.test.js
@@ -1,0 +1,50 @@
+// @flow
+import zIndex from '../zIndex'
+
+describe('stripUnit', () => {
+  const layersArray = [
+    'modal',
+    'backDrop',
+    'header',
+    'goTop',
+    'base',
+  ]
+  const layersObject = {
+    header: 10,
+    modal: 23,
+    goTop: 6,
+    base: 1,
+    backDrop: 18,
+  }
+
+  it('should return correct z-index value in array', () => {
+    expect({ ...zIndex('modal', layersArray) }).toMatchSnapshot()
+  })
+
+  it('should return correct z-index value in array with base value', () => {
+    expect({ ...zIndex('modal', layersArray, 100) }).toMatchSnapshot()
+  })
+
+  it('should return correct z-index value in object', () => {
+    expect({ ...zIndex('modal', layersObject) }).toMatchSnapshot()
+  })
+
+  it('should not allow when any parameter is not defined', () => {
+    expect(() => {
+      zIndex()
+    }).toThrow()
+  })
+
+  it('should not allow when layers array or object parameter is not defined', () => {
+    expect(() => {
+      zIndex('modal')
+    }).toThrow()
+  })
+
+  it('should properly add rules when block has existing rules', () => {
+    expect({
+      background: 'red',
+      ...zIndex('base', layersArray),
+    }).toMatchSnapshot()
+  })
+})

--- a/src/helpers/zIndex.js
+++ b/src/helpers/zIndex.js
@@ -1,0 +1,50 @@
+// @flow
+
+/**
+ * Returns the z-index value in array or object
+ * first parameter: key in the array or object
+ * second paramater: z-index array or object
+ *   if it is array, first element of array
+ *   will have the highest z-index value, last element of array will have
+ *   the lowest z-index value
+ *   if it is object, it will return the z-index of key
+ * third parameter (optional): base z-index. this helper function will add the base value
+ *   to the z-index value of the key.
+ *
+ * @example
+ * const zArray = ['modal', 'backDrop', 'lightbox', 'header', 'base']
+ * // Styles as object usage
+ * const styles = {
+ *   ...zIndex('header', zArray)
+ * }
+ *
+ * // styled-components usage
+ * const div = styled.div`
+ *   ${zIndex('header', zArray)}
+ * `
+ *
+ * // CSS in JS Output
+ *
+ * div {
+ *   z-index: 2;
+ * }
+ */
+
+function zIndex(layer: string, layers: Array | Object, base: number = 0) {
+  if (!layer) throw new Error('zIndex expects a layer name in first parameter')
+
+  if (Array.isArray(layers)) {
+    const reversedLayers = layers.slice().reverse()
+    return {
+      'z-index': base + reversedLayers.indexOf(layer),
+    }
+  } else if (typeof layers === 'object') {
+    return {
+      'z-index': layers[`${layer}`],
+    }
+  } else {
+    throw new Error('zIndex expects an array or object of layers in second parameter')
+  }
+}
+
+export default zIndex

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import em from './helpers/em'
 import modularScale from './helpers/modularScale'
 import rem from './helpers/rem'
 import stripUnit from './helpers/stripUnit'
+import zIndex from './helpers/zIndex'
 
 // Mixins
 import clearFix from './mixins/clearFix'
@@ -116,4 +117,5 @@ export {
   transitions,
   transparentize,
   wordWrap,
+  zIndex,
 }


### PR DESCRIPTION
Let's imagine, our website have modal lightbox and backdrop div for the modal and also we have a fixed header and a button at the bottom right corner to scroll to top. When we open the modal, we want backdrop div appears on top on the body elements and our model content should appear on top of the backDrop layer. 

We can keep them in an array like above. 
```javascript
const zArray = [
    'modal',
    'backDrop',
    'header',
    'goTop',
    'base',
  ]
```

With polished zIndex helper, The first element of the array which is modal will get the highest z-index value ```z-index: 4``` 

We can write it like that in styled-components
```javascript
const Modal = styled.div `
  position: absolute;
  background-color: #fff;
  ${zIndex('modal', zArray)};
`;
```

And it will generate this css
```css
.modal {
  position: absolute;
  background-color: #fff;
  z-index: 4
}
```

We can also define our own z-index values but we need to keep them in an object instead of an array.

```javascript
const zObject = {
    modal: 1000
    backDrop: 900,
    header: 500,
    goTop: 100,
    base: 1,
  }
```

We need to pass zObject to zIndex helper

```javascript
const Modal = styled.div `
  ...
  ${zIndex('modal', zObject)};
`;
```

We will able to see our modal z-index value that we defined in zObject
```css
.modal {
  ...
  z-index: 1000;
}
```

zIndex helper expects 3 parameters.

**First parameter:** layer name in our stack _(string)_
**Second parameter:** layer Array or layer Object _(array, object)_
**Third parameter:** base value for when calculating z-index. it will be added to reversed index value of the key in our stack if we pass an array _(number)_

```javascript
const Modal = styled.div `
  ...
  ${zIndex('modal', zArray, 50)};
`;
```

```css
.modal {
  ...
  z-index: 54;
}
```

