### PR TITLE
Specify files to publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,11 @@
     "inline-styles",
     "react"
   ],
+  "files": [
+    "package.json",
+    "lib",
+    "flow-typed"
+  ],
   "bugs": {
     "url": "https://github.com/styled-components/polished/issues"
   },


### PR DESCRIPTION
This way not all folders and files get published. There is no need for the docs to be in the npm package.

The main reason why I submit this pr is because currently the `.babelrc` file is also published, and causing mayhem in my React Native project.

I'm not sure if the files I specified are sufficient, but it can be a start to cleaner publishes.