### PR TITLE
docs(placeholder): reflect the usage

### DIFF
--- a/src/mixins/placeholder.js
+++ b/src/mixins/placeholder.js
@@ -6,12 +6,12 @@
  * @example
  * // Styles as object usage
  * const styles = {
- *   ...placeholder(styles)
+ *   ...placeholder({'color': 'blue'})
  * }
  *
  * // styled-components usage
  * const div = styled.input`
- *    ${placeholder(css`styles`)}
+ *    ${placeholder({'color': 'blue'})}
  * `
  *
  * // CSS as JS Output


### PR DESCRIPTION
According to the [conversation](https://github.com/styled-components/polished/pull/41#discussion_r91830362), I think the `mixins` do not work with `css` of SC.