### PR TITLE
Fixed typo in documentation

### DIFF
--- a/docs/assets/polished.js
+++ b/docs/assets/polished.js
@@ -506,7 +506,7 @@ function generateSources(fontFilePath, localFonts, fileFormats) {
  * }
  *
  * // styled-components basic usage
- * injectGlobals`${
+ * injectGlobal`${
  *   fontFace({
  *     'fontFamily': 'Sans-Pro'
  *     'fontFilePath': 'path/to/file'
@@ -784,7 +784,7 @@ function mergeRules(baseRules, additionalRules) {
  * }
  *
  * // styled-components usage
- * injectGlobals`${normalize()}`
+ * injectGlobal`${normalize()}`
  *
  * // CSS as JS Output
  *

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -1111,7 +1111,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
 }
 
 <span class="hljs-comment">// styled-components basic usage</span>
-injectGlobals`${
+injectGlobal`${
   fontFace({
     <span class="hljs-symbol">'fontFamily</span>': <span class="hljs-symbol">'Sans</span>-Pro'
     <span class="hljs-symbol">'fontFilePath</span>': <span class="hljs-symbol">'path</span>/to/file'
@@ -1365,7 +1365,7 @@ const styles = {
 }
 
 <span class="hljs-comment">// styled-components usage</span>
-injectGlobals<span class="hljs-string">`${normalize()}`</span>
+injectGlobal<span class="hljs-string">`${normalize()}`</span>
 
 <span class="hljs-comment">// CSS as JS Output</span>
 

--- a/src/mixins/fontFace.js
+++ b/src/mixins/fontFace.js
@@ -43,7 +43,7 @@ function generateSources(fontFilePath?: string, localFonts?: Array<string>, file
  * }
  *
  * // styled-components basic usage
- * injectGlobals`${
+ * injectGlobal`${
  *   fontFace({
  *     'fontFamily': 'Sans-Pro'
  *     'fontFilePath': 'path/to/file'

--- a/src/mixins/normalize.js
+++ b/src/mixins/normalize.js
@@ -278,7 +278,7 @@ function mergeRules(baseRules: Object, additionalRules: Object) {
  * }
  *
  * // styled-components usage
- * injectGlobals`${normalize()}`
+ * injectGlobal`${normalize()}`
  *
  * // CSS as JS Output
  *


### PR DESCRIPTION
https://github.com/styled-components/styled-components/blob/master/docs/api.md#injectglobal

The method name should be injectGlobal instead of injectGlobals or am I missing something?