### PR TITLE
chore(color): Allow whitespace in rgb and hsl values.

### DIFF
--- a/src/color/parseToRgb.js
+++ b/src/color/parseToRgb.js
@@ -5,10 +5,10 @@ import type { RgbColor, RgbaColor } from '../types/color'
 
 const hexRegex = /^#[a-fA-F0-9]{6}$/
 const reducedHexRegex = /^#[a-fA-F0-9]{3}$/
-const rgbRegex = /^rgb\((\d{1,3}), ?(\d{1,3}), ?(\d{1,3})\)$/
-const rgbaRegex = /^rgba\((\d{1,3}), ?(\d{1,3}), ?(\d{1,3}), ?([-+]?[0-9]*[.]?[0-9]+)\)$/
-const hslRegex = /^hsl\((\d{1,3}), ?(\d{1,3})%, ?(\d{1,3})%\)$/
-const hslaRegex = /^hsla\((\d{1,3}), ?(\d{1,3})%, ?(\d{1,3})%, ?([-+]?[0-9]*[.]?[0-9]+)\)$/
+const rgbRegex = /^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/
+const rgbaRegex = /^rgba\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*([-+]?[0-9]*[.]?[0-9]+)\s*\)$/
+const hslRegex = /^hsl\(\s*(\d{1,3})\s*,\s*(\d{1,3})%\s*,\s*(\d{1,3})%\s*\)$/
+const hslaRegex = /^hsla\(\s*(\d{1,3})\s*,\s*(\d{1,3})%\s*,\s*(\d{1,3})%\s*,\s*([-+]?[0-9]*[.]?[0-9]+)\s*\)$/
 
 /**
  * Returns an RgbColor or RgbaColor object. This utility function is only useful

--- a/src/color/test/__snapshots__/parseToRgb.test.js.snap
+++ b/src/color/test/__snapshots__/parseToRgb.test.js.snap
@@ -14,7 +14,24 @@ Object {
 }
 `;
 
+exports[`parseToRgb should parse a hsl color representation 2`] = `
+Object {
+  "blue": 11,
+  "green": 10,
+  "red": 9,
+}
+`;
+
 exports[`parseToRgb should parse a hsla color representation 1`] = `
+Object {
+  "alpha": 0.75,
+  "blue": 112,
+  "green": 102,
+  "red": 92,
+}
+`;
+
+exports[`parseToRgb should parse a hsla color representation 2`] = `
 Object {
   "alpha": 0.75,
   "blue": 112,
@@ -39,7 +56,24 @@ Object {
 }
 `;
 
+exports[`parseToRgb should parse a rgb color representation 2`] = `
+Object {
+  "blue": 255,
+  "green": 67,
+  "red": 174,
+}
+`;
+
 exports[`parseToRgb should parse a rgba color representation 1`] = `
+Object {
+  "alpha": 0.6,
+  "blue": 255,
+  "green": 67,
+  "red": 174,
+}
+`;
+
+exports[`parseToRgb should parse a rgba color representation 2`] = `
 Object {
   "alpha": 0.6,
   "blue": 255,

--- a/src/color/test/parseToRgb.test.js
+++ b/src/color/test/parseToRgb.test.js
@@ -11,18 +11,22 @@ describe('parseToRgb', () => {
 
   it('should parse a rgba color representation', () => {
     expect(parseToRgb('rgba(174,67,255,0.6)')).toMatchSnapshot()
+    expect(parseToRgb('rgba( 174 , 67 , 255 , 0.6 )')).toMatchSnapshot()
   })
 
   it('should parse a rgb color representation', () => {
     expect(parseToRgb('rgb(174,67,255)')).toMatchSnapshot()
+    expect(parseToRgb('rgb( 174 , 67 , 255 )')).toMatchSnapshot()
   })
 
   it('should parse a hsl color representation', () => {
     expect(parseToRgb('hsl(210,10%,4%)')).toMatchSnapshot()
+    expect(parseToRgb('hsl( 210 , 10% , 4% )')).toMatchSnapshot()
   })
 
   it('should parse a hsla color representation', () => {
     expect(parseToRgb('hsla(210,10%,40%,0.75)')).toMatchSnapshot()
+    expect(parseToRgb('hsla( 210 , 10% , 40% , 0.75 )')).toMatchSnapshot()
   })
 
   it('should throw an error if an invalid color string is provided', () => {


### PR DESCRIPTION
As per the spec: https://drafts.csswg.org/css-color-3/#rgb-color.

> White space characters are allowed around the numerical values.