### PR TITLE
feat(getLuminance): Add getLuminance function

### DIFF
--- a/.documentation.json
+++ b/.documentation.json
@@ -37,6 +37,7 @@
     "complement",
     "darken",
     "desaturate",
+    "getLuminance",
     "grayscale",
     "hsl",
     "hsla",

--- a/docs/assets/polished.js
+++ b/docs/assets/polished.js
@@ -394,7 +394,43 @@ var set = function set(object, property, value, receiver) {
   return value;
 };
 
+var slicedToArray = function () {
+  function sliceIterator(arr, i) {
+    var _arr = [];
+    var _n = true;
+    var _d = false;
+    var _e = undefined;
 
+    try {
+      for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) {
+        _arr.push(_s.value);
+
+        if (i && _arr.length === i) break;
+      }
+    } catch (err) {
+      _d = true;
+      _e = err;
+    } finally {
+      try {
+        if (!_n && _i["return"]) _i["return"]();
+      } finally {
+        if (_d) throw _e;
+      }
+    }
+
+    return _arr;
+  }
+
+  return function (arr, i) {
+    if (Array.isArray(arr)) {
+      return arr;
+    } else if (Symbol.iterator in Object(arr)) {
+      return sliceIterator(arr, i);
+    } else {
+      throw new TypeError("Invalid attempt to destructure non-iterable instance");
+    }
+  };
+}();
 
 
 
@@ -1990,6 +2026,48 @@ function desaturate(amount, color) {
 var curriedDesaturate = /*#__PURE__*/curry(desaturate); // eslint-disable-line spaced-comment
 
 //      
+/**
+ * Returns a number (float) representing the luminance of a color.
+ *
+ * @example
+ * // Styles as object usage
+ * const styles = {
+ *   background: getLuminance('#CCCD64') >= getLuminance('#0000ff') ? '#CCCD64' : '#0000ff',
+ *   background: getLuminance('rgba(58, 133, 255, 1)') >= getLuminance('rgba(255, 57, 149, 1)') ?
+ *                             'rgba(58, 133, 255, 1)' :
+ *                             'rgba(255, 57, 149, 1)',
+ * }
+ *
+ * // styled-components usage
+ * const div = styled.div`
+ *   background: ${getLuminance('#CCCD64') >= getLuminance('#0000ff') ? '#CCCD64' : '#0000ff'};
+ *   background: ${getLuminance('rgba(58, 133, 255, 1)') >= getLuminance('rgba(255, 57, 149, 1)') ?
+ *                             'rgba(58, 133, 255, 1)' :
+ *                             'rgba(255, 57, 149, 1)'};
+ *
+ * // CSS in JS Output
+ *
+ * div {
+ *   background: "#CCCD64";
+ *   background: "rgba(58, 133, 255, 1)";
+ * }
+ */
+function getLuminance(color) {
+  var rgbColor = parseToRgb(color);
+
+  var _Object$keys$map = Object.keys(rgbColor).map(function (key) {
+    var channel = rgbColor[key] / 255;
+    return channel <= 0.03928 ? channel / 12.92 : Math.pow((channel + 0.055) / 1.055, 2.4);
+  }),
+      _Object$keys$map2 = slicedToArray(_Object$keys$map, 3),
+      r = _Object$keys$map2[0],
+      g = _Object$keys$map2[1],
+      b = _Object$keys$map2[2];
+
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+//      
 
 /**
  * Converts the color to a grayscale, by reducing its saturation to 0.
@@ -2200,10 +2278,6 @@ function opacify(amount, color) {
 var curriedOpacify = /*#__PURE__*/curry(opacify); // eslint-disable-line spaced-comment
 
 //      
-var h = function h(c) {
-  return c / 255 <= 0.03928 ? c / 255 / 12.92 : Math.pow((c / 255 + 0.055) / 1.055, 2.4);
-};
-
 /**
  * Selects black or white for best contrast depending on the luminosity of the given color.
  * Follows W3C specs for readability at https://www.w3.org/TR/WCAG20-TECHS/G18.html
@@ -2233,8 +2307,7 @@ var h = function h(c) {
  */
 
 function readableColor(color) {
-  var c = parseToRgb(color);
-  return h(c.red) * 0.2126 + h(c.green) * 0.7152 + h(c.blue) * 0.0722 > 0.179 ? '#000' : '#fff';
+  return getLuminance(color) > 0.179 ? '#000' : '#fff';
 }
 
 // Don’t inline this variable into export because Rollup will remove the /*#__PURE__*/ comment
@@ -3095,6 +3168,7 @@ exports.directionalProperty = directionalProperty;
 exports.ellipsis = ellipsis;
 exports.em = em;
 exports.fontFace = fontFace;
+exports.getLuminance = getLuminance;
 exports.grayscale = grayscale;
 exports.invert = invert;
 exports.hideText = hideText;

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -775,6 +775,16 @@
             
               
               <li><a
+                href='#getluminance'
+                class="">
+                getLuminance
+                
+              </a>
+              
+              </li>
+            
+              
+              <li><a
                 href='#tocolorstring'
                 class="">
                 toColorString
@@ -855,7 +865,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/mixins/clearFix.js#L26-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/clearFix.js#L26-L35'>
       <span>src/mixins/clearFix.js</span>
       </a>
     
@@ -946,7 +956,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/mixins/ellipsis.js#L29-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/ellipsis.js#L29-L38'>
       <span>src/mixins/ellipsis.js</span>
       </a>
     
@@ -1040,7 +1050,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/mixins/fontFace.js#L72-L111'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/fontFace.js#L72-L111'>
       <span>src/mixins/fontFace.js</span>
       </a>
     
@@ -1207,7 +1217,7 @@ injectGlobal`${
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/mixins/hiDPI.js#L32-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/hiDPI.js#L32-L40'>
       <span>src/mixins/hiDPI.js</span>
       </a>
     
@@ -1304,7 +1314,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/mixins/hideText.js#L29-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/hideText.js#L29-L35'>
       <span>src/mixins/hideText.js</span>
       </a>
     
@@ -1384,7 +1394,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/mixins/normalize.js#L288-L291'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/normalize.js#L288-L291'>
       <span>src/mixins/normalize.js</span>
       </a>
     
@@ -1472,7 +1482,7 @@ html {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/mixins/placeholder.js#L35-L50'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/placeholder.js#L35-L50'>
       <span>src/mixins/placeholder.js</span>
       </a>
     
@@ -1580,7 +1590,7 @@ const div = styled.input`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/mixins/radialGradient.js#L78-L96'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/radialGradient.js#L78-L96'>
       <span>src/mixins/radialGradient.js</span>
       </a>
     
@@ -1725,7 +1735,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/mixins/retinaImage.js#L33-L58'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/retinaImage.js#L33-L58'>
       <span>src/mixins/retinaImage.js</span>
       </a>
     
@@ -1855,7 +1865,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/mixins/selection.js#L31-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/selection.js#L31-L40'>
       <span>src/mixins/selection.js</span>
       </a>
     
@@ -1959,7 +1969,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/mixins/timingFunctions.js#L82-L84'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/timingFunctions.js#L82-L84'>
       <span>src/mixins/timingFunctions.js</span>
       </a>
     
@@ -2047,7 +2057,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/mixins/triangle.js#L72-L106'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/triangle.js#L72-L106'>
       <span>src/mixins/triangle.js</span>
       </a>
     
@@ -2190,7 +2200,7 @@ div:</span> {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/mixins/wordWrap.js#L26-L33'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/wordWrap.js#L26-L33'>
       <span>src/mixins/wordWrap.js</span>
       </a>
     
@@ -2293,7 +2303,7 @@ div:</span> {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/color/adjustHue.js#L31-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/adjustHue.js#L31-L37'>
       <span>src/color/adjustHue.js</span>
       </a>
     
@@ -2393,7 +2403,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/color/complement.js#L28-L34'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/complement.js#L28-L34'>
       <span>src/color/complement.js</span>
       </a>
     
@@ -2483,7 +2493,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/color/darken.js#L31-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/darken.js#L31-L37'>
       <span>src/color/darken.js</span>
       </a>
     
@@ -2582,7 +2592,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/color/desaturate.js#L32-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/desaturate.js#L32-L38'>
       <span>src/color/desaturate.js</span>
       </a>
     
@@ -2682,7 +2692,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/color/grayscale.js#L28-L33'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/grayscale.js#L28-L33'>
       <span>src/color/grayscale.js</span>
       </a>
     
@@ -2772,7 +2782,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/color/hsl.js#L29-L51'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/hsl.js#L29-L51'>
       <span>src/color/hsl.js</span>
       </a>
     
@@ -2879,7 +2889,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/color/hsla.js#L33-L66'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/hsla.js#L33-L66'>
       <span>src/color/hsla.js</span>
       </a>
     
@@ -2997,7 +3007,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/color/invert.js#L29-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/invert.js#L29-L38'>
       <span>src/color/invert.js</span>
       </a>
     
@@ -3088,7 +3098,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/color/lighten.js#L31-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/lighten.js#L31-L37'>
       <span>src/color/lighten.js</span>
       </a>
     
@@ -3187,7 +3197,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/color/mix.js#L38-L68'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/mix.js#L38-L68'>
       <span>src/color/mix.js</span>
       </a>
     
@@ -3302,7 +3312,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/color/opacify.js#L34-L43'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/opacify.js#L34-L43'>
       <span>src/color/opacify.js</span>
       </a>
     
@@ -3404,7 +3414,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/color/parseToHsl.js#L18-L22'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/parseToHsl.js#L18-L22'>
       <span>src/color/parseToHsl.js</span>
       </a>
     
@@ -3483,7 +3493,7 @@ const color2 = 'hsla(<span class="hljs-number">210</span>, <span class="hljs-num
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/color/parseToRgb.js#L24-L92'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/parseToRgb.js#L24-L92'>
       <span>src/color/parseToRgb.js</span>
       </a>
     
@@ -3562,7 +3572,7 @@ const color2 = 'hsla(<span class="hljs-number">210</span>, <span class="hljs-num
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/color/readableColor.js#L36-L41'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/readableColor.js#L36-L41'>
       <span>src/color/readableColor.js</span>
       </a>
     
@@ -3657,7 +3667,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/color/rgb.js#L30-L50'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/rgb.js#L30-L50'>
       <span>src/color/rgb.js</span>
       </a>
     
@@ -3764,7 +3774,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/color/rgba.js#L41-L73'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/rgba.js#L41-L73'>
       <span>src/color/rgba.js</span>
       </a>
     
@@ -3889,7 +3899,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/color/saturate.js#L33-L39'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/saturate.js#L33-L39'>
       <span>src/color/saturate.js</span>
       </a>
     
@@ -3990,7 +4000,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/color/setHue.js#L30-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/setHue.js#L30-L35'>
       <span>src/color/setHue.js</span>
       </a>
     
@@ -4089,7 +4099,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/color/setLightness.js#L30-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/setLightness.js#L30-L35'>
       <span>src/color/setLightness.js</span>
       </a>
     
@@ -4188,7 +4198,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/color/setSaturation.js#L30-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/setSaturation.js#L30-L35'>
       <span>src/color/setSaturation.js</span>
       </a>
     
@@ -4287,7 +4297,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/color/shade.js#L29-L41'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/shade.js#L29-L41'>
       <span>src/color/shade.js</span>
       </a>
     
@@ -4385,7 +4395,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/color/tint.js#L29-L41'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/tint.js#L29-L41'>
       <span>src/color/tint.js</span>
       </a>
     
@@ -4483,7 +4493,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/color/transparentize.js#L34-L43'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/transparentize.js#L34-L43'>
       <span>src/color/transparentize.js</span>
       </a>
     
@@ -4597,7 +4607,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/shorthands/animation.js#L42-L75'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/animation.js#L42-L75'>
       <span>src/shorthands/animation.js</span>
       </a>
     
@@ -4703,7 +4713,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/shorthands/backgroundImages.js#L23-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/backgroundImages.js#L23-L27'>
       <span>src/shorthands/backgroundImages.js</span>
       </a>
     
@@ -4791,7 +4801,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/shorthands/backgrounds.js#L22-L26'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/backgrounds.js#L22-L26'>
       <span>src/shorthands/backgrounds.js</span>
       </a>
     
@@ -4879,7 +4889,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/shorthands/borderColor.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/borderColor.js#L27-L29'>
       <span>src/shorthands/borderColor.js</span>
       </a>
     
@@ -4970,7 +4980,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/shorthands/borderRadius.js#L25-L49'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/borderRadius.js#L25-L49'>
       <span>src/shorthands/borderRadius.js</span>
       </a>
     
@@ -5067,7 +5077,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/shorthands/borderStyle.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/borderStyle.js#L27-L29'>
       <span>src/shorthands/borderStyle.js</span>
       </a>
     
@@ -5158,7 +5168,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/shorthands/borderWidth.js#L26-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/borderWidth.js#L26-L28'>
       <span>src/shorthands/borderWidth.js</span>
       </a>
     
@@ -5249,7 +5259,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/shorthands/buttons.js#L42-L44'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/buttons.js#L42-L44'>
       <span>src/shorthands/buttons.js</span>
       </a>
     
@@ -5344,7 +5354,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/shorthands/margin.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/margin.js#L27-L29'>
       <span>src/shorthands/margin.js</span>
       </a>
     
@@ -5435,7 +5445,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/shorthands/padding.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/padding.js#L27-L29'>
       <span>src/shorthands/padding.js</span>
       </a>
     
@@ -5526,7 +5536,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/shorthands/position.js#L49-L62'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/position.js#L49-L62'>
       <span>src/shorthands/position.js</span>
       </a>
     
@@ -5645,7 +5655,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/shorthands/size.js#L24-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/size.js#L24-L29'>
       <span>src/shorthands/size.js</span>
       </a>
     
@@ -5743,7 +5753,7 @@ const <span class="hljs-keyword">div</span> = styled.<span class="hljs-keyword">
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/shorthands/textInputs.js#L66-L68'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/textInputs.js#L66-L68'>
       <span>src/shorthands/textInputs.js</span>
       </a>
     
@@ -5850,7 +5860,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/shorthands/transitions.js#L23-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/transitions.js#L23-L27'>
       <span>src/shorthands/transitions.js</span>
       </a>
     
@@ -5950,7 +5960,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/helpers/directionalProperty.js#L50-L58'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/helpers/directionalProperty.js#L50-L58'>
       <span>src/helpers/directionalProperty.js</span>
       </a>
     
@@ -6049,7 +6059,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/helpers/em.js#L29-L32'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/helpers/em.js#L29-L32'>
       <span>src/helpers/em.js</span>
       </a>
     
@@ -6147,7 +6157,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/helpers/modularScale.js#L67-L93'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/helpers/modularScale.js#L67-L93'>
       <span>src/helpers/modularScale.js</span>
       </a>
     
@@ -6255,7 +6265,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/helpers/rem.js#L30-L33'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/helpers/rem.js#L30-L33'>
       <span>src/helpers/rem.js</span>
       </a>
     
@@ -6353,7 +6363,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/helpers/stripUnit.js#L24-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/helpers/stripUnit.js#L24-L28'>
       <span>src/helpers/stripUnit.js</span>
       </a>
     
@@ -6453,7 +6463,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/shorthands/animation.js#L4-L4'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/animation.js#L4-L4'>
       <span>src/shorthands/animation.js</span>
       </a>
     
@@ -6507,7 +6517,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/mixins/fontFace.js#L4-L14'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/fontFace.js#L4-L14'>
       <span>src/mixins/fontFace.js</span>
       </a>
     
@@ -6620,7 +6630,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/types/color.js#L11-L15'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/types/color.js#L11-L15'>
       <span>src/types/color.js</span>
       </a>
     
@@ -6697,7 +6707,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/types/color.js#L23-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/types/color.js#L23-L28'>
       <span>src/types/color.js</span>
       </a>
     
@@ -6780,7 +6790,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/types/interactionState.js#L9-L14'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/types/interactionState.js#L9-L14'>
       <span>src/types/interactionState.js</span>
       </a>
     
@@ -6834,7 +6844,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/mixins/triangle.js#L4-L4'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/triangle.js#L4-L4'>
       <span>src/mixins/triangle.js</span>
       </a>
     
@@ -6888,7 +6898,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/mixins/radialGradient.js#L4-L10'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/radialGradient.js#L4-L10'>
       <span>src/mixins/radialGradient.js</span>
       </a>
     
@@ -6977,7 +6987,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/helpers/modularScale.js#L26-L44'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/helpers/modularScale.js#L26-L44'>
       <span>src/helpers/modularScale.js</span>
       </a>
     
@@ -7031,7 +7041,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/types/color.js#L47-L52'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/types/color.js#L47-L52'>
       <span>src/types/color.js</span>
       </a>
     
@@ -7114,7 +7124,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/types/color.js#L35-L39'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/types/color.js#L35-L39'>
       <span>src/types/color.js</span>
       </a>
     
@@ -7191,7 +7201,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/mixins/timingFunctions.js#L35-L59'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/timingFunctions.js#L35-L59'>
       <span>src/mixins/timingFunctions.js</span>
       </a>
     
@@ -7240,12 +7250,99 @@ element {
   
   <div class='clearfix'>
     
+    <h3 class='fl m0' id='getluminance'>
+      getLuminance
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/getLuminance.js#L27-L36'>
+      <span>src/color/getLuminance.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Returns a number representing the luminance of a color.</p>
+
+
+  <div class='pre p1 fill-light mt0'>getLuminance(color: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>color</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+	    
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></code>
+    
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
+<span class="hljs-keyword">const</span> styles = {
+  <span class="hljs-built_in">background</span>: getLuminance(<span class="hljs-string">'#CCCD64'</span>) &gt;= getLuminance(<span class="hljs-string">'#0000ff'</span>) ? <span class="hljs-string">'#CCCD64'</span> : <span class="hljs-string">'#0000ff'</span>,
+  <span class="hljs-built_in">background</span>: getLuminance(<span class="hljs-string">'rgba(58, 133, 255, 1)'</span>) &gt;= getLuminance(<span class="hljs-string">'rgba(255, 57, 149, 1)'</span>) ?
+                            <span class="hljs-string">'rgba(58, 133, 255, 1)'</span> :
+                            <span class="hljs-string">'rgba(255, 57, 149, 1)'</span>,
+}
+
+<span class="hljs-comment">// styled-components usage</span>
+<span class="hljs-keyword">const</span> div = styled.div`
+  <span class="hljs-built_in">background</span>: ${getLuminance(<span class="hljs-string">'#CCCD64'</span>) &gt;= getLuminance(<span class="hljs-string">'#0000ff'</span>) ? <span class="hljs-string">'#CCCD64'</span> : <span class="hljs-string">'#0000ff'</span>};
+  <span class="hljs-built_in">background</span>: ${getLuminance(<span class="hljs-string">'rgba(58, 133, 255, 1)'</span>) &gt;= getLuminance(<span class="hljs-string">'rgba(255, 57, 149, 1)'</span>) ?
+                            <span class="hljs-string">'rgba(58, 133, 255, 1)'</span> :
+                            <span class="hljs-string">'rgba(255, 57, 149, 1)'</span>};</pre>
+    
+  
+
+  
+
+  
+
+  
+</section>
+
+        
+      
+        
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
     <h3 class='fl m0' id='tocolorstring'>
       toColorString
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/color/toColorString.js#L65-L73'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/toColorString.js#L65-L73'>
       <span>src/color/toColorString.js</span>
       </a>
     
@@ -7343,7 +7440,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/9288ee23f6781e1b865cad0fb1c507c695957148/src/types/modularScaleRatio.js#L9-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/types/modularScaleRatio.js#L9-L27'>
       <span>src/types/modularScaleRatio.js</span>
       </a>
     

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -255,6 +255,16 @@
             
               
               <li><a
+                href='#getluminance'
+                class="">
+                getLuminance
+                
+              </a>
+              
+              </li>
+            
+              
+              <li><a
                 href='#grayscale'
                 class="">
                 grayscale
@@ -775,16 +785,6 @@
             
               
               <li><a
-                href='#getluminance'
-                class="">
-                getLuminance
-                
-              </a>
-              
-              </li>
-            
-              
-              <li><a
                 href='#tocolorstring'
                 class="">
                 toColorString
@@ -865,7 +865,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/clearFix.js#L26-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/mixins/clearFix.js#L26-L35'>
       <span>src/mixins/clearFix.js</span>
       </a>
     
@@ -956,7 +956,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/ellipsis.js#L29-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/mixins/ellipsis.js#L29-L38'>
       <span>src/mixins/ellipsis.js</span>
       </a>
     
@@ -1050,7 +1050,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/fontFace.js#L72-L111'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/mixins/fontFace.js#L72-L111'>
       <span>src/mixins/fontFace.js</span>
       </a>
     
@@ -1217,7 +1217,7 @@ injectGlobal`${
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/hiDPI.js#L32-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/mixins/hiDPI.js#L32-L40'>
       <span>src/mixins/hiDPI.js</span>
       </a>
     
@@ -1314,7 +1314,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/hideText.js#L29-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/mixins/hideText.js#L29-L35'>
       <span>src/mixins/hideText.js</span>
       </a>
     
@@ -1394,7 +1394,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/normalize.js#L288-L291'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/mixins/normalize.js#L288-L291'>
       <span>src/mixins/normalize.js</span>
       </a>
     
@@ -1482,7 +1482,7 @@ html {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/placeholder.js#L35-L50'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/mixins/placeholder.js#L35-L50'>
       <span>src/mixins/placeholder.js</span>
       </a>
     
@@ -1590,7 +1590,7 @@ const div = styled.input`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/radialGradient.js#L78-L96'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/mixins/radialGradient.js#L78-L96'>
       <span>src/mixins/radialGradient.js</span>
       </a>
     
@@ -1735,7 +1735,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/retinaImage.js#L33-L58'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/mixins/retinaImage.js#L33-L58'>
       <span>src/mixins/retinaImage.js</span>
       </a>
     
@@ -1865,7 +1865,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/selection.js#L31-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/mixins/selection.js#L31-L40'>
       <span>src/mixins/selection.js</span>
       </a>
     
@@ -1969,7 +1969,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/timingFunctions.js#L82-L84'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/mixins/timingFunctions.js#L82-L84'>
       <span>src/mixins/timingFunctions.js</span>
       </a>
     
@@ -2057,7 +2057,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/triangle.js#L72-L106'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/mixins/triangle.js#L72-L106'>
       <span>src/mixins/triangle.js</span>
       </a>
     
@@ -2200,7 +2200,7 @@ div:</span> {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/wordWrap.js#L26-L33'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/mixins/wordWrap.js#L26-L33'>
       <span>src/mixins/wordWrap.js</span>
       </a>
     
@@ -2303,7 +2303,7 @@ div:</span> {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/adjustHue.js#L31-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/color/adjustHue.js#L31-L37'>
       <span>src/color/adjustHue.js</span>
       </a>
     
@@ -2403,7 +2403,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/complement.js#L28-L34'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/color/complement.js#L28-L34'>
       <span>src/color/complement.js</span>
       </a>
     
@@ -2493,7 +2493,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/darken.js#L31-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/color/darken.js#L31-L37'>
       <span>src/color/darken.js</span>
       </a>
     
@@ -2592,7 +2592,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/desaturate.js#L32-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/color/desaturate.js#L32-L38'>
       <span>src/color/desaturate.js</span>
       </a>
     
@@ -2687,12 +2687,106 @@ element {
   
   <div class='clearfix'>
     
+    <h3 class='fl m0' id='getluminance'>
+      getLuminance
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/color/getLuminance.js#L30-L39'>
+      <span>src/color/getLuminance.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Returns a number (float) representing the luminance of a color.</p>
+
+
+  <div class='pre p1 fill-light mt0'>getLuminance(color: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>color</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+	    
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></code>
+    
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
+<span class="hljs-keyword">const</span> styles = {
+  <span class="hljs-built_in">background</span>: getLuminance(<span class="hljs-string">'#CCCD64'</span>) &gt;= getLuminance(<span class="hljs-string">'#0000ff'</span>) ? <span class="hljs-string">'#CCCD64'</span> : <span class="hljs-string">'#0000ff'</span>,
+  <span class="hljs-built_in">background</span>: getLuminance(<span class="hljs-string">'rgba(58, 133, 255, 1)'</span>) &gt;= getLuminance(<span class="hljs-string">'rgba(255, 57, 149, 1)'</span>) ?
+                            <span class="hljs-string">'rgba(58, 133, 255, 1)'</span> :
+                            <span class="hljs-string">'rgba(255, 57, 149, 1)'</span>,
+}
+
+<span class="hljs-comment">// styled-components usage</span>
+<span class="hljs-keyword">const</span> div = styled.div`
+  <span class="hljs-built_in">background</span>: ${getLuminance(<span class="hljs-string">'#CCCD64'</span>) &gt;= getLuminance(<span class="hljs-string">'#0000ff'</span>) ? <span class="hljs-string">'#CCCD64'</span> : <span class="hljs-string">'#0000ff'</span>};
+  <span class="hljs-built_in">background</span>: ${getLuminance(<span class="hljs-string">'rgba(58, 133, 255, 1)'</span>) &gt;= getLuminance(<span class="hljs-string">'rgba(255, 57, 149, 1)'</span>) ?
+                            <span class="hljs-string">'rgba(58, 133, 255, 1)'</span> :
+                            <span class="hljs-string">'rgba(255, 57, 149, 1)'</span>};
+
+<span class="hljs-comment">// CSS in JS Output</span>
+
+div {
+  <span class="hljs-built_in">background</span>: <span class="hljs-string">"#CCCD64"</span>;
+  <span class="hljs-built_in">background</span>: <span class="hljs-string">"rgba(58, 133, 255, 1)"</span>;
+}</pre>
+    
+  
+
+  
+
+  
+
+  
+</section>
+
+        
+      
+        
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
     <h3 class='fl m0' id='grayscale'>
       grayscale
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/grayscale.js#L28-L33'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/color/grayscale.js#L28-L33'>
       <span>src/color/grayscale.js</span>
       </a>
     
@@ -2782,7 +2876,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/hsl.js#L29-L51'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/color/hsl.js#L29-L51'>
       <span>src/color/hsl.js</span>
       </a>
     
@@ -2889,7 +2983,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/hsla.js#L33-L66'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/color/hsla.js#L33-L66'>
       <span>src/color/hsla.js</span>
       </a>
     
@@ -3007,7 +3101,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/invert.js#L29-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/color/invert.js#L29-L38'>
       <span>src/color/invert.js</span>
       </a>
     
@@ -3098,7 +3192,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/lighten.js#L31-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/color/lighten.js#L31-L37'>
       <span>src/color/lighten.js</span>
       </a>
     
@@ -3197,7 +3291,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/mix.js#L38-L68'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/color/mix.js#L38-L68'>
       <span>src/color/mix.js</span>
       </a>
     
@@ -3312,7 +3406,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/opacify.js#L34-L43'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/color/opacify.js#L34-L43'>
       <span>src/color/opacify.js</span>
       </a>
     
@@ -3414,7 +3508,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/parseToHsl.js#L18-L22'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/color/parseToHsl.js#L18-L22'>
       <span>src/color/parseToHsl.js</span>
       </a>
     
@@ -3493,7 +3587,7 @@ const color2 = 'hsla(<span class="hljs-number">210</span>, <span class="hljs-num
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/parseToRgb.js#L24-L92'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/color/parseToRgb.js#L24-L92'>
       <span>src/color/parseToRgb.js</span>
       </a>
     
@@ -3572,7 +3666,7 @@ const color2 = 'hsla(<span class="hljs-number">210</span>, <span class="hljs-num
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/readableColor.js#L36-L41'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/color/readableColor.js#L33-L35'>
       <span>src/color/readableColor.js</span>
       </a>
     
@@ -3667,7 +3761,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/rgb.js#L30-L50'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/color/rgb.js#L30-L50'>
       <span>src/color/rgb.js</span>
       </a>
     
@@ -3774,7 +3868,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/rgba.js#L41-L73'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/color/rgba.js#L41-L73'>
       <span>src/color/rgba.js</span>
       </a>
     
@@ -3899,7 +3993,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/saturate.js#L33-L39'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/color/saturate.js#L33-L39'>
       <span>src/color/saturate.js</span>
       </a>
     
@@ -4000,7 +4094,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/setHue.js#L30-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/color/setHue.js#L30-L35'>
       <span>src/color/setHue.js</span>
       </a>
     
@@ -4099,7 +4193,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/setLightness.js#L30-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/color/setLightness.js#L30-L35'>
       <span>src/color/setLightness.js</span>
       </a>
     
@@ -4198,7 +4292,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/setSaturation.js#L30-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/color/setSaturation.js#L30-L35'>
       <span>src/color/setSaturation.js</span>
       </a>
     
@@ -4297,7 +4391,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/shade.js#L29-L41'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/color/shade.js#L29-L41'>
       <span>src/color/shade.js</span>
       </a>
     
@@ -4395,7 +4489,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/tint.js#L29-L41'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/color/tint.js#L29-L41'>
       <span>src/color/tint.js</span>
       </a>
     
@@ -4493,7 +4587,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/transparentize.js#L34-L43'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/color/transparentize.js#L34-L43'>
       <span>src/color/transparentize.js</span>
       </a>
     
@@ -4607,7 +4701,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/animation.js#L42-L75'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/shorthands/animation.js#L42-L75'>
       <span>src/shorthands/animation.js</span>
       </a>
     
@@ -4713,7 +4807,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/backgroundImages.js#L23-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/shorthands/backgroundImages.js#L23-L27'>
       <span>src/shorthands/backgroundImages.js</span>
       </a>
     
@@ -4801,7 +4895,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/backgrounds.js#L22-L26'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/shorthands/backgrounds.js#L22-L26'>
       <span>src/shorthands/backgrounds.js</span>
       </a>
     
@@ -4889,7 +4983,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/borderColor.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/shorthands/borderColor.js#L27-L29'>
       <span>src/shorthands/borderColor.js</span>
       </a>
     
@@ -4980,7 +5074,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/borderRadius.js#L25-L49'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/shorthands/borderRadius.js#L25-L49'>
       <span>src/shorthands/borderRadius.js</span>
       </a>
     
@@ -5077,7 +5171,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/borderStyle.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/shorthands/borderStyle.js#L27-L29'>
       <span>src/shorthands/borderStyle.js</span>
       </a>
     
@@ -5168,7 +5262,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/borderWidth.js#L26-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/shorthands/borderWidth.js#L26-L28'>
       <span>src/shorthands/borderWidth.js</span>
       </a>
     
@@ -5259,7 +5353,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/buttons.js#L42-L44'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/shorthands/buttons.js#L42-L44'>
       <span>src/shorthands/buttons.js</span>
       </a>
     
@@ -5354,7 +5448,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/margin.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/shorthands/margin.js#L27-L29'>
       <span>src/shorthands/margin.js</span>
       </a>
     
@@ -5445,7 +5539,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/padding.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/shorthands/padding.js#L27-L29'>
       <span>src/shorthands/padding.js</span>
       </a>
     
@@ -5536,7 +5630,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/position.js#L49-L62'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/shorthands/position.js#L49-L62'>
       <span>src/shorthands/position.js</span>
       </a>
     
@@ -5655,7 +5749,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/size.js#L24-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/shorthands/size.js#L24-L29'>
       <span>src/shorthands/size.js</span>
       </a>
     
@@ -5753,7 +5847,7 @@ const <span class="hljs-keyword">div</span> = styled.<span class="hljs-keyword">
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/textInputs.js#L66-L68'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/shorthands/textInputs.js#L66-L68'>
       <span>src/shorthands/textInputs.js</span>
       </a>
     
@@ -5860,7 +5954,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/transitions.js#L23-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/shorthands/transitions.js#L23-L27'>
       <span>src/shorthands/transitions.js</span>
       </a>
     
@@ -5960,7 +6054,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/helpers/directionalProperty.js#L50-L58'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/helpers/directionalProperty.js#L50-L58'>
       <span>src/helpers/directionalProperty.js</span>
       </a>
     
@@ -6059,7 +6153,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/helpers/em.js#L29-L32'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/helpers/em.js#L29-L32'>
       <span>src/helpers/em.js</span>
       </a>
     
@@ -6157,7 +6251,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/helpers/modularScale.js#L67-L93'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/helpers/modularScale.js#L67-L93'>
       <span>src/helpers/modularScale.js</span>
       </a>
     
@@ -6265,7 +6359,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/helpers/rem.js#L30-L33'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/helpers/rem.js#L30-L33'>
       <span>src/helpers/rem.js</span>
       </a>
     
@@ -6363,7 +6457,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/helpers/stripUnit.js#L24-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/helpers/stripUnit.js#L24-L28'>
       <span>src/helpers/stripUnit.js</span>
       </a>
     
@@ -6463,7 +6557,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/shorthands/animation.js#L4-L4'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/shorthands/animation.js#L4-L4'>
       <span>src/shorthands/animation.js</span>
       </a>
     
@@ -6517,7 +6611,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/fontFace.js#L4-L14'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/mixins/fontFace.js#L4-L14'>
       <span>src/mixins/fontFace.js</span>
       </a>
     
@@ -6630,7 +6724,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/types/color.js#L11-L15'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/types/color.js#L11-L15'>
       <span>src/types/color.js</span>
       </a>
     
@@ -6707,7 +6801,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/types/color.js#L23-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/types/color.js#L23-L28'>
       <span>src/types/color.js</span>
       </a>
     
@@ -6790,7 +6884,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/types/interactionState.js#L9-L14'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/types/interactionState.js#L9-L14'>
       <span>src/types/interactionState.js</span>
       </a>
     
@@ -6844,7 +6938,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/triangle.js#L4-L4'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/mixins/triangle.js#L4-L4'>
       <span>src/mixins/triangle.js</span>
       </a>
     
@@ -6898,7 +6992,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/radialGradient.js#L4-L10'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/mixins/radialGradient.js#L4-L10'>
       <span>src/mixins/radialGradient.js</span>
       </a>
     
@@ -6987,7 +7081,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/helpers/modularScale.js#L26-L44'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/helpers/modularScale.js#L26-L44'>
       <span>src/helpers/modularScale.js</span>
       </a>
     
@@ -7041,7 +7135,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/types/color.js#L47-L52'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/types/color.js#L47-L52'>
       <span>src/types/color.js</span>
       </a>
     
@@ -7124,7 +7218,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/types/color.js#L35-L39'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/types/color.js#L35-L39'>
       <span>src/types/color.js</span>
       </a>
     
@@ -7201,7 +7295,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/mixins/timingFunctions.js#L35-L59'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/mixins/timingFunctions.js#L35-L59'>
       <span>src/mixins/timingFunctions.js</span>
       </a>
     
@@ -7250,99 +7344,12 @@ element {
   
   <div class='clearfix'>
     
-    <h3 class='fl m0' id='getluminance'>
-      getLuminance
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/getLuminance.js#L27-L36'>
-      <span>src/color/getLuminance.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Returns a number representing the luminance of a color.</p>
-
-
-  <div class='pre p1 fill-light mt0'>getLuminance(color: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Parameters</div>
-    <div class='prose'>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>color</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></code>
-    
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
-      <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
-<span class="hljs-keyword">const</span> styles = {
-  <span class="hljs-built_in">background</span>: getLuminance(<span class="hljs-string">'#CCCD64'</span>) &gt;= getLuminance(<span class="hljs-string">'#0000ff'</span>) ? <span class="hljs-string">'#CCCD64'</span> : <span class="hljs-string">'#0000ff'</span>,
-  <span class="hljs-built_in">background</span>: getLuminance(<span class="hljs-string">'rgba(58, 133, 255, 1)'</span>) &gt;= getLuminance(<span class="hljs-string">'rgba(255, 57, 149, 1)'</span>) ?
-                            <span class="hljs-string">'rgba(58, 133, 255, 1)'</span> :
-                            <span class="hljs-string">'rgba(255, 57, 149, 1)'</span>,
-}
-
-<span class="hljs-comment">// styled-components usage</span>
-<span class="hljs-keyword">const</span> div = styled.div`
-  <span class="hljs-built_in">background</span>: ${getLuminance(<span class="hljs-string">'#CCCD64'</span>) &gt;= getLuminance(<span class="hljs-string">'#0000ff'</span>) ? <span class="hljs-string">'#CCCD64'</span> : <span class="hljs-string">'#0000ff'</span>};
-  <span class="hljs-built_in">background</span>: ${getLuminance(<span class="hljs-string">'rgba(58, 133, 255, 1)'</span>) &gt;= getLuminance(<span class="hljs-string">'rgba(255, 57, 149, 1)'</span>) ?
-                            <span class="hljs-string">'rgba(58, 133, 255, 1)'</span> :
-                            <span class="hljs-string">'rgba(255, 57, 149, 1)'</span>};</pre>
-    
-  
-
-  
-
-  
-
-  
-</section>
-
-        
-      
-        
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
     <h3 class='fl m0' id='tocolorstring'>
       toColorString
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/color/toColorString.js#L65-L73'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/color/toColorString.js#L65-L73'>
       <span>src/color/toColorString.js</span>
       </a>
     
@@ -7440,7 +7447,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/be8b05ac4db6292bea597cc9463da10cf8a2187b/src/types/modularScaleRatio.js#L9-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/jcquinlan/polished/blob/d1d29365b157177e7cc1bcfbad77bdbd31d8228c/src/types/modularScaleRatio.js#L9-L27'>
       <span>src/types/modularScaleRatio.js</span>
       </a>
     

--- a/src/color/getLuminance.js
+++ b/src/color/getLuminance.js
@@ -1,0 +1,41 @@
+// @flow
+
+import parseToRgb from './parseToRgb'
+import curry from '../internalHelpers/_curry'
+
+/**
+ * Returns a number representing the luminance of a color.
+ *
+ * @example
+ * // Styles as object usage
+ * const styles = {
+ *   background: getLuminance('#CCCD64') >= getLuminance('#0000ff') ? '#CCCD64' : '#0000ff',
+ *   background: getLuminance('rgba(58, 133, 255, 1)') >= getLuminance('rgba(255, 57, 149, 1)') ?
+ *                             'rgba(58, 133, 255, 1)' :
+ *                             'rgba(255, 57, 149, 1)',
+ * }
+ *
+ * // styled-components usage
+ * const div = styled.div`
+ *   background: ${getLuminance('#CCCD64') >= getLuminance('#0000ff') ? '#CCCD64' : '#0000ff'};
+ *   background: ${getLuminance('rgba(58, 133, 255, 1)') >= getLuminance('rgba(255, 57, 149, 1)') ?
+ *                             'rgba(58, 133, 255, 1)' :
+ *                             'rgba(255, 57, 149, 1)'};
+ *
+ *
+ */
+function getLuminance(color: string): number {
+  const rgbColor = parseToRgb(color);
+  const [r, g, b] = Object.keys(rgbColor).map(key => {
+    const channel = rgbColor[key] / 255;
+    return channel <= 0.03928
+      ? channel / 12.92
+      : Math.pow((channel + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+
+// Don’t inline this variable into export because Rollup will remove the /*#__PURE__*/ comment
+const curriedGetLuminance = /*#__PURE__*/ curry(getLuminance) // eslint-disable-line spaced-comment
+export default curriedGetLuminance

--- a/src/color/getLuminance.js
+++ b/src/color/getLuminance.js
@@ -1,6 +1,5 @@
 // @flow
 import parseToRgb from './parseToRgb'
-import curry from '../internalHelpers/_curry'
 
 /**
  * Returns a number (float) representing the luminance of a color.
@@ -39,6 +38,4 @@ function getLuminance(color: string): number {
   return 0.2126 * r + 0.7152 * g + 0.0722 * b
 }
 
-// Don’t inline this variable into export because Rollup will remove the /*#__PURE__*/ comment
-const curriedGetLuminance = /*#__PURE__*/ curry(getLuminance) // eslint-disable-line spaced-comment
-export default curriedGetLuminance
+export default getLuminance

--- a/src/color/getLuminance.js
+++ b/src/color/getLuminance.js
@@ -1,10 +1,9 @@
 // @flow
-
 import parseToRgb from './parseToRgb'
 import curry from '../internalHelpers/_curry'
 
 /**
- * Returns a number representing the luminance of a color.
+ * Returns a number (float) representing the luminance of a color.
  *
  * @example
  * // Styles as object usage
@@ -22,7 +21,12 @@ import curry from '../internalHelpers/_curry'
  *                             'rgba(58, 133, 255, 1)' :
  *                             'rgba(255, 57, 149, 1)'};
  *
+ * // CSS in JS Output
  *
+ * div {
+ *   background: "#CCCD64";
+ *   background: "rgba(58, 133, 255, 1)";
+ * }
  */
 function getLuminance(color: string): number {
   const rgbColor: { [string]: number } = parseToRgb(color)
@@ -32,9 +36,8 @@ function getLuminance(color: string): number {
       ? channel / 12.92
       : ((channel + 0.055) / 1.055) ** 2.4
   })
-  return (0.2126 * r) + (0.7152 * g) + (0.0722 * b)
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b
 }
-
 
 // Don’t inline this variable into export because Rollup will remove the /*#__PURE__*/ comment
 const curriedGetLuminance = /*#__PURE__*/ curry(getLuminance) // eslint-disable-line spaced-comment

--- a/src/color/getLuminance.js
+++ b/src/color/getLuminance.js
@@ -25,7 +25,7 @@ import curry from '../internalHelpers/_curry'
  *
  */
 function getLuminance(color: string): number {
-  const rgbColor = parseToRgb(color)
+  const rgbColor: { [string]: number } = parseToRgb(color)
   const [r, g, b] = Object.keys(rgbColor).map(key => {
     const channel = rgbColor[key] / 255
     return channel <= 0.03928

--- a/src/color/getLuminance.js
+++ b/src/color/getLuminance.js
@@ -25,14 +25,14 @@ import curry from '../internalHelpers/_curry'
  *
  */
 function getLuminance(color: string): number {
-  const rgbColor = parseToRgb(color);
+  const rgbColor = parseToRgb(color)
   const [r, g, b] = Object.keys(rgbColor).map(key => {
-    const channel = rgbColor[key] / 255;
+    const channel = rgbColor[key] / 255
     return channel <= 0.03928
       ? channel / 12.92
-      : Math.pow((channel + 0.055) / 1.055, 2.4);
-  });
-  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+      : ((channel + 0.055) / 1.055) ** 2.4
+  })
+  return (0.2126 * r) + (0.7152 * g) + (0.0722 * b)
 }
 
 

--- a/src/color/readableColor.js
+++ b/src/color/readableColor.js
@@ -1,9 +1,6 @@
 // @flow
-import parseToRgb from './parseToRgb'
+import getLuminance from './getLuminance'
 import curry from '../internalHelpers/_curry'
-
-const h = (c: number): number =>
-  c / 255 <= 0.03928 ? c / 255 / 12.92 : ((c / 255 + 0.055) / 1.055) ** 2.4
 
 /**
  * Selects black or white for best contrast depending on the luminosity of the given color.
@@ -34,10 +31,7 @@ const h = (c: number): number =>
  */
 
 function readableColor(color: string): string {
-  const c = parseToRgb(color)
-  return h(c.red) * 0.2126 + h(c.green) * 0.7152 + h(c.blue) * 0.0722 > 0.179
-    ? '#000'
-    : '#fff'
+  return getLuminance(color) > 0.179 ? '#000' : '#fff'
 }
 
 // Don’t inline this variable into export because Rollup will remove the /*#__PURE__*/ comment

--- a/src/color/test/__snapshots__/getLuminance.test.js.snap
+++ b/src/color/test/__snapshots__/getLuminance.test.js.snap
@@ -1,0 +1,3 @@
+exports[`getLuminance should return the luminance of a hex color 1`] = `0.05780543019106723`;
+
+exports[`getLuminance should return the luminance of an rgba color 1`] = `0.5742011250098834`;

--- a/src/color/test/__snapshots__/getLuminance.test.js.snap
+++ b/src/color/test/__snapshots__/getLuminance.test.js.snap
@@ -1,3 +1,11 @@
 exports[`getLuminance should return the luminance of a hex color 1`] = `0.05780543019106723`;
 
+exports[`getLuminance should return the luminance of a named CSS color 1`] = `0.877971001998354`;
+
+exports[`getLuminance should return the luminance of an hls color 1`] = `0.2126`;
+
+exports[`getLuminance should return the luminance of an hlsa color 1`] = `0.07733591265855211`;
+
+exports[`getLuminance should return the luminance of an rgb color 1`] = `0.5742011250098834`;
+
 exports[`getLuminance should return the luminance of an rgba color 1`] = `0.5742011250098834`;

--- a/src/color/test/getLuminance.test.js
+++ b/src/color/test/getLuminance.test.js
@@ -1,0 +1,12 @@
+// @flow
+import getLuminance from '../getLuminance'
+
+describe('getLuminance', () => {
+  it('should return the luminance of a hex color', () => {
+    expect(getLuminance('#444')).toMatchSnapshot()
+  })
+
+  it('should return the luminance of an rgba color', () => {
+    expect(getLuminance('rgba(204,205,100,0.7)')).toMatchSnapshot()
+  })
+})

--- a/src/color/test/getLuminance.test.js
+++ b/src/color/test/getLuminance.test.js
@@ -9,4 +9,20 @@ describe('getLuminance', () => {
   it('should return the luminance of an rgba color', () => {
     expect(getLuminance('rgba(204,205,100,0.7)')).toMatchSnapshot()
   })
+
+  it('should return the luminance of an rgb color', () => {
+    expect(getLuminance('rgb(204,205,100)')).toMatchSnapshot()
+  })
+
+  it('should return the luminance of an hlsa color', () => {
+    expect(getLuminance('hsla(250, 100%, 50%, 0.2)')).toMatchSnapshot()
+  })
+
+  it('should return the luminance of an hls color', () => {
+    expect(getLuminance('hsl(0, 100%, 50%)')).toMatchSnapshot()
+  })
+
+  it('should return the luminance of a named CSS color', () => {
+    expect(getLuminance('papayawhip')).toMatchSnapshot()
+  })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ import adjustHue from './color/adjustHue'
 import complement from './color/complement'
 import darken from './color/darken'
 import desaturate from './color/desaturate'
+import getLuminance from './color/getLuminance'
 import grayscale from './color/grayscale'
 import hsl from './color/hsl'
 import hsla from './color/hsla'
@@ -81,6 +82,7 @@ export {
   ellipsis,
   em,
   fontFace,
+  getLuminance,
   grayscale,
   invert,
   hideText,


### PR DESCRIPTION
Closes #148 

At least partially, as it allows the user to get the value, but doesn't have an accompanying setter to change the luminance. It seemed like this was already being handled by other methods.

I feel like to really make this useful, another method would need to allow a user to compare the contrast ratio of two colors and return a boolean stating whether or not it adheres to the [W3C specs](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html#contrast-ratiodef).