### PR TITLE
Permit number inputs including allowing zero as a valid value.

### DIFF
--- a/src/helpers/directionalProperty.js
+++ b/src/helpers/directionalProperty.js
@@ -8,10 +8,10 @@ function generateProperty(property: string, position: string) {
   return splitPropertyName.join('-')
 }
 
-function generateStyles(property: string, valuesWithDefaults: Array<?string>) {
+function generateStyles(property: string, valuesWithDefaults: Array<?string | ?number>) {
   const styles = {}
   for (let i = 0; i < valuesWithDefaults.length; i += 1) {
-    if (valuesWithDefaults[i]) {
+    if (valuesWithDefaults[i] || valuesWithDefaults[i] === 0) {
       styles[generateProperty(property, positionMap[i])] = valuesWithDefaults[i]
     }
   }
@@ -41,7 +41,7 @@ function generateStyles(property: string, valuesWithDefaults: Array<?string>) {
  * }
  */
 
-function directionalProperty(property: string, ...values: Array<?string>) {
+function directionalProperty(property: string, ...values: Array<?string | ?number>) {
   //  prettier-ignore
   // $FlowIgnoreNextLine doesn't understand destructuring with chained defaults.
   const [firstValue, secondValue = firstValue, thirdValue = firstValue, fourthValue = secondValue] = values

--- a/src/helpers/test/__snapshots__/directionalProperty.test.js.snap
+++ b/src/helpers/test/__snapshots__/directionalProperty.test.js.snap
@@ -52,6 +52,15 @@ Object {
 }
 `;
 
+exports[`directionalProperty properly sets unitless zero 1`] = `
+Object {
+  "bottom": 0,
+  "left": 0,
+  "right": 0,
+  "top": 0,
+}
+`;
+
 exports[`directionalProperty properly skips bottom property when last value is null 1`] = `
 Object {
   "border-left": "24px",

--- a/src/helpers/test/directionalProperty.test.js
+++ b/src/helpers/test/directionalProperty.test.js
@@ -8,6 +8,9 @@ describe('directionalProperty', () => {
   it('properly passes just the position when not given a property', () => {
     expect(directionalProperty('', '12px')).toMatchSnapshot()
   })
+  it('properly sets unitless zero', () => {
+    expect(directionalProperty('', 0)).toMatchSnapshot()
+  })
 
   // One Param
   it('properly applies a value when passed only one', () => {

--- a/src/mixins/ellipsis.js
+++ b/src/mixins/ellipsis.js
@@ -26,7 +26,7 @@
  * }
  */
 
-function ellipsis(width: string = '100%') {
+function ellipsis(width: string | number = '100%') {
   return {
     display: 'inline-block',
     'max-width': width,

--- a/src/mixins/test/__snapshots__/ellipsis.test.js.snap
+++ b/src/mixins/test/__snapshots__/ellipsis.test.js.snap
@@ -20,6 +20,17 @@ Object {
 }
 `;
 
+exports[`ellipsis should permit bare number 1`] = `
+Object {
+  "display": "inline-block",
+  "max-width": 300,
+  "overflow": "hidden",
+  "text-overflow": "ellipsis",
+  "white-space": "nowrap",
+  "word-wrap": "normal",
+}
+`;
+
 exports[`ellipsis should properly add rules when block has existing rules 1`] = `
 Object {
   "background": "red",

--- a/src/mixins/test/ellipsis.test.js
+++ b/src/mixins/test/ellipsis.test.js
@@ -6,6 +6,10 @@ describe('ellipsis', () => {
     expect({ ...ellipsis('300px') }).toMatchSnapshot()
   })
 
+  it('should permit bare number', () => {
+    expect({ ...ellipsis(300) }).toMatchSnapshot()
+  })
+
   it('should properly add rules when block has existing rules', () => {
     expect({
       background: 'red',

--- a/src/shorthands/borderRadius.js
+++ b/src/shorthands/borderRadius.js
@@ -21,10 +21,13 @@
  * }
  */
 
-function borderRadius(side: string, radius: string) {
-  if (!radius || typeof radius !== 'string') {
+function borderRadius(side:string, radius:string | number) {
+  if (
+    (typeof radius !== 'string' || radius === '') &&
+    (typeof radius !== 'number' || Number.isNaN(radius))
+  ) {
     throw new Error(
-      'borderRadius expects a radius value as a string as the second argument.',
+      'borderRadius expects a radius value as a string or number as the second argument.',
     )
   }
   if (side === 'top' || side === 'bottom') {

--- a/src/shorthands/borderWidth.js
+++ b/src/shorthands/borderWidth.js
@@ -24,7 +24,7 @@ import directionalProperty from '../helpers/directionalProperty'
  * }
  */
 
-function borderWidth(...values: Array<?string>) {
+function borderWidth(...values: Array<?string | ?number>) {
   return directionalProperty('border-width', ...values)
 }
 

--- a/src/shorthands/margin.js
+++ b/src/shorthands/margin.js
@@ -24,7 +24,7 @@ import directionalProperty from '../helpers/directionalProperty'
  * }
  */
 
-function margin(...values: Array<?string>) {
+function margin(...values: Array<?string | ?number>) {
   return directionalProperty('margin', ...values)
 }
 

--- a/src/shorthands/padding.js
+++ b/src/shorthands/padding.js
@@ -24,7 +24,7 @@ import directionalProperty from '../helpers/directionalProperty'
  * }
  */
 
-function padding(...values: Array<?string>) {
+function padding(...values: Array<?string | ?number>) {
   return directionalProperty('padding', ...values)
 }
 

--- a/src/shorthands/position.js
+++ b/src/shorthands/position.js
@@ -46,7 +46,7 @@ const positionMap = ['absolute', 'fixed', 'relative', 'static', 'sticky']
  * }
  */
 
-function position(positionKeyword: string | null, ...values: Array<?string>) {
+function position(positionKeyword: string | number | null, ...values: Array<?string | ?number>) {
   if (positionMap.indexOf(positionKeyword) >= 0) {
     return {
       position: positionKeyword,

--- a/src/shorthands/size.js
+++ b/src/shorthands/size.js
@@ -21,7 +21,7 @@
  * }
  */
 
-function size(height: string, width: string = height) {
+function size(height: string | number, width: string | number = height) {
   return {
     height,
     width,

--- a/src/shorthands/test/__snapshots__/borderRadius.test.js.snap
+++ b/src/shorthands/test/__snapshots__/borderRadius.test.js.snap
@@ -1,3 +1,17 @@
+exports[`borderRadius properly applies unitless value 1`] = `
+Object {
+  "border-top-left-radius": 5,
+  "border-top-right-radius": 5,
+}
+`;
+
+exports[`borderRadius properly applies unitless zero 1`] = `
+Object {
+  "border-bottom-left-radius": 0,
+  "border-top-left-radius": 0,
+}
+`;
+
 exports[`borderRadius returns the proper values for the bottom side 1`] = `
 Object {
   "border-bottom-left-radius": "5px",

--- a/src/shorthands/test/__snapshots__/borderWidth.test.js.snap
+++ b/src/shorthands/test/__snapshots__/borderWidth.test.js.snap
@@ -7,6 +7,24 @@ Object {
 }
 `;
 
+exports[`borderWidth properly applies unitless values 1`] = `
+Object {
+  "border-bottom-width": 36,
+  "border-left-width": 48,
+  "border-right-width": 24,
+  "border-top-width": 12,
+}
+`;
+
+exports[`borderWidth properly applies unitless zero 1`] = `
+Object {
+  "border-bottom-width": 0,
+  "border-left-width": 0,
+  "border-right-width": 0,
+  "border-top-width": 0,
+}
+`;
+
 exports[`borderWidth properly applies values when passed four 1`] = `
 Object {
   "border-bottom-width": "36px",

--- a/src/shorthands/test/__snapshots__/margin.test.js.snap
+++ b/src/shorthands/test/__snapshots__/margin.test.js.snap
@@ -7,6 +7,24 @@ Object {
 }
 `;
 
+exports[`margin properly applies unitless values 1`] = `
+Object {
+  "margin-bottom": 36,
+  "margin-left": 48,
+  "margin-right": 24,
+  "margin-top": 12,
+}
+`;
+
+exports[`margin properly applies unitless zero 1`] = `
+Object {
+  "margin-bottom": 0,
+  "margin-left": 0,
+  "margin-right": 0,
+  "margin-top": 0,
+}
+`;
+
 exports[`margin properly applies values when passed four 1`] = `
 Object {
   "margin-bottom": "36px",

--- a/src/shorthands/test/__snapshots__/padding.test.js.snap
+++ b/src/shorthands/test/__snapshots__/padding.test.js.snap
@@ -7,6 +7,24 @@ Object {
 }
 `;
 
+exports[`padding properly applies unitless values 1`] = `
+Object {
+  "padding-bottom": 36,
+  "padding-left": 48,
+  "padding-right": 24,
+  "padding-top": 12,
+}
+`;
+
+exports[`padding properly applies unitless zero 1`] = `
+Object {
+  "padding-bottom": 0,
+  "padding-left": 0,
+  "padding-right": 0,
+  "padding-top": 0,
+}
+`;
+
 exports[`padding properly applies values when passed four 1`] = `
 Object {
   "padding-bottom": "36px",

--- a/src/shorthands/test/__snapshots__/position.test.js.snap
+++ b/src/shorthands/test/__snapshots__/position.test.js.snap
@@ -8,6 +8,24 @@ Object {
 }
 `;
 
+exports[`position properly applies unitless values 1`] = `
+Object {
+  "bottom": 36,
+  "left": 48,
+  "right": 24,
+  "top": 12,
+}
+`;
+
+exports[`position properly applies unitless zero 1`] = `
+Object {
+  "bottom": 0,
+  "left": 0,
+  "right": 0,
+  "top": 0,
+}
+`;
+
 exports[`position properly applies values when passed four 1`] = `
 Object {
   "bottom": "36px",

--- a/src/shorthands/test/__snapshots__/size.test.js.snap
+++ b/src/shorthands/test/__snapshots__/size.test.js.snap
@@ -19,3 +19,17 @@ Object {
   "width": "300px",
 }
 `;
+
+exports[`size should set height and width with unitless values 1`] = `
+Object {
+  "height": 300,
+  "width": 250,
+}
+`;
+
+exports[`size should set height and width with unitless zero 1`] = `
+Object {
+  "height": 0,
+  "width": 0,
+}
+`;

--- a/src/shorthands/test/borderRadius.test.js
+++ b/src/shorthands/test/borderRadius.test.js
@@ -19,15 +19,29 @@ describe('borderRadius', () => {
       // $FlowIgnoreNextLine since the coming is invalid code, flow complains
       borderRadius('top')
     }).toThrow(
-      'borderRadius expects a radius value as a string as the second argument.',
+      'borderRadius expects a radius value as a string or number as the second argument.',
+    )
+  })
+  it('should throw an error when no radius value is provided', () => {
+    expect(() => {
+      borderRadius('top', '')
+    }).toThrow(
+      'borderRadius expects a radius value as a string or number as the second argument.',
+    )
+  })
+  it('should throw an error when no radius value is provided', () => {
+    expect(() => {
+      borderRadius('top', NaN)
+    }).toThrow(
+      'borderRadius expects a radius value as a string or number as the second argument.',
     )
   })
   it('should throw an error when no radius value is provided', () => {
     expect(() => {
       // $FlowIgnoreNextLine since the coming is invalid code, flow complains
-      borderRadius('top', 100)
+      borderRadius('top', true)
     }).toThrow(
-      'borderRadius expects a radius value as a string as the second argument.',
+      'borderRadius expects a radius value as a string or number as the second argument.',
     )
   })
   it('should throw an error when an invalid side value is provided', () => {
@@ -36,5 +50,11 @@ describe('borderRadius', () => {
     }).toThrow(
       'borderRadius expects one of "top", "bottom", "left" or "right" as the first argument.',
     )
+  })
+  it('properly applies unitless value', () => {
+    expect(borderRadius('top', 5)).toMatchSnapshot()
+  })
+  it('properly applies unitless zero', () => {
+    expect(borderRadius('left', 0)).toMatchSnapshot()
   })
 })

--- a/src/shorthands/test/borderWidth.test.js
+++ b/src/shorthands/test/borderWidth.test.js
@@ -14,4 +14,10 @@ describe('borderWidth', () => {
   it('properly applies values when passed four', () => {
     expect(borderWidth('12px', '24px', '36px', '48px')).toMatchSnapshot()
   })
+  it('properly applies unitless values', () => {
+    expect(borderWidth(12, 24, 36, 48)).toMatchSnapshot()
+  })
+  it('properly applies unitless zero', () => {
+    expect(borderWidth(0)).toMatchSnapshot()
+  })
 })

--- a/src/shorthands/test/margin.test.js
+++ b/src/shorthands/test/margin.test.js
@@ -14,4 +14,10 @@ describe('margin', () => {
   it('properly applies values when passed four', () => {
     expect(margin('12px', '24px', '36px', '48px')).toMatchSnapshot()
   })
+  it('properly applies unitless values', () => {
+    expect(margin(12, 24, 36, 48)).toMatchSnapshot()
+  })
+  it('properly applies unitless zero', () => {
+    expect(margin(0)).toMatchSnapshot()
+  })
 })

--- a/src/shorthands/test/padding.test.js
+++ b/src/shorthands/test/padding.test.js
@@ -14,4 +14,10 @@ describe('padding', () => {
   it('properly applies values when passed four', () => {
     expect(padding('12px', '24px', '36px', '48px')).toMatchSnapshot()
   })
+  it('properly applies unitless values', () => {
+    expect(padding(12, 24, 36, 48)).toMatchSnapshot()
+  })
+  it('properly applies unitless zero', () => {
+    expect(padding(0)).toMatchSnapshot()
+  })
 })

--- a/src/shorthands/test/position.test.js
+++ b/src/shorthands/test/position.test.js
@@ -19,4 +19,10 @@ describe('position', () => {
   it('properly ignores position property, when not passed one', () => {
     expect(position('12px', '24px', '36px', '48px')).toMatchSnapshot()
   })
+  it('properly applies unitless values', () => {
+    expect(position(12, 24, 36, 48)).toMatchSnapshot()
+  })
+  it('properly applies unitless zero', () => {
+    expect(position(0)).toMatchSnapshot()
+  })
 })

--- a/src/shorthands/test/size.test.js
+++ b/src/shorthands/test/size.test.js
@@ -16,4 +16,12 @@ describe('size', () => {
   it('should set height and width to the same value when only one parameter is passed', () => {
     expect({ ...size('300px') }).toMatchSnapshot()
   })
+
+  it('should set height and width with unitless values', () => {
+    expect({ ...size(300, 250) }).toMatchSnapshot()
+  })
+
+  it('should set height and width with unitless zero', () => {
+    expect({ ...size(0) }).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
This change allows `0` as a valid value for the `directionalProperty` helper. Previously a zero value would be ignored and left unset.

In practical terms, it means you can type `position(0)` whereas before you had to type `position('0')`.