### PR TITLE
Flexible modularScale output unit

### DIFF
--- a/src/helpers/modularScale.js
+++ b/src/helpers/modularScale.js
@@ -1,5 +1,6 @@
 // @flow
 
+import getUnit from '../internalHelpers/_getUnit'
 import stripUnit from './stripUnit'
 
 const ratioNames = {
@@ -72,6 +73,8 @@ function modularScale(steps: number, base?: number|string = '1em', ratio?: Ratio
     throw new Error('Please pass a number or one of the predefined scales to the modularScale helper as the ratio.')
   }
 
+  const defaultUnit = 'em'
+  const unit = typeof base === 'string' ? (getUnit(base) || defaultUnit) : defaultUnit
   const realBase = typeof base === 'string' ? stripUnit(base) : base
   const realRatio = typeof ratio === 'string' ? ratioNames[ratio] : ratio
 
@@ -79,7 +82,7 @@ function modularScale(steps: number, base?: number|string = '1em', ratio?: Ratio
     throw new Error(`Invalid value passed as base to modularScale, expected number or em string but got "${base}"`)
   }
 
-  return `${realBase * (realRatio ** steps)}em`
+  return `${realBase * (realRatio ** steps)}${unit}`
 }
 
 export { ratioNames }

--- a/src/helpers/test/__snapshots__/modularScale.test.js.snap
+++ b/src/helpers/test/__snapshots__/modularScale.test.js.snap
@@ -129,3 +129,21 @@ Object {
   "font-size": "1em",
 }
 `;
+
+exports[`modularScale should use the base unit as the output value 1`] = `
+Object {
+  "font-size": "1rem",
+}
+`;
+
+exports[`modularScale should use the base unit as the output value 2`] = `
+Object {
+  "font-size": "1em",
+}
+`;
+
+exports[`modularScale should use the base unit as the output value 3`] = `
+Object {
+  "font-size": "2em",
+}
+`;

--- a/src/helpers/test/modularScale.test.js
+++ b/src/helpers/test/modularScale.test.js
@@ -27,6 +27,12 @@ describe('modularScale', () => {
     })
   })
 
+  it('should use the base unit as the output value', () => {
+    expect({ 'font-size': modularScale(1, '1rem', 1) }).toMatchSnapshot()
+    expect({ 'font-size': modularScale(1, '1', 1) }).toMatchSnapshot()
+    expect({ 'font-size': modularScale(1, 2, 1) }).toMatchSnapshot()
+  })
+
   it('should throw an error if an invalid base is provided', () => {
     expect(() => {
       modularScale(2, 'invalid')

--- a/src/internalHelpers/_getUnit.js
+++ b/src/internalHelpers/_getUnit.js
@@ -1,0 +1,36 @@
+// @flow
+
+/**
+ * Returns the unit from a given CSS value. (or null if an invalid string was passed)
+ */
+
+const units = [
+  '%',
+  'ch',
+  'cm',
+  'em',
+  'ex',
+  'ic',
+  'in',
+  'mm',
+  'lh',
+  'pc',
+  'pt',
+  'px',
+  'rem',
+  'rlh',
+  'vh',
+  'vi',
+  'vb',
+  'q',
+  'vmax',
+  'vmin',
+  'vw',
+]
+
+function getUnit(value: string): string {
+  const unit = value.replace(/[^a-zA-Z-%]/g, '')
+  return units.includes(unit) ? unit : null;
+}
+
+export default getUnit

--- a/src/internalHelpers/_getUnit.js
+++ b/src/internalHelpers/_getUnit.js
@@ -28,9 +28,9 @@ const units = [
   'vw',
 ]
 
-function getUnit(value: string): string {
+function getUnit(value: string): string | null {
   const unit = value.replace(/[^a-zA-Z-%]/g, '')
-  return units.includes(unit) ? unit : null;
+  return units.includes(unit) ? unit : null
 }
 
 export default getUnit

--- a/src/internalHelpers/test/__snapshots__/_getUnit.test.js.snap
+++ b/src/internalHelpers/test/__snapshots__/_getUnit.test.js.snap
@@ -1,0 +1,67 @@
+exports[`getUnit should get % from decimal values 1`] = `"%"`;
+
+exports[`getUnit should get % from whole values 1`] = `"%"`;
+
+exports[`getUnit should get ch from decimal values 1`] = `"ch"`;
+
+exports[`getUnit should get ch from whole values 1`] = `"ch"`;
+
+exports[`getUnit should get cm from values 1`] = `"cm"`;
+
+exports[`getUnit should get cm from whole values 1`] = `"cm"`;
+
+exports[`getUnit should get em from decimal values 1`] = `"em"`;
+
+exports[`getUnit should get em from whole value 1`] = `"em"`;
+
+exports[`getUnit should get ex from decimal values 1`] = `"ex"`;
+
+exports[`getUnit should get ex from whole values 1`] = `"ex"`;
+
+exports[`getUnit should get in from values 1`] = `"in"`;
+
+exports[`getUnit should get in from whole values 1`] = `"in"`;
+
+exports[`getUnit should get mm from values 1`] = `"mm"`;
+
+exports[`getUnit should get mm from whole values 1`] = `"mm"`;
+
+exports[`getUnit should get pc from values 1`] = `"pc"`;
+
+exports[`getUnit should get pc from whole values 1`] = `"pc"`;
+
+exports[`getUnit should get pt from values 1`] = `"pt"`;
+
+exports[`getUnit should get pt from whole values 1`] = `"pt"`;
+
+exports[`getUnit should get px from values 1`] = `"px"`;
+
+exports[`getUnit should get px from whole values 1`] = `"px"`;
+
+exports[`getUnit should get q from values 1`] = `"q"`;
+
+exports[`getUnit should get q from whole values 1`] = `"q"`;
+
+exports[`getUnit should get rem from decimal values 1`] = `"rem"`;
+
+exports[`getUnit should get rem from whole values 1`] = `"rem"`;
+
+exports[`getUnit should get vh from decimal values 1`] = `"vh"`;
+
+exports[`getUnit should get vh from whole values 1`] = `"vh"`;
+
+exports[`getUnit should get vmax from decimal values 1`] = `"vmax"`;
+
+exports[`getUnit should get vmax from whole values 1`] = `"vmax"`;
+
+exports[`getUnit should get vmin from decimal values 1`] = `"vmin"`;
+
+exports[`getUnit should get vmin from whole values 1`] = `"vmin"`;
+
+exports[`getUnit should get vw from decimal values 1`] = `"vw"`;
+
+exports[`getUnit should get vw from whole values 1`] = `"vw"`;
+
+exports[`getUnit should return null when passed a unitless value 1`] = `null`;
+
+exports[`getUnit should return null when passed an untouched string 1`] = `null`;

--- a/src/internalHelpers/test/__snapshots__/_getUnit.test.js.snap
+++ b/src/internalHelpers/test/__snapshots__/_getUnit.test.js.snap
@@ -1,64 +1,96 @@
 exports[`getUnit should get % from decimal values 1`] = `"%"`;
 
+exports[`getUnit should get % from decimal values 2`] = `"%"`;
+
 exports[`getUnit should get % from whole values 1`] = `"%"`;
 
 exports[`getUnit should get ch from decimal values 1`] = `"ch"`;
+
+exports[`getUnit should get ch from decimal values 2`] = `"ch"`;
 
 exports[`getUnit should get ch from whole values 1`] = `"ch"`;
 
 exports[`getUnit should get cm from values 1`] = `"cm"`;
 
+exports[`getUnit should get cm from values 2`] = `"cm"`;
+
 exports[`getUnit should get cm from whole values 1`] = `"cm"`;
 
 exports[`getUnit should get em from decimal values 1`] = `"em"`;
+
+exports[`getUnit should get em from decimal values 2`] = `"em"`;
 
 exports[`getUnit should get em from whole value 1`] = `"em"`;
 
 exports[`getUnit should get ex from decimal values 1`] = `"ex"`;
 
+exports[`getUnit should get ex from decimal values 2`] = `"ex"`;
+
 exports[`getUnit should get ex from whole values 1`] = `"ex"`;
 
 exports[`getUnit should get in from values 1`] = `"in"`;
+
+exports[`getUnit should get in from values 2`] = `"in"`;
 
 exports[`getUnit should get in from whole values 1`] = `"in"`;
 
 exports[`getUnit should get mm from values 1`] = `"mm"`;
 
+exports[`getUnit should get mm from values 2`] = `"mm"`;
+
 exports[`getUnit should get mm from whole values 1`] = `"mm"`;
 
 exports[`getUnit should get pc from values 1`] = `"pc"`;
+
+exports[`getUnit should get pc from values 2`] = `"pc"`;
 
 exports[`getUnit should get pc from whole values 1`] = `"pc"`;
 
 exports[`getUnit should get pt from values 1`] = `"pt"`;
 
+exports[`getUnit should get pt from values 2`] = `"pt"`;
+
 exports[`getUnit should get pt from whole values 1`] = `"pt"`;
 
 exports[`getUnit should get px from values 1`] = `"px"`;
+
+exports[`getUnit should get px from values 2`] = `"px"`;
 
 exports[`getUnit should get px from whole values 1`] = `"px"`;
 
 exports[`getUnit should get q from values 1`] = `"q"`;
 
+exports[`getUnit should get q from values 2`] = `"q"`;
+
 exports[`getUnit should get q from whole values 1`] = `"q"`;
 
 exports[`getUnit should get rem from decimal values 1`] = `"rem"`;
+
+exports[`getUnit should get rem from decimal values 2`] = `"rem"`;
 
 exports[`getUnit should get rem from whole values 1`] = `"rem"`;
 
 exports[`getUnit should get vh from decimal values 1`] = `"vh"`;
 
+exports[`getUnit should get vh from decimal values 2`] = `"vh"`;
+
 exports[`getUnit should get vh from whole values 1`] = `"vh"`;
 
 exports[`getUnit should get vmax from decimal values 1`] = `"vmax"`;
+
+exports[`getUnit should get vmax from decimal values 2`] = `"vmax"`;
 
 exports[`getUnit should get vmax from whole values 1`] = `"vmax"`;
 
 exports[`getUnit should get vmin from decimal values 1`] = `"vmin"`;
 
+exports[`getUnit should get vmin from decimal values 2`] = `"vmin"`;
+
 exports[`getUnit should get vmin from whole values 1`] = `"vmin"`;
 
 exports[`getUnit should get vw from decimal values 1`] = `"vw"`;
+
+exports[`getUnit should get vw from decimal values 2`] = `"vw"`;
 
 exports[`getUnit should get vw from whole values 1`] = `"vw"`;
 

--- a/src/internalHelpers/test/_getUnit.test.js
+++ b/src/internalHelpers/test/_getUnit.test.js
@@ -1,0 +1,141 @@
+// @flow
+
+import getUnit from '../_getUnit'
+
+describe('getUnit', () => {
+  it('should get px from whole values', () => {
+    expect(getUnit('1px')).toMatchSnapshot()
+  })
+
+  it('should get px from values', () => {
+    expect(getUnit('1.5px')).toMatchSnapshot()
+  })
+
+  it('should get pt from whole values', () => {
+    expect(getUnit('1pt')).toMatchSnapshot()
+  })
+
+  it('should get pt from values', () => {
+    expect(getUnit('1.5pt')).toMatchSnapshot()
+  })
+
+  it('should get pc from whole values', () => {
+    expect(getUnit('1pc')).toMatchSnapshot()
+  })
+
+  it('should get pc from values', () => {
+    expect(getUnit('1.5pc')).toMatchSnapshot()
+  })
+
+  it('should get mm from whole values', () => {
+    expect(getUnit('1mm')).toMatchSnapshot()
+  })
+
+  it('should get mm from values', () => {
+    expect(getUnit('1.5mm')).toMatchSnapshot()
+  })
+
+  it('should get q from whole values', () => {
+    expect(getUnit('1q')).toMatchSnapshot()
+  })
+
+  it('should get q from values', () => {
+    expect(getUnit('1.5q')).toMatchSnapshot()
+  })
+
+  it('should get cm from whole values', () => {
+    expect(getUnit('1cm')).toMatchSnapshot()
+  })
+
+  it('should get cm from values', () => {
+    expect(getUnit('1.5cm')).toMatchSnapshot()
+  })
+
+  it('should get in from whole values', () => {
+    expect(getUnit('1in')).toMatchSnapshot()
+  })
+
+  it('should get in from values', () => {
+    expect(getUnit('1.5in')).toMatchSnapshot()
+  })
+
+  it('should get em from whole value', () => {
+    expect(getUnit('1em')).toMatchSnapshot()
+  })
+
+  it('should get em from decimal values', () => {
+    expect(getUnit('1.2em')).toMatchSnapshot()
+  })
+
+  it('should get rem from whole values', () => {
+    expect(getUnit('1rem')).toMatchSnapshot()
+  })
+
+  it('should get rem from decimal values', () => {
+    expect(getUnit('1.2rem')).toMatchSnapshot()
+  })
+
+  it('should get ex from whole values', () => {
+    expect(getUnit('1ex')).toMatchSnapshot()
+  })
+
+  it('should get ex from decimal values', () => {
+    expect(getUnit('1.2ex')).toMatchSnapshot()
+  })
+
+  it('should get ch from whole values', () => {
+    expect(getUnit('1ch')).toMatchSnapshot()
+  })
+
+  it('should get ch from decimal values', () => {
+    expect(getUnit('1.2ch')).toMatchSnapshot()
+  })
+
+  it('should get vh from whole values', () => {
+    expect(getUnit('100vh')).toMatchSnapshot()
+  })
+
+  it('should get vh from decimal values', () => {
+    expect(getUnit('33.33vh')).toMatchSnapshot()
+  })
+
+  it('should get vw from whole values', () => {
+    expect(getUnit('100vw')).toMatchSnapshot()
+  })
+
+  it('should get vw from decimal values', () => {
+    expect(getUnit('33.33vw')).toMatchSnapshot()
+  })
+
+  it('should get vmin from whole values', () => {
+    expect(getUnit('100vmin')).toMatchSnapshot()
+  })
+
+  it('should get vmin from decimal values', () => {
+    expect(getUnit('33.33vmin')).toMatchSnapshot()
+  })
+
+  it('should get vmax from whole values', () => {
+    expect(getUnit('100vmax')).toMatchSnapshot()
+  })
+
+  it('should get vmax from decimal values', () => {
+    expect(getUnit('33.33vmax')).toMatchSnapshot()
+  })
+
+  it('should get % from whole values', () => {
+    expect(getUnit('80%')).toMatchSnapshot()
+  })
+
+  it('should get % from decimal values', () => {
+    expect(getUnit('33.3%')).toMatchSnapshot()
+  })
+
+  it('should return null when passed a unitless value', () => {
+    expect(getUnit('100')).toMatchSnapshot()
+  })
+
+  it('should return null when passed an untouched string', () => {
+    expect(getUnit('red')).toMatchSnapshot()
+  })
+})

--- a/src/internalHelpers/test/_getUnit.test.js
+++ b/src/internalHelpers/test/_getUnit.test.js
@@ -8,6 +8,7 @@ describe('getUnit', () => {
   })
 
   it('should get px from values', () => {
+    expect(getUnit('.05px')).toMatchSnapshot()
     expect(getUnit('1.5px')).toMatchSnapshot()
   })
 
@@ -16,6 +17,7 @@ describe('getUnit', () => {
   })
 
   it('should get pt from values', () => {
+    expect(getUnit('.05pt')).toMatchSnapshot()
     expect(getUnit('1.5pt')).toMatchSnapshot()
   })
 
@@ -24,6 +26,7 @@ describe('getUnit', () => {
   })
 
   it('should get pc from values', () => {
+    expect(getUnit('.05pc')).toMatchSnapshot()
     expect(getUnit('1.5pc')).toMatchSnapshot()
   })
 
@@ -32,6 +35,7 @@ describe('getUnit', () => {
   })
 
   it('should get mm from values', () => {
+    expect(getUnit('.05mm')).toMatchSnapshot()
     expect(getUnit('1.5mm')).toMatchSnapshot()
   })
 
@@ -40,6 +44,7 @@ describe('getUnit', () => {
   })
 
   it('should get q from values', () => {
+    expect(getUnit('.05q')).toMatchSnapshot()
     expect(getUnit('1.5q')).toMatchSnapshot()
   })
 
@@ -48,6 +53,7 @@ describe('getUnit', () => {
   })
 
   it('should get cm from values', () => {
+    expect(getUnit('.05cm')).toMatchSnapshot()
     expect(getUnit('1.5cm')).toMatchSnapshot()
   })
 
@@ -56,6 +62,7 @@ describe('getUnit', () => {
   })
 
   it('should get in from values', () => {
+    expect(getUnit('.05in')).toMatchSnapshot()
     expect(getUnit('1.5in')).toMatchSnapshot()
   })
 
@@ -64,6 +71,7 @@ describe('getUnit', () => {
   })
 
   it('should get em from decimal values', () => {
+    expect(getUnit('.05em')).toMatchSnapshot()
     expect(getUnit('1.2em')).toMatchSnapshot()
   })
 
@@ -72,6 +80,7 @@ describe('getUnit', () => {
   })
 
   it('should get rem from decimal values', () => {
+    expect(getUnit('.05rem')).toMatchSnapshot()
     expect(getUnit('1.2rem')).toMatchSnapshot()
   })
 
@@ -80,6 +89,7 @@ describe('getUnit', () => {
   })
 
   it('should get ex from decimal values', () => {
+    expect(getUnit('.05ex')).toMatchSnapshot()
     expect(getUnit('1.2ex')).toMatchSnapshot()
   })
 
@@ -88,6 +98,7 @@ describe('getUnit', () => {
   })
 
   it('should get ch from decimal values', () => {
+    expect(getUnit('.05ch')).toMatchSnapshot()
     expect(getUnit('1.2ch')).toMatchSnapshot()
   })
 
@@ -96,6 +107,7 @@ describe('getUnit', () => {
   })
 
   it('should get vh from decimal values', () => {
+    expect(getUnit('.05vh')).toMatchSnapshot()
     expect(getUnit('33.33vh')).toMatchSnapshot()
   })
 
@@ -104,6 +116,7 @@ describe('getUnit', () => {
   })
 
   it('should get vw from decimal values', () => {
+    expect(getUnit('.05vw')).toMatchSnapshot()
     expect(getUnit('33.33vw')).toMatchSnapshot()
   })
 
@@ -112,6 +125,7 @@ describe('getUnit', () => {
   })
 
   it('should get vmin from decimal values', () => {
+    expect(getUnit('.05vmin')).toMatchSnapshot()
     expect(getUnit('33.33vmin')).toMatchSnapshot()
   })
 
@@ -120,6 +134,7 @@ describe('getUnit', () => {
   })
 
   it('should get vmax from decimal values', () => {
+    expect(getUnit('.05vmax')).toMatchSnapshot()
     expect(getUnit('33.33vmax')).toMatchSnapshot()
   })
 
@@ -128,6 +143,7 @@ describe('getUnit', () => {
   })
 
   it('should get % from decimal values', () => {
+    expect(getUnit('.05%')).toMatchSnapshot()
     expect(getUnit('33.3%')).toMatchSnapshot()
   })
 


### PR DESCRIPTION
The output of `modularScale` is currently hard-coded to use `em` for its ouput. In an attempt to avoid this assumption and make the function return other units this PR extends `modularScale` to parse the unit from the base argument.

Related to #150 (RFC change modularScale default unit from `em` to `rem`).