### PR TITLE
[V2][WIP] feat(Color): Returns most readable color, black or white

### DIFF
--- a/.documentation.json
+++ b/.documentation.json
@@ -46,6 +46,7 @@
     "opacify",
     "parseToHsl",
     "parseToRgb",
+    "readableColor",
     "rgb",
     "rgba",
     "saturate",

--- a/docs/assets/polished.js
+++ b/docs/assets/polished.js
@@ -1,32 +1,30 @@
-(function(global, factory) {
-  typeof exports === 'object' && typeof module !== 'undefined'
-    ? factory(exports)
-    : typeof define === 'function' && define.amd
-        ? define(['exports'], factory)
-        : factory((global.polished = global.polished || {}))
-}(this, (exports) => {
-  //
-  const positionMap = ['top', 'right', 'bottom', 'left']
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+  typeof define === 'function' && define.amd ? define(['exports'], factory) :
+  (factory((global.polished = global.polished || {})));
+}(this, (function (exports) { 'use strict';
 
-  function generateProperty(property, position) {
-    if (!property) return position
-    const splitPropertyName = property.split('-')
-    splitPropertyName.splice(1, 0, position)
-    return splitPropertyName.join('-')
-  }
+//      
+var positionMap = ['top', 'right', 'bottom', 'left'];
 
-  function generateStyles(property, valuesWithDefaults) {
-    const styles = {}
-    for (let i = 0; i < valuesWithDefaults.length; i += 1) {
-      if (valuesWithDefaults[i]) {
-        styles[generateProperty(property, positionMap[i])] =
-          valuesWithDefaults[i]
-      }
+function generateProperty(property, position) {
+  if (!property) return position;
+  var splitPropertyName = property.split('-');
+  splitPropertyName.splice(1, 0, position);
+  return splitPropertyName.join('-');
+}
+
+function generateStyles(property, valuesWithDefaults) {
+  var styles = {};
+  for (var i = 0; i < valuesWithDefaults.length; i += 1) {
+    if (valuesWithDefaults[i]) {
+      styles[generateProperty(property, positionMap[i])] = valuesWithDefaults[i];
     }
-    return styles
   }
+  return styles;
+}
 
-  /**
+/**
  * The directional property helper enables shorthand for direction based properties. It accepts a property and up to four values that map to top, right, bottom, and left, respectively. You can optionally pass an empty string to get only the directional values as properties. You can optionally pass a null argument for a directional value to ignore it.
  * @example
  * // Styles as object usage
@@ -49,44 +47,38 @@
  * }
  */
 
-  function directionalProperty(property) {
-    for (
-      var _len = arguments.length,
-        values = Array(_len > 1 ? _len - 1 : 0),
-        _key = 1;
-      _key < _len;
-      _key++
-    ) {
-      values[_key - 1] = arguments[_key]
-    }
+function directionalProperty(property) {
+  for (var _len = arguments.length, values = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+    values[_key - 1] = arguments[_key];
+  }
 
-    // prettier-ignore
-    // $FlowIgnoreNextLine doesn't understand destructuring with chained defaults.
-    let firstValue = values[0],
+  //  prettier-ignore
+  // $FlowIgnoreNextLine doesn't understand destructuring with chained defaults.
+  var firstValue = values[0],
       _values$ = values[1],
       secondValue = _values$ === undefined ? firstValue : _values$,
       _values$2 = values[2],
       thirdValue = _values$2 === undefined ? firstValue : _values$2,
       _values$3 = values[3],
-      fourthValue = _values$3 === undefined ? secondValue : _values$3
+      fourthValue = _values$3 === undefined ? secondValue : _values$3;
 
-    const valuesWithDefaults = [firstValue, secondValue, thirdValue, fourthValue]
-    return generateStyles(property, valuesWithDefaults)
-  }
+  var valuesWithDefaults = [firstValue, secondValue, thirdValue, fourthValue];
+  return generateStyles(property, valuesWithDefaults);
+}
 
-  //
+//      
 
-  /**
+/**
  * Check if a string ends with something
  * @private
  */
-  const endsWith = function(string, suffix) {
-    return string.substr(-suffix.length) === suffix
-  }
+var endsWith = function (string, suffix) {
+  return string.substr(-suffix.length) === suffix;
+};
 
-  //
+//      
 
-  /**
+/**
  * Strip the unit from a given CSS value, returning just the number. (or the original value if an invalid string was passed)
  *
  * @example
@@ -107,79 +99,53 @@
  * }
  */
 
-  function stripUnit(value) {
-    const unitlessValue = parseFloat(value)
-    if (isNaN(unitlessValue)) return value
-    return unitlessValue
-  }
+function stripUnit(value) {
+  var unitlessValue = parseFloat(value);
+  if (isNaN(unitlessValue)) return value;
+  return unitlessValue;
+}
 
-  //
+//      
 
-  /**
+/**
  * Factory function that creates pixel-to-x converters
  * @private
  */
-  const pxtoFactory$1 = function pxtoFactory$1(to) {
-    return function(pxval) {
-      const base = arguments.length > 1 && arguments[1] !== undefined
-        ? arguments[1]
-        : '16px'
+var pxtoFactory$1 = function pxtoFactory$1(to) {
+  return function (pxval) {
+    var base = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '16px';
 
-      let newPxval = pxval
-      let newBase = base
-      if (typeof pxval === 'string') {
-        if (!endsWith(pxval, 'px')) {
-          throw new Error(
-            `Expected a string ending in "px" or a number passed as the first argument to ${
-              to
-              }(), got "${
-              pxval
-              }" instead.`,
-          )
-        }
-        newPxval = stripUnit(pxval)
+    var newPxval = pxval;
+    var newBase = base;
+    if (typeof pxval === 'string') {
+      if (!endsWith(pxval, 'px')) {
+        throw new Error('Expected a string ending in "px" or a number passed as the first argument to ' + to + '(), got "' + pxval + '" instead.');
       }
-
-      if (typeof base === 'string') {
-        if (!endsWith(base, 'px')) {
-          throw new Error(
-            `Expected a string ending in "px" or a number passed as the second argument to ${
-              to
-              }(), got "${
-              base
-              }" instead.`,
-          )
-        }
-        newBase = stripUnit(base)
-      }
-
-      if (typeof newPxval === 'string') {
-        throw new Error(
-          `Passed invalid pixel value ("${
-            pxval
-            }") to ${
-            to
-            }(), please pass a value like "12px" or 12.`,
-        )
-      }
-
-      if (typeof newBase === 'string') {
-        throw new Error(
-          `Passed invalid base value ("${
-            base
-            }") to ${
-            to
-            }(), please pass a value like "12px" or 12.`,
-        )
-      }
-
-      return `${newPxval / newBase}${to}`
+      newPxval = stripUnit(pxval);
     }
-  }
 
-  //
+    if (typeof base === 'string') {
+      if (!endsWith(base, 'px')) {
+        throw new Error('Expected a string ending in "px" or a number passed as the second argument to ' + to + '(), got "' + base + '" instead.');
+      }
+      newBase = stripUnit(base);
+    }
 
-  /**
+    if (typeof newPxval === 'string') {
+      throw new Error('Passed invalid pixel value ("' + pxval + '") to ' + to + '(), please pass a value like "12px" or 12.');
+    }
+
+    if (typeof newBase === 'string') {
+      throw new Error('Passed invalid base value ("' + base + '") to ' + to + '(), please pass a value like "12px" or 12.');
+    }
+
+    return '' + newPxval / newBase + to;
+  };
+};
+
+//      
+
+/**
  * Convert pixel value to ems. The default base value is 16px, but can be changed by passing a
  * second argument to the function.
  * @function
@@ -203,89 +169,76 @@
  * }
  */
 
-  const em = pxtoFactory$1('em')
+var em = pxtoFactory$1('em');
 
-  //
+//      
 
-  const ratioNames = {
-    minorSecond: 1.067,
-    majorSecond: 1.125,
-    minorThird: 1.2,
-    majorThird: 1.25,
-    perfectFourth: 1.333,
-    augFourth: 1.414,
-    perfectFifth: 1.5,
-    minorSixth: 1.6,
-    goldenSection: 1.618,
-    majorSixth: 1.667,
-    minorSeventh: 1.778,
-    majorSeventh: 1.875,
-    octave: 2,
-    majorTenth: 2.5,
-    majorEleventh: 2.667,
-    majorTwelfth: 3,
-    doubleOctave: 4,
-  }
+var ratioNames = {
+  minorSecond: 1.067,
+  majorSecond: 1.125,
+  minorThird: 1.2,
+  majorThird: 1.25,
+  perfectFourth: 1.333,
+  augFourth: 1.414,
+  perfectFifth: 1.5,
+  minorSixth: 1.6,
+  goldenSection: 1.618,
+  majorSixth: 1.667,
+  minorSeventh: 1.778,
+  majorSeventh: 1.875,
+  octave: 2,
+  majorTenth: 2.5,
+  majorEleventh: 2.667,
+  majorTwelfth: 3,
+  doubleOctave: 4
 
   /** */
 
   /**
- * Establish consistent measurements and spacial relationships throughout your projects by incrementing up or down a defined scale. We provide a list of commonly used scales as pre-defined variables, see below.
- * @example
- * // Styles as object usage
- * const styles = {
- *    // Increment two steps up the default scale
- *   'font-size': modularScale(2)
- * }
- *
- * // styled-components usage
- * const div = styled.div`
- *    // Increment two steps up the default scale
- *   font-size: ${modularScale(2)}
- * `
- *
- * // CSS in JS Output
- *
- * element {
- *   'font-size': '1.77689em'
- * }
- */
-  function modularScale(steps) {
-    const base = arguments.length > 1 && arguments[1] !== undefined
-      ? arguments[1]
-      : '1em'
-    const ratio = arguments.length > 2 && arguments[2] !== undefined
-      ? arguments[2]
-      : 'perfectFourth'
+   * Establish consistent measurements and spacial relationships throughout your projects by incrementing up or down a defined scale. We provide a list of commonly used scales as pre-defined variables, see below.
+   * @example
+   * // Styles as object usage
+   * const styles = {
+   *    // Increment two steps up the default scale
+   *   'font-size': modularScale(2)
+   * }
+   *
+   * // styled-components usage
+   * const div = styled.div`
+   *    // Increment two steps up the default scale
+   *   font-size: ${modularScale(2)}
+   * `
+   *
+   * // CSS in JS Output
+   *
+   * element {
+   *   'font-size': '1.77689em'
+   * }
+   */
+};function modularScale(steps) {
+  var base = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '1em';
+  var ratio = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 'perfectFourth';
 
-    if (typeof steps !== 'number') {
-      throw new Error(
-        'Please provide a number of steps to the modularScale helper.',
-      )
-    }
-    if (typeof ratio === 'string' && !ratioNames[ratio]) {
-      throw new Error(
-        'Please pass a number or one of the predefined scales to the modularScale helper as the ratio.',
-      )
-    }
-
-    const realBase = typeof base === 'string' ? stripUnit(base) : base
-    const realRatio = typeof ratio === 'string' ? ratioNames[ratio] : ratio
-
-    if (typeof realBase === 'string') {
-      throw new Error(
-        `Invalid value passed as base to modularScale, expected number or em string but got "${
-          base
-          }"`,
-      )
-    }
-
-    return `${realBase * Math.pow(realRatio, steps)}em`
+  if (typeof steps !== 'number') {
+    throw new Error('Please provide a number of steps to the modularScale helper.');
+  }
+  if (typeof ratio === 'string' && !ratioNames[ratio]) {
+    throw new Error('Please pass a number or one of the predefined scales to the modularScale helper as the ratio.');
   }
 
-  //
+  var realBase = typeof base === 'string' ? stripUnit(base) : base;
+  var realRatio = typeof ratio === 'string' ? ratioNames[ratio] : ratio;
 
-  /**
+  if (typeof realBase === 'string') {
+    throw new Error('Invalid value passed as base to modularScale, expected number or em string but got "' + base + '"');
+  }
+
+  return realBase * Math.pow(realRatio, steps) + 'em';
+}
+
+//      
+
+/**
  * Convert pixel value to rems. The default base value is 16px, but can be changed by passing a
  * second argument to the function.
  * @function
@@ -308,113 +261,139 @@
  *   'height': '1rem'
  * }
  */
-  const rem = pxtoFactory$1('rem')
+var rem = pxtoFactory$1('rem');
 
-  const _typeof = typeof Symbol === 'function' &&
-    typeof Symbol.iterator === 'symbol'
-    ? function(obj) {
-      return typeof obj
-    }
-    : function(obj) {
-      return obj &&
-          typeof Symbol === 'function' &&
-          obj.constructor === Symbol &&
-          obj !== Symbol.prototype
-          ? 'symbol'
-          : typeof obj
-    }
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) {
+  return typeof obj;
+} : function (obj) {
+  return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
+};
 
-  const defineProperty = function(obj, key, value) {
-    if (key in obj) {
-      Object.defineProperty(obj, key, {
-        value,
-        enumerable: true,
-        configurable: true,
-        writable: true,
-      })
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+var defineProperty = function (obj, key, value) {
+  if (key in obj) {
+    Object.defineProperty(obj, key, {
+      value: value,
+      enumerable: true,
+      configurable: true,
+      writable: true
+    });
+  } else {
+    obj[key] = value;
+  }
+
+  return obj;
+};
+
+var _extends = Object.assign || function (target) {
+  for (var i = 1; i < arguments.length; i++) {
+    var source = arguments[i];
+
+    for (var key in source) {
+      if (Object.prototype.hasOwnProperty.call(source, key)) {
+        target[key] = source[key];
+      }
+    }
+  }
+
+  return target;
+};
+
+var get = function get(object, property, receiver) {
+  if (object === null) object = Function.prototype;
+  var desc = Object.getOwnPropertyDescriptor(object, property);
+
+  if (desc === undefined) {
+    var parent = Object.getPrototypeOf(object);
+
+    if (parent === null) {
+      return undefined;
     } else {
-      obj[key] = value
+      return get(parent, property, receiver);
+    }
+  } else if ("value" in desc) {
+    return desc.value;
+  } else {
+    var getter = desc.get;
+
+    if (getter === undefined) {
+      return undefined;
     }
 
-    return obj
+    return getter.call(receiver);
   }
+};
 
-  const _extends =
-    Object.assign ||
-    function(target) {
-      for (let i = 1; i < arguments.length; i++) {
-        const source = arguments[i]
 
-        for (const key in source) {
-          if (Object.prototype.hasOwnProperty.call(source, key)) {
-            target[key] = source[key]
-          }
-        }
-      }
 
-      return target
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+var set = function set(object, property, value, receiver) {
+  var desc = Object.getOwnPropertyDescriptor(object, property);
+
+  if (desc === undefined) {
+    var parent = Object.getPrototypeOf(object);
+
+    if (parent !== null) {
+      set(parent, property, value, receiver);
     }
+  } else if ("value" in desc && desc.writable) {
+    desc.value = value;
+  } else {
+    var setter = desc.set;
 
-  const get = function get(object, property, receiver) {
-    if (object === null) object = Function.prototype
-    const desc = Object.getOwnPropertyDescriptor(object, property)
-
-    if (desc === undefined) {
-      const parent = Object.getPrototypeOf(object)
-
-      if (parent === null) {
-        return undefined
-      } else {
-        return get(parent, property, receiver)
-      }
-    } else if ('value' in desc) {
-      return desc.value
-    } else {
-      const getter = desc.get
-
-      if (getter === undefined) {
-        return undefined
-      }
-
-      return getter.call(receiver)
+    if (setter !== undefined) {
+      setter.call(receiver, value);
     }
   }
 
-  const set = function set(object, property, value, receiver) {
-    const desc = Object.getOwnPropertyDescriptor(object, property)
+  return value;
+};
 
-    if (desc === undefined) {
-      const parent = Object.getPrototypeOf(object)
 
-      if (parent !== null) {
-        set(parent, property, value, receiver)
-      }
-    } else if ('value' in desc && desc.writable) {
-      desc.value = value
-    } else {
-      const setter = desc.set
 
-      if (setter !== undefined) {
-        setter.call(receiver, value)
-      }
+
+
+var taggedTemplateLiteral = function (strings, raw) {
+  return Object.freeze(Object.defineProperties(strings, {
+    raw: {
+      value: Object.freeze(raw)
     }
+  }));
+};
 
-    return value
-  }
+//      
 
-  const taggedTemplateLiteral = function(strings, raw) {
-    return Object.freeze(
-      Object.defineProperties(strings, {
-        raw: {
-          value: Object.freeze(raw),
-        },
-      }),
-    )
-  }
-
-  //
-
-  /**
+/**
  * CSS to contain a float (credit to CSSMojo).
  *
  * @example
@@ -437,22 +416,20 @@
  * }
  */
 
-  function clearFix() {
-    const parent = arguments.length > 0 && arguments[0] !== undefined
-      ? arguments[0]
-      : '&'
+function clearFix() {
+  var parent = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '&';
 
-    const pseudoSelector = `${parent}::after`
-    return defineProperty({}, pseudoSelector, {
-      clear: 'both',
-      content: '""',
-      display: 'table',
-    })
-  }
+  var pseudoSelector = parent + '::after';
+  return defineProperty({}, pseudoSelector, {
+    clear: 'both',
+    content: '""',
+    display: 'table'
+  });
+}
 
-  //
+//      
 
-  /**
+/**
  * CSS to represent truncated text with an ellipsis.
  *
  * @example
@@ -478,45 +455,47 @@
  * }
  */
 
-  function ellipsis() {
-    const width = arguments.length > 0 && arguments[0] !== undefined
-      ? arguments[0]
-      : '100%'
+function ellipsis() {
+  var width = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '100%';
 
-    return {
-      display: 'inline-block',
-      'max-width': width,
-      overflow: 'hidden',
-      'text-overflow': 'ellipsis',
-      'white-space': 'nowrap',
-      'word-wrap': 'normal',
-    }
+  return {
+    display: 'inline-block',
+    'max-width': width,
+    overflow: 'hidden',
+    'text-overflow': 'ellipsis',
+    'white-space': 'nowrap',
+    'word-wrap': 'normal'
+  };
+}
+
+//      
+
+/** */
+
+function generateFileReferences(fontFilePath, fileFormats) {
+  var fileFontReferences = fileFormats.map(function (format) {
+    return 'url("' + fontFilePath + '.' + format + '")';
+  });
+  return fileFontReferences.join(', ');
+}
+
+function generateLocalReferences(localFonts) {
+  var localFontReferences = localFonts.map(function (font) {
+    return 'local("' + font + '")';
+  });
+  return localFontReferences.join(', ');
+}
+
+function generateSources(fontFilePath, localFonts, fileFormats) {
+  var fontReferences = [];
+  if (localFonts) fontReferences.push(generateLocalReferences(localFonts));
+  if (fontFilePath) {
+    fontReferences.push(generateFileReferences(fontFilePath, fileFormats));
   }
+  return fontReferences.join(', ');
+}
 
-  //
-
-  /** */
-
-  function generateFileReferences(fontFilePath, fileFormats) {
-    const fileFontReferences = fileFormats.map((format) => `url("${fontFilePath}.${format}")`)
-    return fileFontReferences.join(', ')
-  }
-
-  function generateLocalReferences(localFonts) {
-    const localFontReferences = localFonts.map((font) => `local("${font}")`)
-    return localFontReferences.join(', ')
-  }
-
-  function generateSources(fontFilePath, localFonts, fileFormats) {
-    const fontReferences = []
-    if (localFonts) fontReferences.push(generateLocalReferences(localFonts))
-    if (fontFilePath) {
-      fontReferences.push(generateFileReferences(fontFilePath, fileFormats))
-    }
-    return fontReferences.join(', ')
-  }
-
-  /**
+/**
  * CSS for a @font-face declaration.
  *
  * @example
@@ -544,53 +523,48 @@
  * }
  */
 
-  function fontFace(_ref) {
-    let fontFamily = _ref.fontFamily,
+function fontFace(_ref) {
+  var fontFamily = _ref.fontFamily,
       fontFilePath = _ref.fontFilePath,
       fontStretch = _ref.fontStretch,
       fontStyle = _ref.fontStyle,
       fontVariant = _ref.fontVariant,
       fontWeight = _ref.fontWeight,
       _ref$fileFormats = _ref.fileFormats,
-      fileFormats = _ref$fileFormats === undefined
-        ? ['eot', 'woff2', 'woff', 'ttf', 'svg']
-        : _ref$fileFormats,
+      fileFormats = _ref$fileFormats === undefined ? ['eot', 'woff2', 'woff', 'ttf', 'svg'] : _ref$fileFormats,
       localFonts = _ref.localFonts,
-      unicodeRange = _ref.unicodeRange
+      unicodeRange = _ref.unicodeRange;
 
-    // Error Handling
-    if (!fontFamily) { throw new Error('fontFace expects a name of a font-family.') }
-    if (!fontFilePath && !localFonts) {
-      throw new Error(
-        'fontFace expects either the path to the font file(s) or a name of a local copy.',
-      )
-    }
-    if (localFonts && !Array.isArray(localFonts)) {
-      throw new Error('fontFace expects localFonts to be an array.')
-    }
-    if (!Array.isArray(fileFormats)) {
-      throw new Error('fontFace expects fileFormats to be an array.')
-    }
+  // Error Handling
+  if (!fontFamily) throw new Error('fontFace expects a name of a font-family.');
+  if (!fontFilePath && !localFonts) {
+    throw new Error('fontFace expects either the path to the font file(s) or a name of a local copy.');
+  }
+  if (localFonts && !Array.isArray(localFonts)) {
+    throw new Error('fontFace expects localFonts to be an array.');
+  }
+  if (!Array.isArray(fileFormats)) {
+    throw new Error('fontFace expects fileFormats to be an array.');
+  }
 
-    const fontFaceDeclaration = {
-      '@font-face': {
-        'font-family': fontFamily,
-        src: generateSources(fontFilePath, localFonts, fileFormats),
-        'unicode-range': unicodeRange,
-        'font-stretch': fontStretch,
-        'font-style': fontStyle,
-        'font-variant': fontVariant,
-        'font-weight': fontWeight,
-      },
+  var fontFaceDeclaration = {
+    '@font-face': {
+      'font-family': fontFamily,
+      src: generateSources(fontFilePath, localFonts, fileFormats),
+      'unicode-range': unicodeRange,
+      'font-stretch': fontStretch,
+      'font-style': fontStyle,
+      'font-variant': fontVariant,
+      'font-weight': fontWeight
     }
 
     // Removes undefined fields for cleaner css object.
-    return JSON.parse(JSON.stringify(fontFaceDeclaration))
-  }
+  };return JSON.parse(JSON.stringify(fontFaceDeclaration));
+}
 
-  //
+//      
 
-  /**
+/**
  * CSS to hide text to show a background image in a SEO-friendly way.
  *
  * @example
@@ -616,17 +590,17 @@
  * }
  */
 
-  function hideText() {
-    return {
-      'text-indent': '101%',
-      overflow: 'hidden',
-      'white-space': 'nowrap',
-    }
-  }
+function hideText() {
+  return {
+    'text-indent': '101%',
+    overflow: 'hidden',
+    'white-space': 'nowrap'
+  };
+}
 
-  //
+//      
 
-  /**
+/**
  * Generates a media query to target HiDPI devices.
  *
  * @example
@@ -655,215 +629,159 @@
  * }
  */
 
-  function hiDPI() {
-    const ratio = arguments.length > 0 && arguments[0] !== undefined
-      ? arguments[0]
-      : 1.3
+function hiDPI() {
+  var ratio = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 1.3;
 
-    return (
-      `\n    @media only screen and (-webkit-min-device-pixel-ratio: ${
-      ratio
-      }),\n    only screen and (min--moz-device-pixel-ratio: ${
-      ratio
-      }),\n    only screen and (-o-min-device-pixel-ratio: ${
-      ratio
-      }/1),\n    only screen and (min-resolution: ${
-      Math.round(ratio * 96)
-      }dpi),\n    only screen and (min-resolution: ${
-      ratio
-      }dppx)\n  `
-    )
+  return "\n    @media only screen and (-webkit-min-device-pixel-ratio: " + ratio + "),\n    only screen and (min--moz-device-pixel-ratio: " + ratio + "),\n    only screen and (-o-min-device-pixel-ratio: " + ratio + "/1),\n    only screen and (min-resolution: " + Math.round(ratio * 96) + "dpi),\n    only screen and (min-resolution: " + ratio + "dppx)\n  ";
+}
+
+var _opinionatedRules;
+var _unopinionatedRules;
+
+//      
+var opinionatedRules = (_opinionatedRules = {
+  html: {
+    'font-family': 'sans-serif'
+  },
+
+  body: {
+    margin: '0'
   }
 
-  let _opinionatedRules
-  let _unopinionatedRules
+}, defineProperty(_opinionatedRules, 'a:active,\n  a:hover', {
+  'outline-width': '0'
+}), defineProperty(_opinionatedRules, 'button,\n  input,\n  optgroup,\n  select,\n  textarea', {
+  'font-family': 'sans-serif',
+  'font-size': '100%',
+  'line-height': '1.15'
+}), _opinionatedRules);
 
-  //
-  const opinionatedRules = ((_opinionatedRules = {
-    html: {
-      'font-family': 'sans-serif',
-    },
-
-    body: {
-      margin: '0',
-    },
-  }), defineProperty(_opinionatedRules, 'a:active,\n  a:hover', {
-    'outline-width': '0',
-  }), defineProperty(
-    _opinionatedRules,
-    'button,\n  input,\n  optgroup,\n  select,\n  textarea',
-    {
-      'font-family': 'sans-serif',
-      'font-size': '100%',
-      'line-height': '1.15',
-    },
-  ), _opinionatedRules)
-
-  const unopinionatedRules = ((_unopinionatedRules = {
-    html: {
-      'line-height': '1.15',
-      '-ms-text-size-adjust': '100%',
-      '-webkit-text-size-adjust': '100%',
-    },
-  }), defineProperty(
-    _unopinionatedRules,
-    'article,\n  aside,\n  footer,\n  header,\n  nav,\n  section',
-    {
-      display: 'block',
-    },
-  ), defineProperty(_unopinionatedRules, 'h1', {
-    'font-size': '2em',
-    margin: '0.67em 0',
-  }), defineProperty(_unopinionatedRules, 'figcaption,\n  figure,\n  main', {
-    display: 'block',
-  }), defineProperty(_unopinionatedRules, 'figure', {
-    margin: '1em 40px',
-  }), defineProperty(_unopinionatedRules, 'hr', {
-    'box-sizing': 'content-box',
-    height: '0',
-    overflow: 'visible',
-  }), defineProperty(_unopinionatedRules, 'pre', {
-    'font-family': 'monospace, monospace',
-    'font-size': '1em',
-  }), defineProperty(_unopinionatedRules, 'a', {
-    'background-color': 'transparent',
-    '-webkit-text-decoration-skip': 'objects',
-  }), defineProperty(
-    _unopinionatedRules,
-    'abbr[title]',
-    defineProperty(
-      {
-        'border-bottom': 'none',
-        'text-decoration': 'underline',
-      },
-      'text-decoration',
-      'underline dotted',
-    ),
-  ), defineProperty(_unopinionatedRules, 'b,\n  strong', {
-    'font-weight': 'inherit',
-  }), defineProperty(_unopinionatedRules, 'code,\n  kbd,\n  samp', {
-    'font-family': 'monospace, monospace',
-    'font-size': '1em',
-  }), defineProperty(_unopinionatedRules, 'dfn', {
-    'font-style': 'italic',
-  }), defineProperty(_unopinionatedRules, 'mark', {
-    'background-color': '#ff0',
-    color: '#000',
-  }), defineProperty(_unopinionatedRules, 'small', {
-    'font-size': '80%',
-  }), defineProperty(_unopinionatedRules, 'sub,\n  sup', {
-    'font-size': '75%',
-    'line-height': '0',
-    position: 'relative',
-    'vertical-align': 'baseline',
-  }), defineProperty(_unopinionatedRules, 'sub', {
-    bottom: '-0.25em',
-  }), defineProperty(_unopinionatedRules, 'sup', {
-    top: '-0.5em',
-  }), defineProperty(_unopinionatedRules, 'audio,\n  video', {
-    display: 'inline-block',
-  }), defineProperty(_unopinionatedRules, 'audio:not([controls])', {
-    display: 'none',
-    height: '0',
-  }), defineProperty(_unopinionatedRules, 'img', {
-    'border-style': 'none',
-  }), defineProperty(_unopinionatedRules, 'svg:not(:root)', {
-    overflow: 'hidden',
-  }), defineProperty(
-    _unopinionatedRules,
-    'button,\n  input,\n  optgroup,\n  select,\n  textarea',
-    {
-      margin: '0',
-    },
-  ), defineProperty(_unopinionatedRules, 'button,\n  input', {
-    overflow: 'visible',
-  }), defineProperty(_unopinionatedRules, 'button,\n  select', {
-    'text-transform': 'none',
-  }), defineProperty(
-    _unopinionatedRules,
-    'button,\n  html [type="button"],\n  [type="reset"],\n  [type="submit"]',
-    {
-      '-webkit-appearance': 'button',
-    },
-  ), defineProperty(
-    _unopinionatedRules,
-    'button::-moz-focus-inner,\n  [type="button"]::-moz-focus-inner,\n  [type="reset"]::-moz-focus-inner,\n  [type="submit"]::-moz-focus-inner',
-    {
-      'border-style': 'none',
-      padding: '0',
-    },
-  ), defineProperty(
-    _unopinionatedRules,
-    'button:-moz-focusring,\n  [type="button"]:-moz-focusring,\n  [type="reset"]:-moz-focusring,\n  [type="submit"]:-moz-focusring',
-    {
-      outline: '1px dotted ButtonText',
-    },
-  ), defineProperty(_unopinionatedRules, 'fieldset', {
-    border: '1px solid #c0c0c0',
-    margin: '0 2px',
-    padding: '0.35em 0.625em 0.75em',
-  }), defineProperty(_unopinionatedRules, 'legend', {
-    'box-sizing': 'border-box',
-    color: 'inherit',
-    display: 'table',
-    'max-width': '100%',
-    padding: '0',
-    'white-space': 'normal',
-  }), defineProperty(_unopinionatedRules, 'progress', {
-    display: 'inline-block',
-    'vertical-align': 'baseline',
-  }), defineProperty(_unopinionatedRules, 'textarea', {
-    overflow: 'auto',
-  }), defineProperty(
-    _unopinionatedRules,
-    '[type="checkbox"],\n  [type="radio"]',
-    {
-      'box-sizing': 'border-box',
-      padding: '0',
-    },
-  ), defineProperty(
-    _unopinionatedRules,
-    '[type="number"]::-webkit-inner-spin-button,\n  [type="number"]::-webkit-outer-spin-button',
-    {
-      height: 'auto',
-    },
-  ), defineProperty(_unopinionatedRules, '[type="search"]', {
-    '-webkit-appearance': 'textfield',
-    'outline-offset': '-2px',
-  }), defineProperty(
-    _unopinionatedRules,
-    '[type="search"]::-webkit-search-cancel-button,\n  [type="search"]::-webkit-search-decoration',
-    {
-      '-webkit-appearance': 'none',
-    },
-  ), defineProperty(_unopinionatedRules, '::-webkit-file-upload-button', {
-    '-webkit-appearance': 'button',
-    font: 'inherit',
-  }), defineProperty(_unopinionatedRules, 'details,\n  menu', {
-    display: 'block',
-  }), defineProperty(_unopinionatedRules, 'summary', {
-    display: 'list-item',
-  }), defineProperty(_unopinionatedRules, 'canvas', {
-    display: 'inline-block',
-  }), defineProperty(_unopinionatedRules, 'template', {
-    display: 'none',
-  }), defineProperty(_unopinionatedRules, '[hidden]', {
-    display: 'none',
-  }), _unopinionatedRules)
-
-  function mergeRules(baseRules, additionalRules) {
-    const mergedRules = _extends({}, baseRules)
-    Object.keys(additionalRules).forEach((key) => {
-      if (mergedRules[key]) {
-        mergedRules[key] = _extends({}, mergedRules[key], additionalRules[key])
-      } else {
-        mergedRules[key] = _extends({}, additionalRules[key])
-      }
-    })
-    return mergedRules
+var unopinionatedRules = (_unopinionatedRules = {
+  html: {
+    'line-height': '1.15',
+    '-ms-text-size-adjust': '100%',
+    '-webkit-text-size-adjust': '100%'
   }
 
-  /**
+}, defineProperty(_unopinionatedRules, 'article,\n  aside,\n  footer,\n  header,\n  nav,\n  section', {
+  display: 'block'
+}), defineProperty(_unopinionatedRules, 'h1', {
+  'font-size': '2em',
+  margin: '0.67em 0'
+}), defineProperty(_unopinionatedRules, 'figcaption,\n  figure,\n  main', {
+  display: 'block'
+}), defineProperty(_unopinionatedRules, 'figure', {
+  margin: '1em 40px'
+}), defineProperty(_unopinionatedRules, 'hr', {
+  'box-sizing': 'content-box',
+  height: '0',
+  overflow: 'visible'
+}), defineProperty(_unopinionatedRules, 'pre', {
+  'font-family': 'monospace, monospace',
+  'font-size': '1em'
+}), defineProperty(_unopinionatedRules, 'a', {
+  'background-color': 'transparent',
+  '-webkit-text-decoration-skip': 'objects'
+}), defineProperty(_unopinionatedRules, 'abbr[title]', defineProperty({
+  'border-bottom': 'none',
+  'text-decoration': 'underline'
+}, 'text-decoration', 'underline dotted')), defineProperty(_unopinionatedRules, 'b,\n  strong', {
+  'font-weight': 'inherit'
+}), defineProperty(_unopinionatedRules, 'code,\n  kbd,\n  samp', {
+  'font-family': 'monospace, monospace',
+  'font-size': '1em'
+}), defineProperty(_unopinionatedRules, 'dfn', {
+  'font-style': 'italic'
+}), defineProperty(_unopinionatedRules, 'mark', {
+  'background-color': '#ff0',
+  color: '#000'
+}), defineProperty(_unopinionatedRules, 'small', {
+  'font-size': '80%'
+}), defineProperty(_unopinionatedRules, 'sub,\n  sup', {
+  'font-size': '75%',
+  'line-height': '0',
+  position: 'relative',
+  'vertical-align': 'baseline'
+}), defineProperty(_unopinionatedRules, 'sub', {
+  bottom: '-0.25em'
+}), defineProperty(_unopinionatedRules, 'sup', {
+  top: '-0.5em'
+}), defineProperty(_unopinionatedRules, 'audio,\n  video', {
+  display: 'inline-block'
+}), defineProperty(_unopinionatedRules, 'audio:not([controls])', {
+  display: 'none',
+  height: '0'
+}), defineProperty(_unopinionatedRules, 'img', {
+  'border-style': 'none'
+}), defineProperty(_unopinionatedRules, 'svg:not(:root)', {
+  overflow: 'hidden'
+}), defineProperty(_unopinionatedRules, 'button,\n  input,\n  optgroup,\n  select,\n  textarea', {
+  margin: '0'
+}), defineProperty(_unopinionatedRules, 'button,\n  input', {
+  overflow: 'visible'
+}), defineProperty(_unopinionatedRules, 'button,\n  select', {
+  'text-transform': 'none'
+}), defineProperty(_unopinionatedRules, 'button,\n  html [type="button"],\n  [type="reset"],\n  [type="submit"]', {
+  '-webkit-appearance': 'button'
+}), defineProperty(_unopinionatedRules, 'button::-moz-focus-inner,\n  [type="button"]::-moz-focus-inner,\n  [type="reset"]::-moz-focus-inner,\n  [type="submit"]::-moz-focus-inner', {
+  'border-style': 'none',
+  padding: '0'
+}), defineProperty(_unopinionatedRules, 'button:-moz-focusring,\n  [type="button"]:-moz-focusring,\n  [type="reset"]:-moz-focusring,\n  [type="submit"]:-moz-focusring', {
+  outline: '1px dotted ButtonText'
+}), defineProperty(_unopinionatedRules, 'fieldset', {
+  border: '1px solid #c0c0c0',
+  margin: '0 2px',
+  padding: '0.35em 0.625em 0.75em'
+}), defineProperty(_unopinionatedRules, 'legend', {
+  'box-sizing': 'border-box',
+  color: 'inherit',
+  display: 'table',
+  'max-width': '100%',
+  padding: '0',
+  'white-space': 'normal'
+}), defineProperty(_unopinionatedRules, 'progress', {
+  display: 'inline-block',
+  'vertical-align': 'baseline'
+}), defineProperty(_unopinionatedRules, 'textarea', {
+  overflow: 'auto'
+}), defineProperty(_unopinionatedRules, '[type="checkbox"],\n  [type="radio"]', {
+  'box-sizing': 'border-box',
+  padding: '0'
+}), defineProperty(_unopinionatedRules, '[type="number"]::-webkit-inner-spin-button,\n  [type="number"]::-webkit-outer-spin-button', {
+  height: 'auto'
+}), defineProperty(_unopinionatedRules, '[type="search"]', {
+  '-webkit-appearance': 'textfield',
+  'outline-offset': '-2px'
+}), defineProperty(_unopinionatedRules, '[type="search"]::-webkit-search-cancel-button,\n  [type="search"]::-webkit-search-decoration', {
+  '-webkit-appearance': 'none'
+}), defineProperty(_unopinionatedRules, '::-webkit-file-upload-button', {
+  '-webkit-appearance': 'button',
+  font: 'inherit'
+}), defineProperty(_unopinionatedRules, 'details,\n  menu', {
+  display: 'block'
+}), defineProperty(_unopinionatedRules, 'summary', {
+  display: 'list-item'
+}), defineProperty(_unopinionatedRules, 'canvas', {
+  display: 'inline-block'
+}), defineProperty(_unopinionatedRules, 'template', {
+  display: 'none'
+}), defineProperty(_unopinionatedRules, '[hidden]', {
+  display: 'none'
+}), _unopinionatedRules);
+
+function mergeRules(baseRules, additionalRules) {
+  var mergedRules = _extends({}, baseRules);
+  Object.keys(additionalRules).forEach(function (key) {
+    if (mergedRules[key]) {
+      mergedRules[key] = _extends({}, mergedRules[key], additionalRules[key]);
+    } else {
+      mergedRules[key] = _extends({}, additionalRules[key]);
+    }
+  });
+  return mergedRules;
+}
+
+/**
  * CSS to normalize abnormalities across browsers (normalize.css v5.0.0 | MIT License | github.com/necolas/normalize.css)
  *
  * @example
@@ -885,14 +803,14 @@
  * } ...
  */
 
-  function normalize(excludeOpinionated) {
-    if (excludeOpinionated) return unopinionatedRules
-    return mergeRules(unopinionatedRules, opinionatedRules)
-  }
+function normalize(excludeOpinionated) {
+  if (excludeOpinionated) return unopinionatedRules;
+  return mergeRules(unopinionatedRules, opinionatedRules);
+}
 
-  //
+//      
 
-  /**
+/**
  * CSS to style the selection psuedo-element.
  *
  * @example
@@ -924,64 +842,44 @@
  * },
  */
 
-  function placeholder(styles) {
-    let _ref
+function placeholder(styles) {
+  var _ref;
 
-    const parent = arguments.length > 1 && arguments[1] !== undefined
-      ? arguments[1]
-      : '&'
+  var parent = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '&';
 
-    return (_ref = {}), defineProperty(_ref, `${parent}::-webkit-input-placeholder`, _extends({}, styles)), defineProperty(_ref, `${parent}:-moz-placeholder`, _extends({}, styles)), defineProperty(_ref, `${parent}::-moz-placeholder`, _extends({}, styles)), defineProperty(_ref, `${parent}:-ms-input-placeholder`, _extends({}, styles)), _ref
-  }
+  return _ref = {}, defineProperty(_ref, parent + '::-webkit-input-placeholder', _extends({}, styles)), defineProperty(_ref, parent + ':-moz-placeholder', _extends({}, styles)), defineProperty(_ref, parent + '::-moz-placeholder', _extends({}, styles)), defineProperty(_ref, parent + ':-ms-input-placeholder', _extends({}, styles)), _ref;
+}
 
-  const _templateObject = taggedTemplateLiteral(
-    ['radial-gradient(', '', '', '', ')'],
-    ['radial-gradient(', '', '', '', ')'],
-  )
+var _templateObject = taggedTemplateLiteral(['radial-gradient(', '', '', '', ')'], ['radial-gradient(', '', '', '', ')']);
 
-  //
+//      
 
-  /** */
+/** */
 
-  function parseFallback(colorStops) {
-    return colorStops[0].split(' ')[0]
-  }
+function parseFallback(colorStops) {
+  return colorStops[0].split(' ')[0];
+}
 
-  function constructGradientValue(literals) {
-    let template = ''
-    for (let i = 0; i < literals.length; i += 1) {
-      template += literals[i]
-      // Adds leading coma if properties preceed color-stops
-      if (
-        i === 3 &&
-        (arguments.length <= i + 1 ? undefined : arguments[i + 1]) &&
-        ((arguments.length <= 1 ? undefined : arguments[1]) ||
-          (arguments.length <= 2 ? undefined : arguments[2]) ||
-          (arguments.length <= 3 ? undefined : arguments[3]))
-      ) {
-        template = template.slice(0, -1)
-        template +=
-          `, ${arguments.length <= i + 1 ? undefined : arguments[i + 1]}`
-        // No trailing space if color-stops is the only param provided
-      } else if (
-        i === 3 &&
-        (arguments.length <= i + 1 ? undefined : arguments[i + 1]) &&
-        !(arguments.length <= 1 ? undefined : arguments[1]) &&
-        !(arguments.length <= 2 ? undefined : arguments[2]) &&
-        !(arguments.length <= 3 ? undefined : arguments[3])
-      ) {
-        template +=
-          `${arguments.length <= i + 1 ? undefined : arguments[i + 1]}`
-        // Only adds substitution if it is defined
-      } else if (arguments.length <= i + 1 ? undefined : arguments[i + 1]) {
-        template +=
-          `${arguments.length <= i + 1 ? undefined : arguments[i + 1]} `
-      }
+function constructGradientValue(literals) {
+  var template = '';
+  for (var i = 0; i < literals.length; i += 1) {
+    template += literals[i];
+    // Adds leading coma if properties preceed color-stops
+    if (i === 3 && (arguments.length <= i + 1 ? undefined : arguments[i + 1]) && ((arguments.length <= 1 ? undefined : arguments[1]) || (arguments.length <= 2 ? undefined : arguments[2]) || (arguments.length <= 3 ? undefined : arguments[3]))) {
+      template = template.slice(0, -1);
+      template += ', ' + (arguments.length <= i + 1 ? undefined : arguments[i + 1]);
+      // No trailing space if color-stops is the only param provided
+    } else if (i === 3 && (arguments.length <= i + 1 ? undefined : arguments[i + 1]) && !(arguments.length <= 1 ? undefined : arguments[1]) && !(arguments.length <= 2 ? undefined : arguments[2]) && !(arguments.length <= 3 ? undefined : arguments[3])) {
+      template += '' + (arguments.length <= i + 1 ? undefined : arguments[i + 1]);
+      // Only adds substitution if it is defined
+    } else if (arguments.length <= i + 1 ? undefined : arguments[i + 1]) {
+      template += (arguments.length <= i + 1 ? undefined : arguments[i + 1]) + ' ';
     }
-    return template.trim()
   }
+  return template.trim();
+}
 
-  /**
+/**
  * CSS for declaring a radial gradient, including a fallback background-color. The fallback is either the first color-stop or an explicitly passed fallback color.
  *
  * @example
@@ -1013,33 +911,25 @@
  * }
  */
 
-  function radialGradient(_ref) {
-    let colorStops = _ref.colorStops,
+function radialGradient(_ref) {
+  var colorStops = _ref.colorStops,
       extent = _ref.extent,
       fallback = _ref.fallback,
       position = _ref.position,
-      shape = _ref.shape
+      shape = _ref.shape;
 
-    if (!colorStops || colorStops.length < 2) {
-      throw new Error(
-        'radialGradient requries at least 2 color-stops to properly render.',
-      )
-    }
-    return {
-      'background-color': fallback || parseFallback(colorStops),
-      'background-image': constructGradientValue(
-        _templateObject,
-        position,
-        shape,
-        extent,
-        colorStops.join(', '),
-      ),
-    }
+  if (!colorStops || colorStops.length < 2) {
+    throw new Error('radialGradient requries at least 2 color-stops to properly render.');
   }
+  return {
+    'background-color': fallback || parseFallback(colorStops),
+    'background-image': constructGradientValue(_templateObject, position, shape, extent, colorStops.join(', '))
+  };
+}
 
-  //
+//      
 
-  /**
+/**
  * The retina-image mixin is a helper to generate a retina background image and non-retina
  * background image. The retina background image will output to a HiDPI media query. The mixin uses
  * a _2x.png filename suffix by default.
@@ -1067,41 +957,29 @@
  *   }
  * }
  */
-  function retinaImage(filename, backgroundSize) {
-    const extension = arguments.length > 2 && arguments[2] !== undefined
-      ? arguments[2]
-      : 'png'
-    const retinaFilename = arguments[3]
-    const retinaSuffix = arguments.length > 4 && arguments[4] !== undefined
-      ? arguments[4]
-      : '_2x'
+function retinaImage(filename, backgroundSize) {
+  var extension = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 'png';
+  var retinaFilename = arguments[3];
+  var retinaSuffix = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : '_2x';
 
-    if (!filename) {
-      throw new Error(
-        'Please supply a filename to retinaImage() as the first argument.',
-      )
-    }
-    // Replace the dot at the beginning of the passed extension if one exists
-    const ext = extension.replace(/^\./, '')
-    const rFilename = retinaFilename
-      ? `${retinaFilename}.${ext}`
-      : `${filename}${retinaSuffix}.${ext}`
-
-    return defineProperty(
-      {
-        backgroundImage: `url(${filename}.${ext})`,
-      },
-      hiDPI(),
-      {
-        backgroundImage: `url(${rFilename})`,
-        backgroundSize,
-      },
-    )
+  if (!filename) {
+    throw new Error('Please supply a filename to retinaImage() as the first argument.');
   }
+  // Replace the dot at the beginning of the passed extension if one exists
+  var ext = extension.replace(/^\./, '');
+  var rFilename = retinaFilename ? retinaFilename + '.' + ext : '' + filename + retinaSuffix + '.' + ext;
 
-  //
+  return defineProperty({
+    backgroundImage: 'url(' + filename + '.' + ext + ')'
+  }, hiDPI(), {
+    backgroundImage: 'url(' + rFilename + ')',
+    backgroundSize: backgroundSize
+  });
+}
 
-  /**
+//      
+
+/**
  * CSS to style the selection psuedo-element.
  *
  * @example
@@ -1129,176 +1007,154 @@
  * }
  */
 
-  function selection(styles) {
-    let _ref
+function selection(styles) {
+  var _ref;
 
-    const parent = arguments.length > 1 && arguments[1] !== undefined
-      ? arguments[1]
-      : ''
+  var parent = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '';
 
-    return (_ref = {}), defineProperty(_ref, `${parent}::-moz-selection`, _extends({}, styles)), defineProperty(_ref, `${parent}::selection`, _extends({}, styles)), _ref
-  }
+  return _ref = {}, defineProperty(_ref, parent + '::-moz-selection', _extends({}, styles)), defineProperty(_ref, parent + '::selection', _extends({}, styles)), _ref;
+}
 
-  //
+//      
 
-  /* eslint-disable key-spacing */
-  const functionsMap = {
-    easeInBack: 'cubic-bezier(0.600, -0.280, 0.735, 0.045)',
-    easeInCirc: 'cubic-bezier(0.600,  0.040, 0.980, 0.335)',
-    easeInCubic: 'cubic-bezier(0.550,  0.055, 0.675, 0.190)',
-    easeInExpo: 'cubic-bezier(0.950,  0.050, 0.795, 0.035)',
-    easeInQuad: 'cubic-bezier(0.550,  0.085, 0.680, 0.530)',
-    easeInQuart: 'cubic-bezier(0.895,  0.030, 0.685, 0.220)',
-    easeInQuint: 'cubic-bezier(0.755,  0.050, 0.855, 0.060)',
-    easeInSine: 'cubic-bezier(0.470,  0.000, 0.745, 0.715)',
+/* eslint-disable key-spacing */
+var functionsMap = {
+  easeInBack: 'cubic-bezier(0.600, -0.280, 0.735, 0.045)',
+  easeInCirc: 'cubic-bezier(0.600,  0.040, 0.980, 0.335)',
+  easeInCubic: 'cubic-bezier(0.550,  0.055, 0.675, 0.190)',
+  easeInExpo: 'cubic-bezier(0.950,  0.050, 0.795, 0.035)',
+  easeInQuad: 'cubic-bezier(0.550,  0.085, 0.680, 0.530)',
+  easeInQuart: 'cubic-bezier(0.895,  0.030, 0.685, 0.220)',
+  easeInQuint: 'cubic-bezier(0.755,  0.050, 0.855, 0.060)',
+  easeInSine: 'cubic-bezier(0.470,  0.000, 0.745, 0.715)',
 
-    easeOutBack: 'cubic-bezier(0.175,  0.885, 0.320, 1.275)',
-    easeOutCubic: 'cubic-bezier(0.215,  0.610, 0.355, 1.000)',
-    easeOutCirc: 'cubic-bezier(0.075,  0.820, 0.165, 1.000)',
-    easeOutExpo: 'cubic-bezier(0.190,  1.000, 0.220, 1.000)',
-    easeOutQuad: 'cubic-bezier(0.250,  0.460, 0.450, 0.940)',
-    easeOutQuart: 'cubic-bezier(0.165,  0.840, 0.440, 1.000)',
-    easeOutQuint: 'cubic-bezier(0.230,  1.000, 0.320, 1.000)',
-    easeOutSine: 'cubic-bezier(0.390,  0.575, 0.565, 1.000)',
+  easeOutBack: 'cubic-bezier(0.175,  0.885, 0.320, 1.275)',
+  easeOutCubic: 'cubic-bezier(0.215,  0.610, 0.355, 1.000)',
+  easeOutCirc: 'cubic-bezier(0.075,  0.820, 0.165, 1.000)',
+  easeOutExpo: 'cubic-bezier(0.190,  1.000, 0.220, 1.000)',
+  easeOutQuad: 'cubic-bezier(0.250,  0.460, 0.450, 0.940)',
+  easeOutQuart: 'cubic-bezier(0.165,  0.840, 0.440, 1.000)',
+  easeOutQuint: 'cubic-bezier(0.230,  1.000, 0.320, 1.000)',
+  easeOutSine: 'cubic-bezier(0.390,  0.575, 0.565, 1.000)',
 
-    easeInOutBack: 'cubic-bezier(0.680, -0.550, 0.265, 1.550)',
-    easeInOutCirc: 'cubic-bezier(0.785,  0.135, 0.150, 0.860)',
-    easeInOutCubic: 'cubic-bezier(0.645,  0.045, 0.355, 1.000)',
-    easeInOutExpo: 'cubic-bezier(1.000,  0.000, 0.000, 1.000)',
-    easeInOutQuad: 'cubic-bezier(0.455,  0.030, 0.515, 0.955)',
-    easeInOutQuart: 'cubic-bezier(0.770,  0.000, 0.175, 1.000)',
-    easeInOutQuint: 'cubic-bezier(0.860,  0.000, 0.070, 1.000)',
-    easeInOutSine: 'cubic-bezier(0.445,  0.050, 0.550, 0.950)',
-  }
+  easeInOutBack: 'cubic-bezier(0.680, -0.550, 0.265, 1.550)',
+  easeInOutCirc: 'cubic-bezier(0.785,  0.135, 0.150, 0.860)',
+  easeInOutCubic: 'cubic-bezier(0.645,  0.045, 0.355, 1.000)',
+  easeInOutExpo: 'cubic-bezier(1.000,  0.000, 0.000, 1.000)',
+  easeInOutQuad: 'cubic-bezier(0.455,  0.030, 0.515, 0.955)',
+  easeInOutQuart: 'cubic-bezier(0.770,  0.000, 0.175, 1.000)',
+  easeInOutQuint: 'cubic-bezier(0.860,  0.000, 0.070, 1.000)',
+  easeInOutSine: 'cubic-bezier(0.445,  0.050, 0.550, 0.950)'
   /* eslint-enable key-spacing */
 
   /** */
 
   /**
- * String to represent common easing functions as demonstrated here: (github.com/jaukia/easie).
- *
- * @example
- * // Styles as object usage
- * const styles = {
- *   'transition-timing-function': timingFunctions('easeInQuad')
- * }
- *
- * // styled-components usage
- *  const div = styled.div`
- *   transition-timing-function: ${timingFunctions('easeInQuad')};
- * `
- *
- * // CSS as JS Output
- *
- * 'div': {
- *   'transition-timing-function': 'cubic-bezier(0.550,  0.085, 0.680, 0.530)',
- * }
- */
+   * String to represent common easing functions as demonstrated here: (github.com/jaukia/easie).
+   *
+   * @example
+   * // Styles as object usage
+   * const styles = {
+   *   'transition-timing-function': timingFunctions('easeInQuad')
+   * }
+   *
+   * // styled-components usage
+   *  const div = styled.div`
+   *   transition-timing-function: ${timingFunctions('easeInQuad')};
+   * `
+   *
+   * // CSS as JS Output
+   *
+   * 'div': {
+   *   'transition-timing-function': 'cubic-bezier(0.550,  0.085, 0.680, 0.530)',
+   * }
+   */
 
-  function timingFunctions(timingFunction) {
-    return functionsMap[timingFunction]
+};function timingFunctions(timingFunction) {
+  return functionsMap[timingFunction];
+}
+
+//      
+
+/** */
+
+var getBorderWidth = function getBorderWidth(pointingDirection, height, width) {
+  switch (pointingDirection) {
+    case 'top':
+      return '0 ' + width / 2 + 'px ' + height + 'px ' + width / 2 + 'px';
+    case 'left':
+      return height / 2 + 'px ' + width + 'px ' + height / 2 + 'px 0';
+    case 'bottom':
+      return height + 'px ' + width / 2 + 'px 0 ' + width / 2 + 'px';
+    case 'right':
+      return height / 2 + 'px 0 ' + height / 2 + 'px ' + width + 'px';
+
+    default:
+      throw new Error("Passed invalid argument to triangle, please pass correct poitingDirection e.g. 'right'.");
   }
+};
 
-  //
-
-  /** */
-
-  const getBorderWidth = function getBorderWidth(
-    pointingDirection,
-    height,
-    width,
-  ) {
-    switch (pointingDirection) {
-      case 'top':
-        return `0 ${width / 2}px ${height}px ${width / 2}px`
-      case 'left':
-        return `${height / 2}px ${width}px ${height / 2}px 0`
-      case 'bottom':
-        return `${height}px ${width / 2}px 0 ${width / 2}px`
-      case 'right':
-        return `${height / 2}px 0 ${height / 2}px ${width}px`
-
-      default:
-        throw new Error(
-          "Passed invalid argument to triangle, please pass correct poitingDirection e.g. 'right'.",
-        )
-    }
-  }
-
-  // needed for border-color
-  const reverseDirection = {
-    left: 'right',
-    right: 'left',
-    top: 'bottom',
-    bottom: 'top',
-  }
+// needed for border-color
+var reverseDirection = {
+  left: 'right',
+  right: 'left',
+  top: 'bottom',
+  bottom: 'top'
 
   /**
- * CSS to represent triangle with any pointing direction with an optional background color. Accepts number or px values for height and width.
- *
- * @example
- * // Styles as object usage
- *
- * const styles = {
- *   ...triangle({ pointingDirection: 'right', width: '100px', height: '100px', foregroundColor: 'red' })
- * }
- *
- *
- * // styled-components usage
- * const div = styled.div`
- *   ${triangle({ pointingDirection: 'right', width: '100px', height: '100px', foregroundColor: 'red' })}
- *
- *
- * // CSS as JS Output
- *
- * div: {
- *  'border-color': 'transparent',
- *  'border-left-color': 'red !important',
- *  'border-style': 'solid',
- *  'border-width': '50px 0 50px 100px',
- *  'height': '0',
- *  'width': '0',
- * }
- */
+   * CSS to represent triangle with any pointing direction with an optional background color. Accepts number or px values for height and width.
+   *
+   * @example
+   * // Styles as object usage
+   *
+   * const styles = {
+   *   ...triangle({ pointingDirection: 'right', width: '100px', height: '100px', foregroundColor: 'red' })
+   * }
+   *
+   *
+   * // styled-components usage
+   * const div = styled.div`
+   *   ${triangle({ pointingDirection: 'right', width: '100px', height: '100px', foregroundColor: 'red' })}
+   *
+   *
+   * // CSS as JS Output
+   *
+   * div: {
+   *  'border-color': 'transparent',
+   *  'border-left-color': 'red !important',
+   *  'border-style': 'solid',
+   *  'border-width': '50px 0 50px 100px',
+   *  'height': '0',
+   *  'width': '0',
+   * }
+   */
 
-  function triangle(_ref) {
-    let pointingDirection = _ref.pointingDirection,
+};function triangle(_ref) {
+  var pointingDirection = _ref.pointingDirection,
       height = _ref.height,
       width = _ref.width,
       foregroundColor = _ref.foregroundColor,
       _ref$backgroundColor = _ref.backgroundColor,
-      backgroundColor = _ref$backgroundColor === undefined
-        ? 'transparent'
-        : _ref$backgroundColor
+      backgroundColor = _ref$backgroundColor === undefined ? 'transparent' : _ref$backgroundColor;
 
-    const unitlessHeight = parseFloat(height)
-    const unitlessWidth = parseFloat(width)
-    if (isNaN(unitlessHeight) || isNaN(unitlessWidth)) {
-      throw new Error(
-        'Passed an invalid value to `height` or `width`. Please provide a pixel based unit',
-      )
-    }
-
-    return defineProperty(
-      {
-        'border-color': backgroundColor,
-        width: '0',
-        height: '0',
-        'border-width': getBorderWidth(
-          pointingDirection,
-          unitlessHeight,
-          unitlessWidth,
-        ),
-        'border-style': 'solid',
-      },
-      `border-${reverseDirection[pointingDirection]}-color`,
-      `${foregroundColor} !important`,
-    )
+  var unitlessHeight = parseFloat(height);
+  var unitlessWidth = parseFloat(width);
+  if (isNaN(unitlessHeight) || isNaN(unitlessWidth)) {
+    throw new Error('Passed an invalid value to `height` or `width`. Please provide a pixel based unit');
   }
 
-  //
+  return defineProperty({
+    'border-color': backgroundColor,
+    width: '0',
+    height: '0',
+    'border-width': getBorderWidth(pointingDirection, unitlessHeight, unitlessWidth),
+    'border-style': 'solid'
+  }, 'border-' + reverseDirection[pointingDirection] + '-color', foregroundColor + ' !important');
+}
 
-  /**
+//      
+
+/**
  * Provides an easy way to change the `word-wrap` property.
  *
  * @example
@@ -1321,249 +1177,243 @@
  * }
  */
 
-  function wordWrap() {
-    const wrap = arguments.length > 0 && arguments[0] !== undefined
-      ? arguments[0]
-      : 'break-word'
+function wordWrap() {
+  var wrap = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 'break-word';
 
-    const wordBreak = wrap === 'break-word' ? 'break-all' : wrap
-    return {
-      'overflow-wrap': wrap,
-      'word-wrap': wrap,
-      'word-break': wordBreak,
-    }
+  var wordBreak = wrap === 'break-word' ? 'break-all' : wrap;
+  return {
+    'overflow-wrap': wrap,
+    'word-wrap': wrap,
+    'word-break': wordBreak
+  };
+}
+
+//      
+
+
+function colorToInt(color) {
+  return Math.round(color * 255);
+}
+
+function convertToInt(red, green, blue) {
+  return colorToInt(red) + "," + colorToInt(green) + "," + colorToInt(blue);
+}
+
+function hslToRgb(hue, saturation, lightness) {
+  var convert = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : convertToInt;
+
+  if (saturation === 0) {
+    // achromatic
+    return convert(lightness, lightness, lightness);
   }
 
-  //
+  // formular from https://en.wikipedia.org/wiki/HSL_and_HSV
+  var huePrime = hue % 360 / 60;
+  var chroma = (1 - Math.abs(2 * lightness - 1)) * saturation;
+  var secondComponent = chroma * (1 - Math.abs(huePrime % 2 - 1));
 
-  function colorToInt(color) {
-    return Math.round(color * 255)
+  var red = 0;
+  var green = 0;
+  var blue = 0;
+
+  if (huePrime >= 0 && huePrime < 1) {
+    red = chroma;
+    green = secondComponent;
+  } else if (huePrime >= 1 && huePrime < 2) {
+    red = secondComponent;
+    green = chroma;
+  } else if (huePrime >= 2 && huePrime < 3) {
+    green = chroma;
+    blue = secondComponent;
+  } else if (huePrime >= 3 && huePrime < 4) {
+    green = secondComponent;
+    blue = chroma;
+  } else if (huePrime >= 4 && huePrime < 5) {
+    red = secondComponent;
+    blue = chroma;
+  } else if (huePrime >= 5 && huePrime < 6) {
+    red = chroma;
+    blue = secondComponent;
   }
 
-  function convertToInt(red, green, blue) {
-    return `${colorToInt(red)},${colorToInt(green)},${colorToInt(blue)}`
-  }
+  var lightnessModification = lightness - chroma / 2;
+  var finalRed = red + lightnessModification;
+  var finalGreen = green + lightnessModification;
+  var finalBlue = blue + lightnessModification;
+  return convert(finalRed, finalGreen, finalBlue);
+}
 
-  function hslToRgb(hue, saturation, lightness) {
-    const convert = arguments.length > 3 && arguments[3] !== undefined
-      ? arguments[3]
-      : convertToInt
-
-    if (saturation === 0) {
-      // achromatic
-      return convert(lightness, lightness, lightness)
-    }
-
-    // formular from https://en.wikipedia.org/wiki/HSL_and_HSV
-    const huePrime = hue % 360 / 60
-    const chroma = (1 - Math.abs(2 * lightness - 1)) * saturation
-    const secondComponent = chroma * (1 - Math.abs(huePrime % 2 - 1))
-
-    let red = 0
-    let green = 0
-    let blue = 0
-
-    if (huePrime >= 0 && huePrime < 1) {
-      red = chroma
-      green = secondComponent
-    } else if (huePrime >= 1 && huePrime < 2) {
-      red = secondComponent
-      green = chroma
-    } else if (huePrime >= 2 && huePrime < 3) {
-      green = chroma
-      blue = secondComponent
-    } else if (huePrime >= 3 && huePrime < 4) {
-      green = secondComponent
-      blue = chroma
-    } else if (huePrime >= 4 && huePrime < 5) {
-      red = secondComponent
-      blue = chroma
-    } else if (huePrime >= 5 && huePrime < 6) {
-      red = chroma
-      blue = secondComponent
-    }
-
-    const lightnessModification = lightness - chroma / 2
-    const finalRed = red + lightnessModification
-    const finalGreen = green + lightnessModification
-    const finalBlue = blue + lightnessModification
-    return convert(finalRed, finalGreen, finalBlue)
-  }
-
-  //
-  const namedColorMap = {
-    aliceblue: 'f0f8ff',
-    antiquewhite: 'faebd7',
-    aqua: '00ffff',
-    aquamarine: '7fffd4',
-    azure: 'f0ffff',
-    beige: 'f5f5dc',
-    bisque: 'ffe4c4',
-    black: '000',
-    blanchedalmond: 'ffebcd',
-    blue: '0000ff',
-    blueviolet: '8a2be2',
-    brown: 'a52a2a',
-    burlywood: 'deb887',
-    cadetblue: '5f9ea0',
-    chartreuse: '7fff00',
-    chocolate: 'd2691e',
-    coral: 'ff7f50',
-    cornflowerblue: '6495ed',
-    cornsilk: 'fff8dc',
-    crimson: 'dc143c',
-    cyan: '00ffff',
-    darkblue: '00008b',
-    darkcyan: '008b8b',
-    darkgoldenrod: 'b8860b',
-    darkgray: 'a9a9a9',
-    darkgreen: '006400',
-    darkgrey: 'a9a9a9',
-    darkkhaki: 'bdb76b',
-    darkmagenta: '8b008b',
-    darkolivegreen: '556b2f',
-    darkorange: 'ff8c00',
-    darkorchid: '9932cc',
-    darkred: '8b0000',
-    darksalmon: 'e9967a',
-    darkseagreen: '8fbc8f',
-    darkslateblue: '483d8b',
-    darkslategray: '2f4f4f',
-    darkslategrey: '2f4f4f',
-    darkturquoise: '00ced1',
-    darkviolet: '9400d3',
-    deeppink: 'ff1493',
-    deepskyblue: '00bfff',
-    dimgray: '696969',
-    dimgrey: '696969',
-    dodgerblue: '1e90ff',
-    firebrick: 'b22222',
-    floralwhite: 'fffaf0',
-    forestgreen: '228b22',
-    fuchsia: 'ff00ff',
-    gainsboro: 'dcdcdc',
-    ghostwhite: 'f8f8ff',
-    gold: 'ffd700',
-    goldenrod: 'daa520',
-    gray: '808080',
-    green: '008000',
-    greenyellow: 'adff2f',
-    grey: '808080',
-    honeydew: 'f0fff0',
-    hotpink: 'ff69b4',
-    indianred: 'cd5c5c',
-    indigo: '4b0082',
-    ivory: 'fffff0',
-    khaki: 'f0e68c',
-    lavender: 'e6e6fa',
-    lavenderblush: 'fff0f5',
-    lawngreen: '7cfc00',
-    lemonchiffon: 'fffacd',
-    lightblue: 'add8e6',
-    lightcoral: 'f08080',
-    lightcyan: 'e0ffff',
-    lightgoldenrodyellow: 'fafad2',
-    lightgray: 'd3d3d3',
-    lightgreen: '90ee90',
-    lightgrey: 'd3d3d3',
-    lightpink: 'ffb6c1',
-    lightsalmon: 'ffa07a',
-    lightseagreen: '20b2aa',
-    lightskyblue: '87cefa',
-    lightslategray: '789',
-    lightslategrey: '789',
-    lightsteelblue: 'b0c4de',
-    lightyellow: 'ffffe0',
-    lime: '0f0',
-    limegreen: '32cd32',
-    linen: 'faf0e6',
-    magenta: 'f0f',
-    maroon: '800000',
-    mediumaquamarine: '66cdaa',
-    mediumblue: '0000cd',
-    mediumorchid: 'ba55d3',
-    mediumpurple: '9370db',
-    mediumseagreen: '3cb371',
-    mediumslateblue: '7b68ee',
-    mediumspringgreen: '00fa9a',
-    mediumturquoise: '48d1cc',
-    mediumvioletred: 'c71585',
-    midnightblue: '191970',
-    mintcream: 'f5fffa',
-    mistyrose: 'ffe4e1',
-    moccasin: 'ffe4b5',
-    navajowhite: 'ffdead',
-    navy: '000080',
-    oldlace: 'fdf5e6',
-    olive: '808000',
-    olivedrab: '6b8e23',
-    orange: 'ffa500',
-    orangered: 'ff4500',
-    orchid: 'da70d6',
-    palegoldenrod: 'eee8aa',
-    palegreen: '98fb98',
-    paleturquoise: 'afeeee',
-    palevioletred: 'db7093',
-    papayawhip: 'ffefd5',
-    peachpuff: 'ffdab9',
-    peru: 'cd853f',
-    pink: 'ffc0cb',
-    plum: 'dda0dd',
-    powderblue: 'b0e0e6',
-    purple: '800080',
-    rebeccapurple: '639',
-    red: 'f00',
-    rosybrown: 'bc8f8f',
-    royalblue: '4169e1',
-    saddlebrown: '8b4513',
-    salmon: 'fa8072',
-    sandybrown: 'f4a460',
-    seagreen: '2e8b57',
-    seashell: 'fff5ee',
-    sienna: 'a0522d',
-    silver: 'c0c0c0',
-    skyblue: '87ceeb',
-    slateblue: '6a5acd',
-    slategray: '708090',
-    slategrey: '708090',
-    snow: 'fffafa',
-    springgreen: '00ff7f',
-    steelblue: '4682b4',
-    tan: 'd2b48c',
-    teal: '008080',
-    thistle: 'd8bfd8',
-    tomato: 'ff6347',
-    turquoise: '40e0d0',
-    violet: 'ee82ee',
-    wheat: 'f5deb3',
-    white: 'fff',
-    whitesmoke: 'f5f5f5',
-    yellow: 'ff0',
-    yellowgreen: '9acd32',
-  }
+//      
+var namedColorMap = {
+  aliceblue: 'f0f8ff',
+  antiquewhite: 'faebd7',
+  aqua: '00ffff',
+  aquamarine: '7fffd4',
+  azure: 'f0ffff',
+  beige: 'f5f5dc',
+  bisque: 'ffe4c4',
+  black: '000',
+  blanchedalmond: 'ffebcd',
+  blue: '0000ff',
+  blueviolet: '8a2be2',
+  brown: 'a52a2a',
+  burlywood: 'deb887',
+  cadetblue: '5f9ea0',
+  chartreuse: '7fff00',
+  chocolate: 'd2691e',
+  coral: 'ff7f50',
+  cornflowerblue: '6495ed',
+  cornsilk: 'fff8dc',
+  crimson: 'dc143c',
+  cyan: '00ffff',
+  darkblue: '00008b',
+  darkcyan: '008b8b',
+  darkgoldenrod: 'b8860b',
+  darkgray: 'a9a9a9',
+  darkgreen: '006400',
+  darkgrey: 'a9a9a9',
+  darkkhaki: 'bdb76b',
+  darkmagenta: '8b008b',
+  darkolivegreen: '556b2f',
+  darkorange: 'ff8c00',
+  darkorchid: '9932cc',
+  darkred: '8b0000',
+  darksalmon: 'e9967a',
+  darkseagreen: '8fbc8f',
+  darkslateblue: '483d8b',
+  darkslategray: '2f4f4f',
+  darkslategrey: '2f4f4f',
+  darkturquoise: '00ced1',
+  darkviolet: '9400d3',
+  deeppink: 'ff1493',
+  deepskyblue: '00bfff',
+  dimgray: '696969',
+  dimgrey: '696969',
+  dodgerblue: '1e90ff',
+  firebrick: 'b22222',
+  floralwhite: 'fffaf0',
+  forestgreen: '228b22',
+  fuchsia: 'ff00ff',
+  gainsboro: 'dcdcdc',
+  ghostwhite: 'f8f8ff',
+  gold: 'ffd700',
+  goldenrod: 'daa520',
+  gray: '808080',
+  green: '008000',
+  greenyellow: 'adff2f',
+  grey: '808080',
+  honeydew: 'f0fff0',
+  hotpink: 'ff69b4',
+  indianred: 'cd5c5c',
+  indigo: '4b0082',
+  ivory: 'fffff0',
+  khaki: 'f0e68c',
+  lavender: 'e6e6fa',
+  lavenderblush: 'fff0f5',
+  lawngreen: '7cfc00',
+  lemonchiffon: 'fffacd',
+  lightblue: 'add8e6',
+  lightcoral: 'f08080',
+  lightcyan: 'e0ffff',
+  lightgoldenrodyellow: 'fafad2',
+  lightgray: 'd3d3d3',
+  lightgreen: '90ee90',
+  lightgrey: 'd3d3d3',
+  lightpink: 'ffb6c1',
+  lightsalmon: 'ffa07a',
+  lightseagreen: '20b2aa',
+  lightskyblue: '87cefa',
+  lightslategray: '789',
+  lightslategrey: '789',
+  lightsteelblue: 'b0c4de',
+  lightyellow: 'ffffe0',
+  lime: '0f0',
+  limegreen: '32cd32',
+  linen: 'faf0e6',
+  magenta: 'f0f',
+  maroon: '800000',
+  mediumaquamarine: '66cdaa',
+  mediumblue: '0000cd',
+  mediumorchid: 'ba55d3',
+  mediumpurple: '9370db',
+  mediumseagreen: '3cb371',
+  mediumslateblue: '7b68ee',
+  mediumspringgreen: '00fa9a',
+  mediumturquoise: '48d1cc',
+  mediumvioletred: 'c71585',
+  midnightblue: '191970',
+  mintcream: 'f5fffa',
+  mistyrose: 'ffe4e1',
+  moccasin: 'ffe4b5',
+  navajowhite: 'ffdead',
+  navy: '000080',
+  oldlace: 'fdf5e6',
+  olive: '808000',
+  olivedrab: '6b8e23',
+  orange: 'ffa500',
+  orangered: 'ff4500',
+  orchid: 'da70d6',
+  palegoldenrod: 'eee8aa',
+  palegreen: '98fb98',
+  paleturquoise: 'afeeee',
+  palevioletred: 'db7093',
+  papayawhip: 'ffefd5',
+  peachpuff: 'ffdab9',
+  peru: 'cd853f',
+  pink: 'ffc0cb',
+  plum: 'dda0dd',
+  powderblue: 'b0e0e6',
+  purple: '800080',
+  rebeccapurple: '639',
+  red: 'f00',
+  rosybrown: 'bc8f8f',
+  royalblue: '4169e1',
+  saddlebrown: '8b4513',
+  salmon: 'fa8072',
+  sandybrown: 'f4a460',
+  seagreen: '2e8b57',
+  seashell: 'fff5ee',
+  sienna: 'a0522d',
+  silver: 'c0c0c0',
+  skyblue: '87ceeb',
+  slateblue: '6a5acd',
+  slategray: '708090',
+  slategrey: '708090',
+  snow: 'fffafa',
+  springgreen: '00ff7f',
+  steelblue: '4682b4',
+  tan: 'd2b48c',
+  teal: '008080',
+  thistle: 'd8bfd8',
+  tomato: 'ff6347',
+  turquoise: '40e0d0',
+  violet: 'ee82ee',
+  wheat: 'f5deb3',
+  white: 'fff',
+  whitesmoke: 'f5f5f5',
+  yellow: 'ff0',
+  yellowgreen: '9acd32'
 
   /**
- * Checks if a string is a CSS named color and returns its equivalent hex value, otherwise returns the original color.
- * @private
- */
-  function nameToHex(color) {
-    if (typeof color !== 'string') return color
-    const normalizedColorName = color.toLowerCase()
-    return namedColorMap[normalizedColorName]
-      ? `#${namedColorMap[normalizedColorName]}`
-      : color
-  }
+   * Checks if a string is a CSS named color and returns its equivalent hex value, otherwise returns the original color.
+   * @private
+   */
+};function nameToHex(color) {
+  if (typeof color !== 'string') return color;
+  var normalizedColorName = color.toLowerCase();
+  return namedColorMap[normalizedColorName] ? '#' + namedColorMap[normalizedColorName] : color;
+}
 
-  //
+//      
 
-  const hexRegex = /^#[a-fA-F0-9]{6}$/
-  const reducedHexRegex = /^#[a-fA-F0-9]{3}$/
-  const rgbRegex = /^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/
-  const rgbaRegex = /^rgba\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*([-+]?[0-9]*[.]?[0-9]+)\s*\)$/
-  const hslRegex = /^hsl\(\s*(\d{1,3})\s*,\s*(\d{1,3})%\s*,\s*(\d{1,3})%\s*\)$/
-  const hslaRegex = /^hsla\(\s*(\d{1,3})\s*,\s*(\d{1,3})%\s*,\s*(\d{1,3})%\s*,\s*([-+]?[0-9]*[.]?[0-9]+)\s*\)$/
+var hexRegex = /^#[a-fA-F0-9]{6}$/;
+var reducedHexRegex = /^#[a-fA-F0-9]{3}$/;
+var rgbRegex = /^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/;
+var rgbaRegex = /^rgba\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*([-+]?[0-9]*[.]?[0-9]+)\s*\)$/;
+var hslRegex = /^hsl\(\s*(\d{1,3})\s*,\s*(\d{1,3})%\s*,\s*(\d{1,3})%\s*\)$/;
+var hslaRegex = /^hsla\(\s*(\d{1,3})\s*,\s*(\d{1,3})%\s*,\s*(\d{1,3})%\s*,\s*([-+]?[0-9]*[.]?[0-9]+)\s*\)$/;
 
-  /**
+/**
  * Returns an RgbColor or RgbaColor object. This utility function is only useful
  * if want to extract a color component. With the color util `toColorString` you
  * can convert a RgbColor or RgbaColor object back to a string.
@@ -1574,136 +1424,120 @@
  * // Assigns `{ red: 92, green: 102, blue: 112, alpha: 0.75 }` to color2
  * const color2 = 'hsla(210, 10%, 40%, 0.75)';
  */
-  function parseToRgb(color) {
-    if (typeof color !== 'string') {
-      throw new Error(
-        'Passed an incorrect argument to a color function, please pass a string representation of a color.',
-      )
-    }
-    const normalizedColor = nameToHex(color)
-    if (normalizedColor.match(hexRegex)) {
-      return {
-        red: parseInt(`${normalizedColor[1]}${normalizedColor[2]}`, 16),
-        green: parseInt(`${normalizedColor[3]}${normalizedColor[4]}`, 16),
-        blue: parseInt(`${normalizedColor[5]}${normalizedColor[6]}`, 16),
-      }
-    }
-    if (normalizedColor.match(reducedHexRegex)) {
-      return {
-        red: parseInt(`${normalizedColor[1]}${normalizedColor[1]}`, 16),
-        green: parseInt(`${normalizedColor[2]}${normalizedColor[2]}`, 16),
-        blue: parseInt(`${normalizedColor[3]}${normalizedColor[3]}`, 16),
-      }
-    }
-    const rgbMatched = rgbRegex.exec(normalizedColor)
-    if (rgbMatched) {
-      return {
-        red: parseInt(`${rgbMatched[1]}`, 10),
-        green: parseInt(`${rgbMatched[2]}`, 10),
-        blue: parseInt(`${rgbMatched[3]}`, 10),
-      }
-    }
-    const rgbaMatched = rgbaRegex.exec(normalizedColor)
-    if (rgbaMatched) {
-      return {
-        red: parseInt(`${rgbaMatched[1]}`, 10),
-        green: parseInt(`${rgbaMatched[2]}`, 10),
-        blue: parseInt(`${rgbaMatched[3]}`, 10),
-        alpha: parseFloat(`${rgbaMatched[4]}`, 10),
-      }
-    }
-    const hslMatched = hslRegex.exec(normalizedColor)
-    if (hslMatched) {
-      const hue = parseInt(`${hslMatched[1]}`, 10)
-      const saturation = parseInt(`${hslMatched[2]}`, 10) / 100
-      const lightness = parseInt(`${hslMatched[3]}`, 10) / 100
-      const rgbColorString = `rgb(${hslToRgb(hue, saturation, lightness)})`
-      const hslRgbMatched = rgbRegex.exec(rgbColorString)
-      return {
-        red: parseInt(`${hslRgbMatched[1]}`, 10),
-        green: parseInt(`${hslRgbMatched[2]}`, 10),
-        blue: parseInt(`${hslRgbMatched[3]}`, 10),
-      }
-    }
-    const hslaMatched = hslaRegex.exec(normalizedColor)
-    if (hslaMatched) {
-      const _hue = parseInt(`${hslaMatched[1]}`, 10)
-      const _saturation = parseInt(`${hslaMatched[2]}`, 10) / 100
-      const _lightness = parseInt(`${hslaMatched[3]}`, 10) / 100
-      const _rgbColorString =
-        `rgb(${hslToRgb(_hue, _saturation, _lightness)})`
-      const _hslRgbMatched = rgbRegex.exec(_rgbColorString)
-      return {
-        red: parseInt(`${_hslRgbMatched[1]}`, 10),
-        green: parseInt(`${_hslRgbMatched[2]}`, 10),
-        blue: parseInt(`${_hslRgbMatched[3]}`, 10),
-        alpha: parseFloat(`${hslaMatched[4]}`, 10),
-      }
-    }
-    throw new Error(
-      "Couldn't parse the color string. Please provide the color as a string in hex, rgb, rgba, hsl or hsla notation.",
-    )
+function parseToRgb(color) {
+  if (typeof color !== 'string') {
+    throw new Error('Passed an incorrect argument to a color function, please pass a string representation of a color.');
   }
+  var normalizedColor = nameToHex(color);
+  if (normalizedColor.match(hexRegex)) {
+    return {
+      red: parseInt('' + normalizedColor[1] + normalizedColor[2], 16),
+      green: parseInt('' + normalizedColor[3] + normalizedColor[4], 16),
+      blue: parseInt('' + normalizedColor[5] + normalizedColor[6], 16)
+    };
+  }
+  if (normalizedColor.match(reducedHexRegex)) {
+    return {
+      red: parseInt('' + normalizedColor[1] + normalizedColor[1], 16),
+      green: parseInt('' + normalizedColor[2] + normalizedColor[2], 16),
+      blue: parseInt('' + normalizedColor[3] + normalizedColor[3], 16)
+    };
+  }
+  var rgbMatched = rgbRegex.exec(normalizedColor);
+  if (rgbMatched) {
+    return {
+      red: parseInt('' + rgbMatched[1], 10),
+      green: parseInt('' + rgbMatched[2], 10),
+      blue: parseInt('' + rgbMatched[3], 10)
+    };
+  }
+  var rgbaMatched = rgbaRegex.exec(normalizedColor);
+  if (rgbaMatched) {
+    return {
+      red: parseInt('' + rgbaMatched[1], 10),
+      green: parseInt('' + rgbaMatched[2], 10),
+      blue: parseInt('' + rgbaMatched[3], 10),
+      alpha: parseFloat('' + rgbaMatched[4], 10)
+    };
+  }
+  var hslMatched = hslRegex.exec(normalizedColor);
+  if (hslMatched) {
+    var hue = parseInt('' + hslMatched[1], 10);
+    var saturation = parseInt('' + hslMatched[2], 10) / 100;
+    var lightness = parseInt('' + hslMatched[3], 10) / 100;
+    var rgbColorString = 'rgb(' + hslToRgb(hue, saturation, lightness) + ')';
+    var hslRgbMatched = rgbRegex.exec(rgbColorString);
+    return {
+      red: parseInt('' + hslRgbMatched[1], 10),
+      green: parseInt('' + hslRgbMatched[2], 10),
+      blue: parseInt('' + hslRgbMatched[3], 10)
+    };
+  }
+  var hslaMatched = hslaRegex.exec(normalizedColor);
+  if (hslaMatched) {
+    var _hue = parseInt('' + hslaMatched[1], 10);
+    var _saturation = parseInt('' + hslaMatched[2], 10) / 100;
+    var _lightness = parseInt('' + hslaMatched[3], 10) / 100;
+    var _rgbColorString = 'rgb(' + hslToRgb(_hue, _saturation, _lightness) + ')';
+    var _hslRgbMatched = rgbRegex.exec(_rgbColorString);
+    return {
+      red: parseInt('' + _hslRgbMatched[1], 10),
+      green: parseInt('' + _hslRgbMatched[2], 10),
+      blue: parseInt('' + _hslRgbMatched[3], 10),
+      alpha: parseFloat('' + hslaMatched[4], 10)
+    };
+  }
+  throw new Error('Could not parse the color string. Please provide the color as a string in hex, rgb, rgba, hsl or hsla notation.');
+}
 
-  //
+//      
 
-  function rgbToHsl(color) {
-    // make sure rgb are contained in a set of [0, 255]
-    const red = color.red / 255
-    const green = color.green / 255
-    const blue = color.blue / 255
 
-    const max = Math.max(red, green, blue)
-    const min = Math.min(red, green, blue)
-    const lightness = (max + min) / 2
+function rgbToHsl(color) {
+  // make sure rgb are contained in a set of [0, 255]
+  var red = color.red / 255;
+  var green = color.green / 255;
+  var blue = color.blue / 255;
 
-    if (max === min) {
-      // achromatic
-      if (color.alpha !== undefined) {
-        return {
-          hue: 0,
-          saturation: 0,
-          lightness,
-          alpha: color.alpha,
-        }
-      } else {
-        return { hue: 0, saturation: 0, lightness }
-      }
-    }
+  var max = Math.max(red, green, blue);
+  var min = Math.min(red, green, blue);
+  var lightness = (max + min) / 2;
 
-    let hue = void 0
-    const delta = max - min
-    const saturation = lightness > 0.5
-      ? delta / (2 - max - min)
-      : delta / (max + min)
-    switch (max) {
-      case red:
-        hue = (green - blue) / delta + (green < blue ? 6 : 0)
-        break
-      case green:
-        hue = (blue - red) / delta + 2
-        break
-      default:
-        // blue case
-        hue = (red - green) / delta + 4
-        break
-    }
-
-    hue *= 60
+  if (max === min) {
+    // achromatic
     if (color.alpha !== undefined) {
-      return {
-        hue,
-        saturation,
-        lightness,
-        alpha: color.alpha,
-      }
+      return { hue: 0, saturation: 0, lightness: lightness, alpha: color.alpha };
+    } else {
+      return { hue: 0, saturation: 0, lightness: lightness };
     }
-    return { hue, saturation, lightness }
   }
 
-  //
+  var hue = void 0;
+  var delta = max - min;
+  var saturation = lightness > 0.5 ? delta / (2 - max - min) : delta / (max + min);
+  switch (max) {
+    case red:
+      hue = (green - blue) / delta + (green < blue ? 6 : 0);
+      break;
+    case green:
+      hue = (blue - red) / delta + 2;
+      break;
+    default:
+      // blue case
+      hue = (red - green) / delta + 4;
+      break;
+  }
 
-  /**
+  hue *= 60;
+  if (color.alpha !== undefined) {
+    return { hue: hue, saturation: saturation, lightness: lightness, alpha: color.alpha };
+  }
+  return { hue: hue, saturation: saturation, lightness: lightness };
+}
+
+//      
+
+/**
  * Returns an HslColor or HslaColor object. This utility function is only useful
  * if want to extract a color component. With the color util `toColorString` you
  * can convert a HslColor or HslaColor object back to a string.
@@ -1714,40 +1548,35 @@
  * // Assigns `{ red: 92, green: 102, blue: 112, alpha: 0.75 }` to color2
  * const color2 = 'hsla(210, 10%, 40%, 0.75)';
  */
-  function parseToHsl(color) {
-    // Note: At a later stage we can optimize this function as right now a hsl
-    // color would be parsed converted to rgb values and converted back to hsl.
-    return rgbToHsl(parseToRgb(color))
-  }
+function parseToHsl(color) {
+  // Note: At a later stage we can optimize this function as right now a hsl
+  // color would be parsed converted to rgb values and converted back to hsl.
+  return rgbToHsl(parseToRgb(color));
+}
 
-  //
+//      
 
-  /**
+/**
  * Reduces hex values if possible e.g. #ff8866 to #f86
  * @private
  */
-  const reduceHexValue = function reduceHexValue(value) {
-    if (
-      value.length === 7 &&
-      value[1] === value[2] &&
-      value[3] === value[4] &&
-      value[5] === value[6]
-    ) {
-      return `#${value[1]}${value[3]}${value[5]}`
-    }
-    return value
+var reduceHexValue = function reduceHexValue(value) {
+  if (value.length === 7 && value[1] === value[2] && value[3] === value[4] && value[5] === value[6]) {
+    return "#" + value[1] + value[3] + value[5];
   }
+  return value;
+};
 
-  //
+//      
 
-  function numberToHex(value) {
-    const hex = value.toString(16)
-    return hex.length === 1 ? `0${hex}` : hex
-  }
+function numberToHex(value) {
+  var hex = value.toString(16);
+  return hex.length === 1 ? "0" + hex : hex;
+}
 
-  //
+//      
 
-  /**
+/**
  * Returns a string value for the color. The returned result is the smallest possible hex notation.
  *
  * @example
@@ -1770,37 +1599,19 @@
  *   background: "#ffcd64";
  * }
  */
-  function rgb(value, green, blue) {
-    if (
-      typeof value === 'number' &&
-      typeof green === 'number' &&
-      typeof blue === 'number'
-    ) {
-      return reduceHexValue(
-        `#${numberToHex(value)}${numberToHex(green)}${numberToHex(blue)}`,
-      )
-    } else if (
-      (typeof value === 'undefined' ? 'undefined' : _typeof(value)) ===
-        'object' &&
-      green === undefined &&
-      blue === undefined
-    ) {
-      return reduceHexValue(
-        `#${
-          numberToHex(value.red)
-          }${numberToHex(value.green)
-          }${numberToHex(value.blue)}`,
-      )
-    }
-
-    throw new Error(
-      'Passed invalid arguments to rgb, please pass multiple numbers e.g. rgb(255, 205, 100) or an object e.g. rgb({ red: 255, green: 205, blue: 100 }).',
-    )
+function rgb(value, green, blue) {
+  if (typeof value === 'number' && typeof green === 'number' && typeof blue === 'number') {
+    return reduceHexValue('#' + numberToHex(value) + numberToHex(green) + numberToHex(blue));
+  } else if ((typeof value === 'undefined' ? 'undefined' : _typeof(value)) === 'object' && green === undefined && blue === undefined) {
+    return reduceHexValue('#' + numberToHex(value.red) + numberToHex(value.green) + numberToHex(value.blue));
   }
 
-  //
+  throw new Error('Passed invalid arguments to rgb, please pass multiple numbers e.g. rgb(255, 205, 100) or an object e.g. rgb({ red: 255, green: 205, blue: 100 }).');
+}
 
-  /**
+//      
+
+/**
  * Returns a string value for the color. The returned result is the smallest possible rgba or hex notation.
  *
  * @example
@@ -1826,60 +1637,33 @@
  *   background: "#ffcd64";
  * }
  */
-  function rgba(value, green, blue, alpha) {
-    if (
-      typeof value === 'number' &&
-      typeof green === 'number' &&
-      typeof blue === 'number' &&
-      typeof alpha === 'number'
-    ) {
-      return alpha >= 1
-        ? rgb(value, green, blue)
-        : `rgba(${value},${green},${blue},${alpha})`
-    } else if (
-      (typeof value === 'undefined' ? 'undefined' : _typeof(value)) ===
-        'object' &&
-      green === undefined &&
-      blue === undefined &&
-      alpha === undefined
-    ) {
-      return value.alpha >= 1
-        ? rgb(value.red, value.green, value.blue)
-        : `rgba(${
-            value.red
-            },${
-            value.green
-            },${
-            value.blue
-            },${
-            value.alpha
-            })`
-    }
-
-    throw new Error(
-      'Passed invalid arguments to rgba, please pass multiple numbers e.g. rgb(255, 205, 100, 0.75) or an object e.g. rgb({ red: 255, green: 205, blue: 100, alpha: 0.75 }).',
-    )
+function rgba(value, green, blue, alpha) {
+  if (typeof value === 'number' && typeof green === 'number' && typeof blue === 'number' && typeof alpha === 'number') {
+    return alpha >= 1 ? rgb(value, green, blue) : 'rgba(' + value + ',' + green + ',' + blue + ',' + alpha + ')';
+  } else if ((typeof value === 'undefined' ? 'undefined' : _typeof(value)) === 'object' && green === undefined && blue === undefined && alpha === undefined) {
+    return value.alpha >= 1 ? rgb(value.red, value.green, value.blue) : 'rgba(' + value.red + ',' + value.green + ',' + value.blue + ',' + value.alpha + ')';
   }
 
-  //
+  throw new Error('Passed invalid arguments to rgba, please pass multiple numbers e.g. rgb(255, 205, 100, 0.75) or an object e.g. rgb({ red: 255, green: 205, blue: 100, alpha: 0.75 }).');
+}
 
-  function colorToHex(color) {
-    return numberToHex(Math.round(color * 255))
-  }
+//      
 
-  function convertToHex(red, green, blue) {
-    return reduceHexValue(
-      `#${colorToHex(red)}${colorToHex(green)}${colorToHex(blue)}`,
-    )
-  }
+function colorToHex(color) {
+  return numberToHex(Math.round(color * 255));
+}
 
-  function hslToHex(hue, saturation, lightness) {
-    return hslToRgb(hue, saturation, lightness, convertToHex)
-  }
+function convertToHex(red, green, blue) {
+  return reduceHexValue('#' + colorToHex(red) + colorToHex(green) + colorToHex(blue));
+}
 
-  //
+function hslToHex(hue, saturation, lightness) {
+  return hslToRgb(hue, saturation, lightness, convertToHex);
+}
 
-  /**
+//      
+
+/**
  * Returns a string value for the color. The returned result is the smallest possible hex notation.
  *
  * @example
@@ -1902,30 +1686,19 @@
  *   background: "#b3191c";
  * }
  */
-  function hsl(value, saturation, lightness) {
-    if (
-      typeof value === 'number' &&
-      typeof saturation === 'number' &&
-      typeof lightness === 'number'
-    ) {
-      return hslToHex(value, saturation, lightness)
-    } else if (
-      (typeof value === 'undefined' ? 'undefined' : _typeof(value)) ===
-        'object' &&
-      saturation === undefined &&
-      lightness === undefined
-    ) {
-      return hslToHex(value.hue, value.saturation, value.lightness)
-    }
-
-    throw new Error(
-      'Passed invalid arguments to hsl, please pass multiple numbers e.g. hsl(360, 0.75, 0.4) or an object e.g. rgb({ hue: 255, saturation: 0.4, lightness: 0.75 }).',
-    )
+function hsl(value, saturation, lightness) {
+  if (typeof value === 'number' && typeof saturation === 'number' && typeof lightness === 'number') {
+    return hslToHex(value, saturation, lightness);
+  } else if ((typeof value === 'undefined' ? 'undefined' : _typeof(value)) === 'object' && saturation === undefined && lightness === undefined) {
+    return hslToHex(value.hue, value.saturation, value.lightness);
   }
 
-  //
+  throw new Error('Passed invalid arguments to hsl, please pass multiple numbers e.g. hsl(360, 0.75, 0.4) or an object e.g. rgb({ hue: 255, saturation: 0.4, lightness: 0.75 }).');
+}
 
-  /**
+//      
+
+/**
  * Returns a string value for the color. The returned result is the smallest possible rgba or hex notation.
  *
  * @example
@@ -1951,88 +1724,43 @@
  *   background: "#b3191c";
  * }
  */
-  function hsla(value, saturation, lightness, alpha) {
-    if (
-      typeof value === 'number' &&
-      typeof saturation === 'number' &&
-      typeof lightness === 'number' &&
-      typeof alpha === 'number'
-    ) {
-      return alpha >= 1
-        ? hslToHex(value, saturation, lightness)
-        : `rgba(${hslToRgb(value, saturation, lightness)},${alpha})`
-    } else if (
-      (typeof value === 'undefined' ? 'undefined' : _typeof(value)) ===
-        'object' &&
-      saturation === undefined &&
-      lightness === undefined &&
-      alpha === undefined
-    ) {
-      return value.alpha >= 1
-        ? hslToHex(value.hue, value.saturation, value.lightness)
-        : `rgba(${
-            hslToRgb(value.hue, value.saturation, value.lightness)
-            },${
-            value.alpha
-            })`
-    }
-
-    throw new Error(
-      'Passed invalid arguments to hsla, please pass multiple numbers e.g. hsl(360, 0.75, 0.4, 0.7) or an object e.g. rgb({ hue: 255, saturation: 0.4, lightness: 0.75, alpha: 0.7 }).',
-    )
+function hsla(value, saturation, lightness, alpha) {
+  if (typeof value === 'number' && typeof saturation === 'number' && typeof lightness === 'number' && typeof alpha === 'number') {
+    return alpha >= 1 ? hslToHex(value, saturation, lightness) : 'rgba(' + hslToRgb(value, saturation, lightness) + ',' + alpha + ')';
+  } else if ((typeof value === 'undefined' ? 'undefined' : _typeof(value)) === 'object' && saturation === undefined && lightness === undefined && alpha === undefined) {
+    return value.alpha >= 1 ? hslToHex(value.hue, value.saturation, value.lightness) : 'rgba(' + hslToRgb(value.hue, value.saturation, value.lightness) + ',' + value.alpha + ')';
   }
 
-  //
+  throw new Error('Passed invalid arguments to hsla, please pass multiple numbers e.g. hsl(360, 0.75, 0.4, 0.7) or an object e.g. rgb({ hue: 255, saturation: 0.4, lightness: 0.75, alpha: 0.7 }).');
+}
 
-  const isRgb = function isRgb(color) {
-    return (
-      (typeof color === 'undefined' ? 'undefined' : _typeof(color)) ===
-        'object' &&
-      typeof color.red === 'number' &&
-      typeof color.green === 'number' &&
-      typeof color.blue === 'number' &&
-      // $FlowIgnoreNextLine not sure why this complains
-      typeof color.alpha !== 'number'
-    )
-  }
+//      
 
-  const isRgba = function isRgba(color) {
-    return (
-      (typeof color === 'undefined' ? 'undefined' : _typeof(color)) ===
-        'object' &&
-      typeof color.red === 'number' &&
-      typeof color.green === 'number' &&
-      typeof color.blue === 'number' &&
-      // $FlowIgnoreNextLine not sure why this complains
-      typeof color.alpha === 'number'
-    )
-  }
+var isRgb = function isRgb(color) {
+  return (typeof color === 'undefined' ? 'undefined' : _typeof(color)) === 'object' && typeof color.red === 'number' && typeof color.green === 'number' && typeof color.blue === 'number' &&
+  // $FlowIgnoreNextLine not sure why this complains
+  typeof color.alpha !== 'number';
+};
 
-  const isHsl = function isHsl(color) {
-    return (
-      (typeof color === 'undefined' ? 'undefined' : _typeof(color)) ===
-        'object' &&
-      typeof color.hue === 'number' &&
-      typeof color.saturation === 'number' &&
-      typeof color.lightness === 'number' &&
-      // $FlowIgnoreNextLine not sure why this complains
-      typeof color.alpha !== 'number'
-    )
-  }
+var isRgba = function isRgba(color) {
+  return (typeof color === 'undefined' ? 'undefined' : _typeof(color)) === 'object' && typeof color.red === 'number' && typeof color.green === 'number' && typeof color.blue === 'number' &&
+  // $FlowIgnoreNextLine not sure why this complains
+  typeof color.alpha === 'number';
+};
 
-  const isHsla = function isHsla(color) {
-    return (
-      (typeof color === 'undefined' ? 'undefined' : _typeof(color)) ===
-        'object' &&
-      typeof color.hue === 'number' &&
-      typeof color.saturation === 'number' &&
-      typeof color.lightness === 'number' &&
-      // $FlowIgnoreNextLine not sure why this complains
-      typeof color.alpha === 'number'
-    )
-  }
+var isHsl = function isHsl(color) {
+  return (typeof color === 'undefined' ? 'undefined' : _typeof(color)) === 'object' && typeof color.hue === 'number' && typeof color.saturation === 'number' && typeof color.lightness === 'number' &&
+  // $FlowIgnoreNextLine not sure why this complains
+  typeof color.alpha !== 'number';
+};
 
-  /**
+var isHsla = function isHsla(color) {
+  return (typeof color === 'undefined' ? 'undefined' : _typeof(color)) === 'object' && typeof color.hue === 'number' && typeof color.saturation === 'number' && typeof color.lightness === 'number' &&
+  // $FlowIgnoreNextLine not sure why this complains
+  typeof color.alpha === 'number';
+};
+
+/**
  * Converts a RgbColor, RgbaColor, HslColor or HslaColor object to a color string.
  * This util is useful in case you only know on runtime which color object is
  * used. Otherwise we recommend to rely on `rgb`, `rgba`, `hsl` or `hsla`.
@@ -2062,52 +1790,51 @@
  *   background: "rgba(179,25,25,0.72)";
  * }
  */
-  function toColorString(color) {
-    if (isRgba(color)) {
-      // $FlowIgnoreNextLine not sure why this complains
-      return rgba(color)
-    } else if (isRgb(color)) {
-      // $FlowIgnoreNextLine not sure why this complains
-      return rgb(color)
-    } else if (isHsla(color)) {
-      // $FlowIgnoreNextLine not sure why this complains
-      return hsla(color)
-    } else if (isHsl(color)) {
-      // $FlowIgnoreNextLine not sure why this complains
-      return hsl(color)
-    }
-    throw new Error(
-      'Passed invalid argument to toColorString, please pass a RgbColor, RgbaColor, HslColor or HslaColor object.',
-    )
+function toColorString(color) {
+  if (isRgba(color)) {
+    // $FlowIgnoreNextLine not sure why this complains
+    return rgba(color);
+  } else if (isRgb(color)) {
+    // $FlowIgnoreNextLine not sure why this complains
+    return rgb(color);
+  } else if (isHsla(color)) {
+    // $FlowIgnoreNextLine not sure why this complains
+    return hsla(color);
+  } else if (isHsl(color)) {
+    // $FlowIgnoreNextLine not sure why this complains
+    return hsl(color);
   }
+  throw new Error('Passed invalid argument to toColorString, please pass a RgbColor, RgbaColor, HslColor or HslaColor object.');
+}
 
-  //
+//      
 
-  // Type definitions taken from https://github.com/gcanti/flow-static-land/blob/master/src/Fun.js
+// Type definitions taken from https://github.com/gcanti/flow-static-land/blob/master/src/Fun.js
 
-  // eslint-disable-next-line no-unused-vars
 
-  // eslint-disable-next-line no-unused-vars
+// eslint-disable-next-line no-unused-vars
 
-  // eslint-disable-next-line no-redeclare
 
-  function curried(f, length, acc) {
-    return function fn() {
-      // eslint-disable-next-line prefer-rest-params
-      const combined = acc.concat(Array.prototype.slice.call(arguments))
-      return combined.length >= length
-        ? f.apply(this, combined)
-        : curried(f, length, combined)
-    }
-  }
-  // eslint-disable-next-line no-redeclare
-  function curry(f) {
-    return curried(f, f.length, [])
-  }
+// eslint-disable-next-line no-unused-vars
 
-  //
+// eslint-disable-next-line no-redeclare
 
-  /**
+
+function curried(f, length, acc) {
+  return function fn() {
+    // eslint-disable-next-line prefer-rest-params
+    var combined = acc.concat(Array.prototype.slice.call(arguments));
+    return combined.length >= length ? f.apply(this, combined) : curried(f, length, combined);
+  };
+}
+// eslint-disable-next-line no-redeclare
+function curry(f) {
+  return curried(f, f.length, []);
+}
+
+//      
+
+/**
  * Changes the hue of the color. Hue is a number between 0 to 360. The first
  * argument for adjustHue is the amount of degrees the color is rotated along
  * the color wheel.
@@ -2131,20 +1858,18 @@
  *   background: "rgba(136,136,68,0.7)";
  * }
  */
-  function adjustHue(degree, color) {
-    const hslColor = parseToHsl(color)
-    return toColorString(
-      _extends({}, hslColor, {
-        hue: (hslColor.hue + degree) % 360,
-      }),
-    )
-  }
+function adjustHue(degree, color) {
+  var hslColor = parseToHsl(color);
+  return toColorString(_extends({}, hslColor, {
+    hue: (hslColor.hue + degree) % 360
+  }));
+}
 
-  const adjustHue$1 = curry(adjustHue)
+var adjustHue$1 = curry(adjustHue);
 
-  //
+//      
 
-  /**
+/**
  * Returns the complement of the provided color. This is identical to adjustHue(180, <color>).
  *
  * @example
@@ -2166,24 +1891,22 @@
  *   background: "rgba(153,153,153,0.7)";
  * }
  */
-  function complement(color) {
-    const hslColor = parseToHsl(color)
-    return toColorString(
-      _extends({}, hslColor, {
-        hue: (hslColor.hue + 180) % 360,
-      }),
-    )
-  }
+function complement(color) {
+  var hslColor = parseToHsl(color);
+  return toColorString(_extends({}, hslColor, {
+    hue: (hslColor.hue + 180) % 360
+  }));
+}
 
-  //
+//      
 
-  function guard(lowerBoundary, upperBoundary, value) {
-    return Math.max(lowerBoundary, Math.min(upperBoundary, value))
-  }
+function guard(lowerBoundary, upperBoundary, value) {
+  return Math.max(lowerBoundary, Math.min(upperBoundary, value));
+}
 
-  //
+//      
 
-  /**
+/**
  * Returns a string value for the darkened color.
  *
  * @example
@@ -2206,20 +1929,18 @@
  *   background: "rgba(255,189,49,0.7)";
  * }
  */
-  function darken(amount, color) {
-    const hslColor = parseToHsl(color)
-    return toColorString(
-      _extends({}, hslColor, {
-        lightness: guard(0, 1, hslColor.lightness - amount),
-      }),
-    )
-  }
+function darken(amount, color) {
+  var hslColor = parseToHsl(color);
+  return toColorString(_extends({}, hslColor, {
+    lightness: guard(0, 1, hslColor.lightness - amount)
+  }));
+}
 
-  const darken$1 = curry(darken)
+var darken$1 = curry(darken);
 
-  //
+//      
 
-  /**
+/**
  * Decreases the intensity of a color. Its range is between 0 to 1. The first
  * argument of the desaturate function is the amount by how much the color
  * intensity should be decreased.
@@ -2243,20 +1964,18 @@
  *   background: "rgba(184,185,121,0.7)";
  * }
  */
-  function desaturate(amount, color) {
-    const hslColor = parseToHsl(color)
-    return toColorString(
-      _extends({}, hslColor, {
-        saturation: guard(0, 1, hslColor.saturation - amount),
-      }),
-    )
-  }
+function desaturate(amount, color) {
+  var hslColor = parseToHsl(color);
+  return toColorString(_extends({}, hslColor, {
+    saturation: guard(0, 1, hslColor.saturation - amount)
+  }));
+}
 
-  const desaturate$1 = curry(desaturate)
+var desaturate$1 = curry(desaturate);
 
-  //
+//      
 
-  /**
+/**
  * Converts the color to a grayscale, by reducing its saturation to 0.
  *
  * @example
@@ -2278,17 +1997,15 @@
  *   background: "rgba(153,153,153,0.7)";
  * }
  */
-  function grayscale(color) {
-    return toColorString(
-      _extends({}, parseToHsl(color), {
-        saturation: 0,
-      }),
-    )
-  }
+function grayscale(color) {
+  return toColorString(_extends({}, parseToHsl(color), {
+    saturation: 0
+  }));
+}
 
-  //
+//      
 
-  /**
+/**
  * Inverts the red, green and blue values of a color.
  *
  * @example
@@ -2311,21 +2028,19 @@
  *   background: "rgba(154,155,50,0.7)";
  * }
  */
-  function invert(color) {
-    // parse color string to rgb
-    const value = parseToRgb(color)
-    return toColorString(
-      _extends({}, value, {
-        red: 255 - value.red,
-        green: 255 - value.green,
-        blue: 255 - value.blue,
-      }),
-    )
-  }
+function invert(color) {
+  // parse color string to rgb
+  var value = parseToRgb(color);
+  return toColorString(_extends({}, value, {
+    red: 255 - value.red,
+    green: 255 - value.green,
+    blue: 255 - value.blue
+  }));
+}
 
-  //
+//      
 
-  /**
+/**
  * Returns a string value for the lightened color.
  *
  * @example
@@ -2348,20 +2063,18 @@
  *   background: "rgba(229,230,177,0.7)";
  * }
  */
-  function lighten(amount, color) {
-    const hslColor = parseToHsl(color)
-    return toColorString(
-      _extends({}, hslColor, {
-        lightness: guard(0, 1, hslColor.lightness + amount),
-      }),
-    )
-  }
+function lighten(amount, color) {
+  var hslColor = parseToHsl(color);
+  return toColorString(_extends({}, hslColor, {
+    lightness: guard(0, 1, hslColor.lightness + amount)
+  }));
+}
 
-  const lighten$1 = curry(lighten)
+var lighten$1 = curry(lighten);
 
-  //
+//      
 
-  /**
+/**
  * Mixes two colors together by calculating the average of each of the RGB components.
  *
  * By default the weight is 0.5 meaning that half of the first color and half the second
@@ -2392,46 +2105,43 @@
  *   background: "rgba(63, 0, 191, 0.75)";
  * }
  */
-  function mix() {
-    const weight = arguments.length > 0 && arguments[0] !== undefined
-      ? arguments[0]
-      : 0.5
-    const color = arguments[1]
-    const otherColor = arguments[2]
+function mix() {
+  var weight = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 0.5;
+  var color = arguments[1];
+  var otherColor = arguments[2];
 
-    const parsedColor1 = parseToRgb(color)
-    const color1 = _extends({}, parsedColor1, {
-      alpha: typeof parsedColor1.alpha === 'number' ? parsedColor1.alpha : 1,
-    })
+  var parsedColor1 = parseToRgb(color);
+  var color1 = _extends({}, parsedColor1, {
+    alpha: typeof parsedColor1.alpha === 'number' ? parsedColor1.alpha : 1
+  });
 
-    const parsedColor2 = parseToRgb(otherColor)
-    const color2 = _extends({}, parsedColor2, {
-      alpha: typeof parsedColor2.alpha === 'number' ? parsedColor2.alpha : 1,
-    })
+  var parsedColor2 = parseToRgb(otherColor);
+  var color2 = _extends({}, parsedColor2, {
+    alpha: typeof parsedColor2.alpha === 'number' ? parsedColor2.alpha : 1
 
     // The formular is copied from the original Sass implementation:
     // http://sass-lang.com/documentation/Sass/Script/Functions.html#mix-instance_method
-    const alphaDelta = color1.alpha - color2.alpha
-    const x = weight * 2 - 1
-    const y = x * alphaDelta === -1 ? x : x + alphaDelta
-    const z = 1 + x * alphaDelta
-    const weight1 = (y / z + 1) / 2.0
-    const weight2 = 1 - weight1
+  });var alphaDelta = color1.alpha - color2.alpha;
+  var x = weight * 2 - 1;
+  var y = x * alphaDelta === -1 ? x : x + alphaDelta;
+  var z = 1 + x * alphaDelta;
+  var weight1 = (y / z + 1) / 2.0;
+  var weight2 = 1 - weight1;
 
-    const mixedColor = {
-      red: Math.floor(color1.red * weight1 + color2.red * weight2),
-      green: Math.floor(color1.green * weight1 + color2.green * weight2),
-      blue: Math.floor(color1.blue * weight1 + color2.blue * weight2),
-      alpha: color1.alpha + (color2.alpha - color1.alpha) * (weight / 1.0),
-    }
+  var mixedColor = {
+    red: Math.floor(color1.red * weight1 + color2.red * weight2),
+    green: Math.floor(color1.green * weight1 + color2.green * weight2),
+    blue: Math.floor(color1.blue * weight1 + color2.blue * weight2),
+    alpha: color1.alpha + (color2.alpha - color1.alpha) * (weight / 1.0)
+  };
 
-    return rgba(mixedColor)
-  }
+  return rgba(mixedColor);
+}
 
-  const mix$1 = curry(mix)
+var mix$1 = curry(mix);
 
-  //
-  /**
+//      
+/**
  * Increases the opacity of a color. Its range for the amount is between 0 to 1.
  *
  *
@@ -2458,20 +2168,20 @@
  *   background: "rgba(255,0,0,0.7)";
  * }
  */
-  function opacify(amount, color) {
-    const parsedColor = parseToRgb(color)
-    const alpha = typeof parsedColor.alpha === 'number' ? parsedColor.alpha : 1
-    const colorWithAlpha = _extends({}, parsedColor, {
-      alpha: guard(0, 1, alpha + amount),
-    })
-    return rgba(colorWithAlpha)
-  }
+function opacify(amount, color) {
+  var parsedColor = parseToRgb(color);
+  var alpha = typeof parsedColor.alpha === 'number' ? parsedColor.alpha : 1;
+  var colorWithAlpha = _extends({}, parsedColor, {
+    alpha: guard(0, 1, alpha + amount)
+  });
+  return rgba(colorWithAlpha);
+}
 
-  const opacify$1 = curry(opacify)
+var opacify$1 = curry(opacify);
 
-  //
+//      
 
-  /**
+/**
  * Increases the intensity of a color. Its range is between 0 to 1. The first
  * argument of the saturate function is the amount by how much the color
  * intensity should be increased.
@@ -2496,20 +2206,18 @@
  *   background: "rgba(224,226,80,0.7)";
  * }
  */
-  function saturate(amount, color) {
-    const hslColor = parseToHsl(color)
-    return toColorString(
-      _extends({}, hslColor, {
-        saturation: guard(0, 1, hslColor.saturation + amount),
-      }),
-    )
-  }
+function saturate(amount, color) {
+  var hslColor = parseToHsl(color);
+  return toColorString(_extends({}, hslColor, {
+    saturation: guard(0, 1, hslColor.saturation + amount)
+  }));
+}
 
-  const saturate$1 = curry(saturate)
+var saturate$1 = curry(saturate);
 
-  //
+//      
 
-  /**
+/**
  * Sets the hue of a color to the provided value. The hue range can be
  * from 0 and 359.
  *
@@ -2532,19 +2240,17 @@
  *   background: "rgba(107,100,205,0.7)";
  * }
  */
-  function setHue(hue, color) {
-    return toColorString(
-      _extends({}, parseToHsl(color), {
-        hue,
-      }),
-    )
-  }
+function setHue(hue, color) {
+  return toColorString(_extends({}, parseToHsl(color), {
+    hue: hue
+  }));
+}
 
-  const setHue$1 = curry(setHue)
+var setHue$1 = curry(setHue);
 
-  //
+//      
 
-  /**
+/**
  * Sets the lightness of a color to the provided value. The lightness range can be
  * from 0 and 1.
  *
@@ -2567,19 +2273,17 @@
  *   background: "rgba(223,224,159,0.7)";
  * }
  */
-  function setLightness(lightness, color) {
-    return toColorString(
-      _extends({}, parseToHsl(color), {
-        lightness,
-      }),
-    )
-  }
+function setLightness(lightness, color) {
+  return toColorString(_extends({}, parseToHsl(color), {
+    lightness: lightness
+  }));
+}
 
-  const setLightness$1 = curry(setLightness)
+var setLightness$1 = curry(setLightness);
 
-  //
+//      
 
-  /**
+/**
  * Sets the saturation of a color to the provided value. The lightness range can be
  * from 0 and 1.
  *
@@ -2602,19 +2306,17 @@
  *   background: "rgba(228,229,76,0.7)";
  * }
  */
-  function setSaturation(saturation, color) {
-    return toColorString(
-      _extends({}, parseToHsl(color), {
-        saturation,
-      }),
-    )
-  }
+function setSaturation(saturation, color) {
+  return toColorString(_extends({}, parseToHsl(color), {
+    saturation: saturation
+  }));
+}
 
-  const setSaturation$1 = curry(setSaturation)
+var setSaturation$1 = curry(setSaturation);
 
-  //
+//      
 
-  /**
+/**
  * Shades a color by mixing it with black. `shade` can produce
  * hue shifts, where as `darken` manipulates the luminance channel and therefore
  * doesn't produce hue shifts.
@@ -2637,25 +2339,21 @@
  * }
  */
 
-  function shade(percentage, color) {
-    if (typeof percentage !== 'number' || percentage > 1 || percentage < -1) {
-      throw new Error(
-        'Passed an incorrect argument to shade, please pass a percentage less than or equal to 1 and larger than or equal to -1.',
-      )
-    }
-    if (typeof color !== 'string') {
-      throw new Error(
-        'Passed an incorrect argument to a color function, please pass a string representation of a color.',
-      )
-    }
-    return mix$1(percentage, color, 'rgb(0, 0, 0)')
+function shade(percentage, color) {
+  if (typeof percentage !== 'number' || percentage > 1 || percentage < -1) {
+    throw new Error('Passed an incorrect argument to shade, please pass a percentage less than or equal to 1 and larger than or equal to -1.');
   }
+  if (typeof color !== 'string') {
+    throw new Error('Passed an incorrect argument to a color function, please pass a string representation of a color.');
+  }
+  return mix$1(percentage, color, 'rgb(0, 0, 0)');
+}
 
-  const shade$1 = curry(shade)
+var shade$1 = curry(shade);
 
-  //
+//      
 
-  /**
+/**
  * Tints a color by mixing it with white. `tint` can produce
  * hue shifts, where as `lighten` manipulates the luminance channel and therefore
  * doesn't produce hue shifts.
@@ -2678,24 +2376,20 @@
  * }
  */
 
-  function tint(percentage, color) {
-    if (typeof percentage !== 'number' || percentage > 1 || percentage < -1) {
-      throw new Error(
-        'Passed an incorrect argument to tint, please pass a percentage less than or equal to 1 and larger than or equal to -1.',
-      )
-    }
-    if (typeof color !== 'string') {
-      throw new Error(
-        'Passed an incorrect argument to a color function, please pass a string representation of a color.',
-      )
-    }
-    return mix$1(percentage, color, 'rgb(255, 255, 255)')
+function tint(percentage, color) {
+  if (typeof percentage !== 'number' || percentage > 1 || percentage < -1) {
+    throw new Error('Passed an incorrect argument to tint, please pass a percentage less than or equal to 1 and larger than or equal to -1.');
   }
+  if (typeof color !== 'string') {
+    throw new Error('Passed an incorrect argument to a color function, please pass a string representation of a color.');
+  }
+  return mix$1(percentage, color, 'rgb(255, 255, 255)');
+}
 
-  const tint$1 = curry(tint)
+var tint$1 = curry(tint);
 
-  //
-  /**
+//      
+/**
  * Decreases the opacity of a color. Its range for the amount is between 0 to 1.
  *
  *
@@ -2722,22 +2416,22 @@
  *   background: "rgba(255,0,0,0.3)";
  * }
  */
-  function transparentize(amount, color) {
-    const parsedColor = parseToRgb(color)
-    const alpha = typeof parsedColor.alpha === 'number' ? parsedColor.alpha : 1
-    const colorWithAlpha = _extends({}, parsedColor, {
-      alpha: guard(0, 1, alpha - amount),
-    })
-    return rgba(colorWithAlpha)
-  }
+function transparentize(amount, color) {
+  var parsedColor = parseToRgb(color);
+  var alpha = typeof parsedColor.alpha === 'number' ? parsedColor.alpha : 1;
+  var colorWithAlpha = _extends({}, parsedColor, {
+    alpha: guard(0, 1, alpha - amount)
+  });
+  return rgba(colorWithAlpha);
+}
 
-  const transparentize$1 = curry(transparentize)
+var transparentize$1 = curry(transparentize);
 
-  //
+//      
 
-  /** */
+/** */
 
-  /**
+/**
  * Shorthand for easily setting the animation property. Allows either multiple arrays with animations
  * or a single animation spread over the arguments.
  * @example
@@ -2773,50 +2467,35 @@
  *   'animation': 'rotate 1s ease-in-out'
  * }
  */
-  function animation() {
-    for (
-      var _len = arguments.length, args = Array(_len), _key = 0;
-      _key < _len;
-      _key++
-    ) {
-      args[_key] = arguments[_key]
-    }
-
-    // Allow single or multiple animations passed
-    const multiMode = Array.isArray(args[0])
-    if (!multiMode && args.length > 8) {
-      throw new Error(
-        'The animation shorthand only takes 8 arguments. See the specification for more information: http://mdn.io/animation',
-      )
-    }
-    const code = args
-      .map((arg) => {
-        if (
-          (multiMode && !Array.isArray(arg)) ||
-          (!multiMode && Array.isArray(arg))
-        ) {
-          throw new Error(
-            "To pass multiple animations please supply them in arrays, e.g. animation(['rotate', '2s'], ['move', '1s'])\nTo pass a single animation please supply them in simple values, e.g. animation('rotate', '2s')",
-          )
-        }
-        if (Array.isArray(arg) && arg.length > 8) {
-          throw new Error(
-            'The animation shorthand arrays can only have 8 elements. See the specification for more information: http://mdn.io/animation',
-          )
-        }
-
-        return Array.isArray(arg) ? arg.join(' ') : arg
-      })
-      .join(', ')
-
-    return {
-      animation: code,
-    }
+function animation() {
+  for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+    args[_key] = arguments[_key];
   }
 
-  //
+  // Allow single or multiple animations passed
+  var multiMode = Array.isArray(args[0]);
+  if (!multiMode && args.length > 8) {
+    throw new Error('The animation shorthand only takes 8 arguments. See the specification for more information: http://mdn.io/animation');
+  }
+  var code = args.map(function (arg) {
+    if (multiMode && !Array.isArray(arg) || !multiMode && Array.isArray(arg)) {
+      throw new Error("To pass multiple animations please supply them in arrays, e.g. animation(['rotate', '2s'], ['move', '1s'])\nTo pass a single animation please supply them in simple values, e.g. animation('rotate', '2s')");
+    }
+    if (Array.isArray(arg) && arg.length > 8) {
+      throw new Error('The animation shorthand arrays can only have 8 elements. See the specification for more information: http://mdn.io/animation');
+    }
 
-  /**
+    return Array.isArray(arg) ? arg.join(' ') : arg;
+  }).join(', ');
+
+  return {
+    animation: code
+  };
+}
+
+//      
+
+/**
  * The backgroundImages shorthand accepts any number of backgroundImage values as parameters for creating a single background statement..
  * @example
  * // Styles as object usage
@@ -2836,23 +2515,19 @@
  * }
  */
 
-  function backgroundImages() {
-    for (
-      var _len = arguments.length, properties = Array(_len), _key = 0;
-      _key < _len;
-      _key++
-    ) {
-      properties[_key] = arguments[_key]
-    }
-
-    return {
-      'background-image': properties.join(', '),
-    }
+function backgroundImages() {
+  for (var _len = arguments.length, properties = Array(_len), _key = 0; _key < _len; _key++) {
+    properties[_key] = arguments[_key];
   }
 
-  //
+  return {
+    'background-image': properties.join(', ')
+  };
+}
 
-  /**
+//      
+
+/**
  * The backgrounds shorthand accepts any number of background values as parameters for creating a single background statement..
  * @example
  * // Styles as object usage
@@ -2871,22 +2546,18 @@
  *   'background': 'url("/image/background.jpg"), linear-gradient(red, green), center no-repeat'
  * }
  */
-  function backgrounds() {
-    for (
-      var _len = arguments.length, properties = Array(_len), _key = 0;
-      _key < _len;
-      _key++
-    ) {
-      properties[_key] = arguments[_key]
-    }
-
-    return {
-      background: properties.join(', '),
-    }
+function backgrounds() {
+  for (var _len = arguments.length, properties = Array(_len), _key = 0; _key < _len; _key++) {
+    properties[_key] = arguments[_key];
   }
 
-  //
-  /**
+  return {
+    background: properties.join(', ')
+  };
+}
+
+//      
+/**
  * The border-color shorthand accepts up to four values, including null to skip a value, and uses the directional-property mixin to map them to their respective directions.
  * @example
  * // Styles as object usage
@@ -2909,21 +2580,17 @@
  * }
  */
 
-  function borderColor() {
-    for (
-      var _len = arguments.length, values = Array(_len), _key = 0;
-      _key < _len;
-      _key++
-    ) {
-      values[_key] = arguments[_key]
-    }
-
-    return directionalProperty(...['border-color'].concat(values))
+function borderColor() {
+  for (var _len = arguments.length, values = Array(_len), _key = 0; _key < _len; _key++) {
+    values[_key] = arguments[_key];
   }
 
-  //
+  return directionalProperty.apply(undefined, ['border-color'].concat(values));
+}
 
-  /**
+//      
+
+/**
  * The border-radius shorthand accepts a value for side and a value for radius and applies the radius value to both corners of the side.
  * @example
  * // Styles as object usage
@@ -2944,43 +2611,27 @@
  * }
  */
 
-  function borderRadius(side, radius) {
-    if (!radius || typeof radius !== 'string') {
-      throw new Error(
-        'borderRadius expects a radius value as a string as the second argument.',
-      )
-    }
-    if (side === 'top' || side === 'bottom') {
-      let _ref
+function borderRadius(side, radius) {
+  if (!radius || typeof radius !== 'string') {
+    throw new Error('borderRadius expects a radius value as a string as the second argument.');
+  }
+  if (side === 'top' || side === 'bottom') {
+    var _ref;
 
-      return (_ref = {}), defineProperty(
-        _ref,
-        `border-${side}-right-radius`,
-        radius,
-      ), defineProperty(_ref, `border-${side}-left-radius`, radius), _ref
-    }
-
-    if (side === 'left' || side === 'right') {
-      let _ref2
-
-      return (_ref2 = {}), defineProperty(
-        _ref2,
-        `border-top-${side}-radius`,
-        radius,
-      ), defineProperty(
-        _ref2,
-        `border-bottom-${side}-radius`,
-        radius,
-      ), _ref2
-    }
-
-    throw new Error(
-      'borderRadius expects one of "top", "bottom", "left" or "right" as the first argument.',
-    )
+    return _ref = {}, defineProperty(_ref, 'border-' + side + '-right-radius', radius), defineProperty(_ref, 'border-' + side + '-left-radius', radius), _ref;
   }
 
-  //
-  /**
+  if (side === 'left' || side === 'right') {
+    var _ref2;
+
+    return _ref2 = {}, defineProperty(_ref2, 'border-top-' + side + '-radius', radius), defineProperty(_ref2, 'border-bottom-' + side + '-radius', radius), _ref2;
+  }
+
+  throw new Error('borderRadius expects one of "top", "bottom", "left" or "right" as the first argument.');
+}
+
+//      
+/**
  * The border-style shorthand accepts up to four values, including null to skip a value, and uses the directional-property mixin to map them to their respective directions.
  * @example
  * // Styles as object usage
@@ -3003,20 +2654,16 @@
  * }
  */
 
-  function borderStyle() {
-    for (
-      var _len = arguments.length, values = Array(_len), _key = 0;
-      _key < _len;
-      _key++
-    ) {
-      values[_key] = arguments[_key]
-    }
-
-    return directionalProperty(...['border-style'].concat(values))
+function borderStyle() {
+  for (var _len = arguments.length, values = Array(_len), _key = 0; _key < _len; _key++) {
+    values[_key] = arguments[_key];
   }
 
-  //
-  /**
+  return directionalProperty.apply(undefined, ['border-style'].concat(values));
+}
+
+//      
+/**
  * The border-width shorthand accepts up to four values, including null to skip a value, and uses the directional-property mixin to map them to their respective directions.
  * @example
  * // Styles as object usage
@@ -3039,63 +2686,48 @@
  * }
  */
 
-  function borderWidth() {
-    for (
-      var _len = arguments.length, values = Array(_len), _key = 0;
-      _key < _len;
-      _key++
-    ) {
-      values[_key] = arguments[_key]
-    }
-
-    return directionalProperty(...['border-width'].concat(values))
+function borderWidth() {
+  for (var _len = arguments.length, values = Array(_len), _key = 0; _key < _len; _key++) {
+    values[_key] = arguments[_key];
   }
 
-  //
-  function generateSelectors(template, state) {
-    const stateSuffix = state ? `:${state}` : ''
-    return template(stateSuffix)
-  }
+  return directionalProperty.apply(undefined, ['border-width'].concat(values));
+}
 
-  /**
+//      
+function generateSelectors(template, state) {
+  var stateSuffix = state ? ':' + state : '';
+  return template(stateSuffix);
+}
+
+/**
  * Function helper that adds an array of states to a template of selectors. Used in textInputs and buttons.
  * @private
  */
-  function statefulSelectors(states, template, stateMap) {
-    if (!template) { throw new Error('You must provide a template to this method.') }
-    if (states.length === 0) return generateSelectors(template, null)
-    let selectors = []
-    for (let i = 0; i < states.length; i += 1) {
-      if (stateMap && stateMap.indexOf(states[i]) < 0) {
-        throw new Error(
-          'You passed an unsupported selector state to this method.',
-        )
-      }
-      selectors.push(generateSelectors(template, states[i]))
+function statefulSelectors(states, template, stateMap) {
+  if (!template) throw new Error('You must provide a template to this method.');
+  if (states.length === 0) return generateSelectors(template, null);
+  var selectors = [];
+  for (var i = 0; i < states.length; i += 1) {
+    if (stateMap && stateMap.indexOf(states[i]) < 0) {
+      throw new Error('You passed an unsupported selector state to this method.');
     }
-    selectors = selectors.join(',')
-    return selectors
+    selectors.push(generateSelectors(template, states[i]));
   }
+  selectors = selectors.join(',');
+  return selectors;
+}
 
-  //
-  const stateMap = [undefined, null, 'active', 'focus', 'hover']
+//      
+var stateMap = [undefined, null, 'active', 'focus', 'hover'];
 
-  function template(state) {
-    return (
-      `button${
-      state
-      },\n  input[type="button"]${
-      state
-      },\n  input[type="reset"]${
-      state
-      },\n  input[type="submit"]${
-      state}`
-    )
-  }
+function template(state) {
+  return 'button' + state + ',\n  input[type="button"]' + state + ',\n  input[type="reset"]' + state + ',\n  input[type="submit"]' + state;
+}
 
-  /** */
+/** */
 
-  /**
+/**
  * Populates selectors that target all buttons. You can pass optional states to append to the selectors.
  * @example
  * // Styles as object usage
@@ -3122,20 +2754,16 @@
  * }
  */
 
-  function buttons() {
-    for (
-      var _len = arguments.length, states = Array(_len), _key = 0;
-      _key < _len;
-      _key++
-    ) {
-      states[_key] = arguments[_key]
-    }
-
-    return statefulSelectors(states, template, stateMap)
+function buttons() {
+  for (var _len = arguments.length, states = Array(_len), _key = 0; _key < _len; _key++) {
+    states[_key] = arguments[_key];
   }
 
-  //
-  /**
+  return statefulSelectors(states, template, stateMap);
+}
+
+//      
+/**
  * The margin shorthand accepts up to four values, including null to skip a value, and uses the directional-property mixin to map them to their respective directions.
  * @example
  * // Styles as object usage
@@ -3158,20 +2786,16 @@
  * }
  */
 
-  function margin() {
-    for (
-      var _len = arguments.length, values = Array(_len), _key = 0;
-      _key < _len;
-      _key++
-    ) {
-      values[_key] = arguments[_key]
-    }
-
-    return directionalProperty(...['margin'].concat(values))
+function margin() {
+  for (var _len = arguments.length, values = Array(_len), _key = 0; _key < _len; _key++) {
+    values[_key] = arguments[_key];
   }
 
-  //
-  /**
+  return directionalProperty.apply(undefined, ['margin'].concat(values));
+}
+
+//      
+/**
  * The padding shorthand accepts up to four values, including null to skip a value, and uses the directional-property mixin to map them to their respective directions.
  * @example
  * // Styles as object usage
@@ -3194,22 +2818,18 @@
  * }
  */
 
-  function padding() {
-    for (
-      var _len = arguments.length, values = Array(_len), _key = 0;
-      _key < _len;
-      _key++
-    ) {
-      values[_key] = arguments[_key]
-    }
-
-    return directionalProperty(...['padding'].concat(values))
+function padding() {
+  for (var _len = arguments.length, values = Array(_len), _key = 0; _key < _len; _key++) {
+    values[_key] = arguments[_key];
   }
 
-  //
-  const positionMap$1 = ['absolute', 'fixed', 'relative', 'static', 'sticky']
+  return directionalProperty.apply(undefined, ['padding'].concat(values));
+}
 
-  /**
+//      
+var positionMap$1 = ['absolute', 'fixed', 'relative', 'static', 'sticky'];
+
+/**
  * The position shorthand accepts up to five values, including null to skip a value, and uses the directional-property mixin to map them to their respective directions. The first calue can optionally be a position keyword.
  * @example
  * // Styles as object usage
@@ -3252,33 +2872,24 @@
  * }
  */
 
-  function position(positionKeyword) {
-    for (
-      var _len = arguments.length,
-        values = Array(_len > 1 ? _len - 1 : 0),
-        _key = 1;
-      _key < _len;
-      _key++
-    ) {
-      values[_key - 1] = arguments[_key]
-    }
-
-    if (positionMap$1.indexOf(positionKeyword) >= 0) {
-      return _extends(
-        {
-          position: positionKeyword,
-        },
-        directionalProperty(...[''].concat(values)),
-      )
-    } else {
-      const firstValue = positionKeyword // in this case position is actually the first value
-      return directionalProperty(...['', firstValue].concat(values))
-    }
+function position(positionKeyword) {
+  for (var _len = arguments.length, values = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+    values[_key - 1] = arguments[_key];
   }
 
-  //
+  if (positionMap$1.indexOf(positionKeyword) >= 0) {
+    return _extends({
+      position: positionKeyword
+    }, directionalProperty.apply(undefined, [''].concat(values)));
+  } else {
+    var firstValue = positionKeyword; // in this case position is actually the first value
+    return directionalProperty.apply(undefined, ['', firstValue].concat(values));
+  }
+}
 
-  /**
+//      
+
+/**
  * Mixin to set the height and width properties in a single statement.
  * @example
  * // Styles as object usage
@@ -3299,60 +2910,25 @@
  * }
  */
 
-  function size(height) {
-    const width = arguments.length > 1 && arguments[1] !== undefined
-      ? arguments[1]
-      : height
+function size(height) {
+  var width = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : height;
 
-    return {
-      height,
-      width,
-    }
-  }
+  return {
+    height: height,
+    width: width
+  };
+}
 
-  //
-  const stateMap$1 = [undefined, null, 'active', 'focus', 'hover']
+//      
+var stateMap$1 = [undefined, null, 'active', 'focus', 'hover'];
 
-  function template$1(state) {
-    return (
-      `input[type="color"]${
-      state
-      },\n    input[type="date"]${
-      state
-      },\n    input[type="datetime"]${
-      state
-      },\n    input[type="datetime-local"]${
-      state
-      },\n    input[type="email"]${
-      state
-      },\n    input[type="month"]${
-      state
-      },\n    input[type="number"]${
-      state
-      },\n    input[type="password"]${
-      state
-      },\n    input[type="search"]${
-      state
-      },\n    input[type="tel"]${
-      state
-      },\n    input[type="text"]${
-      state
-      },\n    input[type="time"]${
-      state
-      },\n    input[type="url"]${
-      state
-      },\n    input[type="week"]${
-      state
-      },\n    input:not([type])${
-      state
-      },\n    textarea${
-      state}`
-    )
-  }
+function template$1(state) {
+  return 'input[type="color"]' + state + ',\n    input[type="date"]' + state + ',\n    input[type="datetime"]' + state + ',\n    input[type="datetime-local"]' + state + ',\n    input[type="email"]' + state + ',\n    input[type="month"]' + state + ',\n    input[type="number"]' + state + ',\n    input[type="password"]' + state + ',\n    input[type="search"]' + state + ',\n    input[type="tel"]' + state + ',\n    input[type="text"]' + state + ',\n    input[type="time"]' + state + ',\n    input[type="url"]' + state + ',\n    input[type="week"]' + state + ',\n    input:not([type])' + state + ',\n    textarea' + state;
+}
 
-  /** */
+/** */
 
-  /**
+/**
  * Populates selectors that target all text inputs. You can pass optional states to append to the selectors.
  * @example
  * // Styles as object usage
@@ -3391,21 +2967,17 @@
  * }
  */
 
-  function textInputs() {
-    for (
-      var _len = arguments.length, states = Array(_len), _key = 0;
-      _key < _len;
-      _key++
-    ) {
-      states[_key] = arguments[_key]
-    }
-
-    return statefulSelectors(states, template$1, stateMap$1)
+function textInputs() {
+  for (var _len = arguments.length, states = Array(_len), _key = 0; _key < _len; _key++) {
+    states[_key] = arguments[_key];
   }
 
-  //
+  return statefulSelectors(states, template$1, stateMap$1);
+}
 
-  /**
+//      
+
+/**
  * The transitions shorthand accepts any number of transition values as parameters for creating a single transition statement..
  * @example
  * // Styles as object usage
@@ -3425,81 +2997,78 @@
  * }
  */
 
-  function transitions() {
-    for (
-      var _len = arguments.length, properties = Array(_len), _key = 0;
-      _key < _len;
-      _key++
-    ) {
-      properties[_key] = arguments[_key]
-    }
-
-    return {
-      transition: properties.join(', '),
-    }
+function transitions() {
+  for (var _len = arguments.length, properties = Array(_len), _key = 0; _key < _len; _key++) {
+    properties[_key] = arguments[_key];
   }
 
-  //
-  // Helpers
-  // Mixins
-  // Color
-  // Shorthands
+  return {
+    transition: properties.join(', ')
+  };
+}
 
-  exports.adjustHue = adjustHue$1
-  exports.animation = animation
-  exports.backgroundImages = backgroundImages
-  exports.backgrounds = backgrounds
-  exports.borderColor = borderColor
-  exports.borderRadius = borderRadius
-  exports.borderStyle = borderStyle
-  exports.borderWidth = borderWidth
-  exports.buttons = buttons
-  exports.clearFix = clearFix
-  exports.complement = complement
-  exports.darken = darken$1
-  exports.desaturate = desaturate$1
-  exports.directionalProperty = directionalProperty
-  exports.ellipsis = ellipsis
-  exports.em = em
-  exports.fontFace = fontFace
-  exports.grayscale = grayscale
-  exports.invert = invert
-  exports.hideText = hideText
-  exports.hiDPI = hiDPI
-  exports.hsl = hsl
-  exports.hsla = hsla
-  exports.lighten = lighten$1
-  exports.margin = margin
-  exports.mix = mix$1
-  exports.modularScale = modularScale
-  exports.normalize = normalize
-  exports.opacify = opacify$1
-  exports.padding = padding
-  exports.parseToHsl = parseToHsl
-  exports.parseToRgb = parseToRgb
-  exports.placeholder = placeholder
-  exports.position = position
-  exports.radialGradient = radialGradient
-  exports.rem = rem
-  exports.retinaImage = retinaImage
-  exports.rgb = rgb
-  exports.rgba = rgba
-  exports.saturate = saturate$1
-  exports.selection = selection
-  exports.setHue = setHue$1
-  exports.setLightness = setLightness$1
-  exports.setSaturation = setSaturation$1
-  exports.shade = shade$1
-  exports.size = size
-  exports.stripUnit = stripUnit
-  exports.textInputs = textInputs
-  exports.timingFunctions = timingFunctions
-  exports.tint = tint$1
-  exports.toColorString = toColorString
-  exports.transitions = transitions
-  exports.transparentize = transparentize$1
-  exports.triangle = triangle
-  exports.wordWrap = wordWrap
+//      
+// Helpers
+// Mixins
+// Color
+// Shorthands
 
-  Object.defineProperty(exports, '__esModule', { value: true })
-}))
+exports.adjustHue = adjustHue$1;
+exports.animation = animation;
+exports.backgroundImages = backgroundImages;
+exports.backgrounds = backgrounds;
+exports.borderColor = borderColor;
+exports.borderRadius = borderRadius;
+exports.borderStyle = borderStyle;
+exports.borderWidth = borderWidth;
+exports.buttons = buttons;
+exports.clearFix = clearFix;
+exports.complement = complement;
+exports.darken = darken$1;
+exports.desaturate = desaturate$1;
+exports.directionalProperty = directionalProperty;
+exports.ellipsis = ellipsis;
+exports.em = em;
+exports.fontFace = fontFace;
+exports.grayscale = grayscale;
+exports.invert = invert;
+exports.hideText = hideText;
+exports.hiDPI = hiDPI;
+exports.hsl = hsl;
+exports.hsla = hsla;
+exports.lighten = lighten$1;
+exports.margin = margin;
+exports.mix = mix$1;
+exports.modularScale = modularScale;
+exports.normalize = normalize;
+exports.opacify = opacify$1;
+exports.padding = padding;
+exports.parseToHsl = parseToHsl;
+exports.parseToRgb = parseToRgb;
+exports.placeholder = placeholder;
+exports.position = position;
+exports.radialGradient = radialGradient;
+exports.rem = rem;
+exports.retinaImage = retinaImage;
+exports.rgb = rgb;
+exports.rgba = rgba;
+exports.saturate = saturate$1;
+exports.selection = selection;
+exports.setHue = setHue$1;
+exports.setLightness = setLightness$1;
+exports.setSaturation = setSaturation$1;
+exports.shade = shade$1;
+exports.size = size;
+exports.stripUnit = stripUnit;
+exports.textInputs = textInputs;
+exports.timingFunctions = timingFunctions;
+exports.tint = tint$1;
+exports.toColorString = toColorString;
+exports.transitions = transitions;
+exports.transparentize = transparentize$1;
+exports.triangle = triangle;
+exports.wordWrap = wordWrap;
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+})));

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -335,6 +335,16 @@
             
               
               <li><a
+                href='#readablecolor'
+                class="">
+                readableColor
+                
+              </a>
+              
+              </li>
+            
+              
+              <li><a
                 href='#rgb'
                 class="">
                 rgb
@@ -745,16 +755,6 @@
             
               
               <li><a
-                href='#readablecolor'
-                class="">
-                readableColor
-                
-              </a>
-              
-              </li>
-            
-              
-              <li><a
                 href='#tocolorstring'
                 class="">
                 toColorString
@@ -855,7 +855,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/clearFix.js#L26-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/mixins/clearFix.js#L26-L35'>
       <span>src/mixins/clearFix.js</span>
       </a>
     
@@ -941,7 +941,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/ellipsis.js#L29-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/mixins/ellipsis.js#L29-L38'>
       <span>src/mixins/ellipsis.js</span>
       </a>
     
@@ -1030,7 +1030,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/fontFace.js#L72-L111'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/mixins/fontFace.js#L72-L111'>
       <span>src/mixins/fontFace.js</span>
       </a>
     
@@ -1192,7 +1192,7 @@ injectGlobal`${
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/hiDPI.js#L32-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/mixins/hiDPI.js#L32-L40'>
       <span>src/mixins/hiDPI.js</span>
       </a>
     
@@ -1284,7 +1284,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/hideText.js#L29-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/mixins/hideText.js#L29-L35'>
       <span>src/mixins/hideText.js</span>
       </a>
     
@@ -1359,7 +1359,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/normalize.js#L291-L294'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/mixins/normalize.js#L291-L294'>
       <span>src/mixins/normalize.js</span>
       </a>
     
@@ -1443,7 +1443,7 @@ html {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/placeholder.js#L35-L50'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/mixins/placeholder.js#L35-L50'>
       <span>src/mixins/placeholder.js</span>
       </a>
     
@@ -1546,7 +1546,7 @@ const div = styled.input`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/radialGradient.js#L78-L94'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/mixins/radialGradient.js#L78-L94'>
       <span>src/mixins/radialGradient.js</span>
       </a>
     
@@ -1686,7 +1686,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/retinaImage.js#L33-L58'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/mixins/retinaImage.js#L33-L58'>
       <span>src/mixins/retinaImage.js</span>
       </a>
     
@@ -1811,7 +1811,7 @@ a _2x.png filename suffix by default.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/selection.js#L31-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/mixins/selection.js#L31-L40'>
       <span>src/mixins/selection.js</span>
       </a>
     
@@ -1910,7 +1910,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/timingFunctions.js#L82-L84'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/mixins/timingFunctions.js#L82-L84'>
       <span>src/mixins/timingFunctions.js</span>
       </a>
     
@@ -1993,7 +1993,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/wordWrap.js#L26-L33'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/mixins/wordWrap.js#L26-L33'>
       <span>src/mixins/wordWrap.js</span>
       </a>
     
@@ -2091,7 +2091,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/adjustHue.js#L31-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/color/adjustHue.js#L31-L37'>
       <span>src/color/adjustHue.js</span>
       </a>
     
@@ -2191,7 +2191,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/complement.js#L28-L34'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/color/complement.js#L28-L34'>
       <span>src/color/complement.js</span>
       </a>
     
@@ -2281,7 +2281,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/darken.js#L31-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/color/darken.js#L31-L37'>
       <span>src/color/darken.js</span>
       </a>
     
@@ -2380,7 +2380,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/desaturate.js#L32-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/color/desaturate.js#L32-L38'>
       <span>src/color/desaturate.js</span>
       </a>
     
@@ -2480,7 +2480,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/grayscale.js#L28-L33'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/color/grayscale.js#L28-L33'>
       <span>src/color/grayscale.js</span>
       </a>
     
@@ -2570,7 +2570,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/hsl.js#L29-L51'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/color/hsl.js#L29-L51'>
       <span>src/color/hsl.js</span>
       </a>
     
@@ -2677,7 +2677,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/hsla.js#L33-L62'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/color/hsla.js#L33-L62'>
       <span>src/color/hsla.js</span>
       </a>
     
@@ -2795,7 +2795,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/invert.js#L29-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/color/invert.js#L29-L38'>
       <span>src/color/invert.js</span>
       </a>
     
@@ -2886,7 +2886,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/lighten.js#L31-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/color/lighten.js#L31-L37'>
       <span>src/color/lighten.js</span>
       </a>
     
@@ -2985,7 +2985,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/mix.js#L38-L68'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/color/mix.js#L38-L68'>
       <span>src/color/mix.js</span>
       </a>
     
@@ -3100,7 +3100,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/opacify.js#L34-L44'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/color/opacify.js#L34-L44'>
       <span>src/color/opacify.js</span>
       </a>
     
@@ -3197,7 +3197,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/parseToHsl.js#L18-L22'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/color/parseToHsl.js#L18-L22'>
       <span>src/color/parseToHsl.js</span>
       </a>
     
@@ -3276,7 +3276,7 @@ const color2 = 'hsla(<span class="hljs-number">210</span>, <span class="hljs-num
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/parseToRgb.js#L25-L93'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/color/parseToRgb.js#L25-L93'>
       <span>src/color/parseToRgb.js</span>
       </a>
     
@@ -3350,12 +3350,107 @@ const color2 = 'hsla(<span class="hljs-number">210</span>, <span class="hljs-num
   
   <div class='clearfix'>
     
+    <h3 class='fl m0' id='readablecolor'>
+      readableColor
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/color/readableColor.js#L37-L42'>
+      <span>src/color/readableColor.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Selects black or white for best contrast depending on the luminosity of the given color.
+Follows W3C specs for readability at <a href="https://www.w3.org/TR/WCAG20-TECHS/G18.html">https://www.w3.org/TR/WCAG20-TECHS/G18.html</a></p>
+
+
+  <div class='pre p1 fill-light mt0'>readableColor(color: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
+  
+  
+
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>color</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+	    
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
+    
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
+<span class="hljs-keyword">const</span> styles = {
+  <span class="hljs-built_in">color</span>: readableColor(<span class="hljs-string">'#000'</span>),
+  <span class="hljs-built_in">color</span>: readableColor(<span class="hljs-string">'papayawhip'</span>),
+  <span class="hljs-built_in">color</span>: readableColor(<span class="hljs-string">'rgb(255,0,0)'</span>),
+}
+
+<span class="hljs-comment">// styled-components usage</span>
+<span class="hljs-keyword">const</span> div = styled.div`
+  <span class="hljs-built_in">color</span>: ${readableColor(<span class="hljs-string">'#000'</span>)};
+  <span class="hljs-built_in">color</span>: ${readableColor(<span class="hljs-string">'papayawhip'</span>)};
+  <span class="hljs-built_in">color</span>: ${readableColor(<span class="hljs-string">'rgb(255,0,0)'</span>)};
+`
+
+<span class="hljs-comment">// CSS in JS Output</span>
+
+element {
+  <span class="hljs-built_in">color</span>: <span class="hljs-string">"#fff"</span>;
+  <span class="hljs-built_in">color</span>: <span class="hljs-string">"#fff"</span>;
+  <span class="hljs-built_in">color</span>: <span class="hljs-string">"#000"</span>;
+}</pre>
+    
+  
+
+  
+
+  
+
+  
+</section>
+
+        
+      
+        
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
     <h3 class='fl m0' id='rgb'>
       rgb
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/rgb.js#L30-L50'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/color/rgb.js#L30-L50'>
       <span>src/color/rgb.js</span>
       </a>
     
@@ -3462,7 +3557,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/rgba.js#L32-L61'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/color/rgba.js#L32-L61'>
       <span>src/color/rgba.js</span>
       </a>
     
@@ -3580,7 +3675,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/saturate.js#L33-L39'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/color/saturate.js#L33-L39'>
       <span>src/color/saturate.js</span>
       </a>
     
@@ -3681,7 +3776,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/setHue.js#L30-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/color/setHue.js#L30-L35'>
       <span>src/color/setHue.js</span>
       </a>
     
@@ -3780,7 +3875,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/setLightness.js#L30-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/color/setLightness.js#L30-L35'>
       <span>src/color/setLightness.js</span>
       </a>
     
@@ -3879,7 +3974,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/setSaturation.js#L30-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/color/setSaturation.js#L30-L35'>
       <span>src/color/setSaturation.js</span>
       </a>
     
@@ -3978,7 +4073,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/shade.js#L29-L41'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/color/shade.js#L29-L41'>
       <span>src/color/shade.js</span>
       </a>
     
@@ -4071,7 +4166,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/tint.js#L29-L41'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/color/tint.js#L29-L41'>
       <span>src/color/tint.js</span>
       </a>
     
@@ -4164,7 +4259,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/transparentize.js#L34-L44'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/color/transparentize.js#L34-L44'>
       <span>src/color/transparentize.js</span>
       </a>
     
@@ -4273,7 +4368,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/animation.js#L42-L75'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/shorthands/animation.js#L42-L75'>
       <span>src/shorthands/animation.js</span>
       </a>
     
@@ -4374,7 +4469,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/backgroundImages.js#L23-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/shorthands/backgroundImages.js#L23-L27'>
       <span>src/shorthands/backgroundImages.js</span>
       </a>
     
@@ -4457,7 +4552,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/backgrounds.js#L22-L26'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/shorthands/backgrounds.js#L22-L26'>
       <span>src/shorthands/backgrounds.js</span>
       </a>
     
@@ -4540,7 +4635,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/borderColor.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/shorthands/borderColor.js#L27-L29'>
       <span>src/shorthands/borderColor.js</span>
       </a>
     
@@ -4626,7 +4721,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/borderRadius.js#L24-L47'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/shorthands/borderRadius.js#L24-L47'>
       <span>src/shorthands/borderRadius.js</span>
       </a>
     
@@ -4718,7 +4813,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/borderStyle.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/shorthands/borderStyle.js#L27-L29'>
       <span>src/shorthands/borderStyle.js</span>
       </a>
     
@@ -4804,7 +4899,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/borderWidth.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/shorthands/borderWidth.js#L27-L29'>
       <span>src/shorthands/borderWidth.js</span>
       </a>
     
@@ -4890,7 +4985,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/buttons.js#L43-L45'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/shorthands/buttons.js#L43-L45'>
       <span>src/shorthands/buttons.js</span>
       </a>
     
@@ -4980,7 +5075,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/margin.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/shorthands/margin.js#L27-L29'>
       <span>src/shorthands/margin.js</span>
       </a>
     
@@ -5066,7 +5161,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/padding.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/shorthands/padding.js#L27-L29'>
       <span>src/shorthands/padding.js</span>
       </a>
     
@@ -5152,7 +5247,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/position.js#L49-L59'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/shorthands/position.js#L49-L59'>
       <span>src/shorthands/position.js</span>
       </a>
     
@@ -5266,7 +5361,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/size.js#L24-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/shorthands/size.js#L24-L29'>
       <span>src/shorthands/size.js</span>
       </a>
     
@@ -5359,7 +5454,7 @@ const <span class="hljs-keyword">div</span> = styled.<span class="hljs-keyword">
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/textInputs.js#L67-L69'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/shorthands/textInputs.js#L67-L69'>
       <span>src/shorthands/textInputs.js</span>
       </a>
     
@@ -5461,7 +5556,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/transitions.js#L23-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/shorthands/transitions.js#L23-L27'>
       <span>src/shorthands/transitions.js</span>
       </a>
     
@@ -5556,7 +5651,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/helpers/directionalProperty.js#L44-L50'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/helpers/directionalProperty.js#L44-L50'>
       <span>src/helpers/directionalProperty.js</span>
       </a>
     
@@ -5650,7 +5745,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/helpers/em.js#L29-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/helpers/em.js#L29-L29'>
       <span>src/helpers/em.js</span>
       </a>
     
@@ -5743,7 +5838,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/helpers/modularScale.js#L67-L93'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/helpers/modularScale.js#L67-L93'>
       <span>src/helpers/modularScale.js</span>
       </a>
     
@@ -5846,7 +5941,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/helpers/rem.js#L28-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/helpers/rem.js#L28-L28'>
       <span>src/helpers/rem.js</span>
       </a>
     
@@ -5939,7 +6034,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/helpers/stripUnit.js#L24-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/helpers/stripUnit.js#L24-L28'>
       <span>src/helpers/stripUnit.js</span>
       </a>
     
@@ -6039,7 +6134,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/animation.js#L4-L4'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/shorthands/animation.js#L4-L4'>
       <span>src/shorthands/animation.js</span>
       </a>
     
@@ -6093,7 +6188,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/buttons.js#L14-L14'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/shorthands/buttons.js#L14-L14'>
       <span>src/shorthands/buttons.js</span>
       </a>
     
@@ -6147,7 +6242,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/fontFace.js#L4-L14'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/mixins/fontFace.js#L4-L14'>
       <span>src/mixins/fontFace.js</span>
       </a>
     
@@ -6260,7 +6355,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/types/color.js#L11-L15'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/types/color.js#L11-L15'>
       <span>src/types/color.js</span>
       </a>
     
@@ -6337,7 +6432,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/types/color.js#L23-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/types/color.js#L23-L28'>
       <span>src/types/color.js</span>
       </a>
     
@@ -6420,7 +6515,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/textInputs.js#L26-L26'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/shorthands/textInputs.js#L26-L26'>
       <span>src/shorthands/textInputs.js</span>
       </a>
     
@@ -6474,7 +6569,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/triangle.js#L4-L4'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/mixins/triangle.js#L4-L4'>
       <span>src/mixins/triangle.js</span>
       </a>
     
@@ -6528,7 +6623,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/radialGradient.js#L4-L10'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/mixins/radialGradient.js#L4-L10'>
       <span>src/mixins/radialGradient.js</span>
       </a>
     
@@ -6617,7 +6712,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/types/color.js#L47-L52'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/types/color.js#L47-L52'>
       <span>src/types/color.js</span>
       </a>
     
@@ -6700,7 +6795,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/types/color.js#L35-L39'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/types/color.js#L35-L39'>
       <span>src/types/color.js</span>
       </a>
     
@@ -6772,107 +6867,12 @@ element {
   
   <div class='clearfix'>
     
-    <h3 class='fl m0' id='readablecolor'>
-      readableColor
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/readableColor.js#L41-L48'>
-      <span>src/color/readableColor.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>Selects black or white or best contrast depending on the luminosity of the supplied color.
-Follows W3C specs for readability at <a href="https://www.w3.org/TR/WCAG20-TECHS/G18.html">https://www.w3.org/TR/WCAG20-TECHS/G18.html</a></p>
-
-
-  <div class='pre p1 fill-light mt0'>readableColor(color: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
-
-  
-  
-  
-  
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Parameters</div>
-    <div class='prose'>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>color</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-    
-      <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
-    
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
-      <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
-<span class="hljs-keyword">const</span> styles = {
-  <span class="hljs-built_in">color</span>: readableColor(<span class="hljs-string">'#000'</span>),
-  <span class="hljs-built_in">color</span>: readableColor(<span class="hljs-string">'papayawhip'</span>),
-  <span class="hljs-built_in">color</span>: readableColor(<span class="hljs-string">'rgb(255,0,0)'</span>),
-}
-
-<span class="hljs-comment">// styled-components usage</span>
-<span class="hljs-keyword">const</span> div = styled.div`
-  <span class="hljs-built_in">color</span>: ${readableColor(<span class="hljs-string">'#000'</span>)};
-  <span class="hljs-built_in">color</span>: ${readableColor(<span class="hljs-string">'papayawhip'</span>)};
-  <span class="hljs-built_in">color</span>: ${readableColor(<span class="hljs-string">'rgb(255,0,0)'</span>)};
-`
-
-<span class="hljs-comment">// CSS in JS Output</span>
-
-element {
-  <span class="hljs-built_in">color</span>: <span class="hljs-string">"#fff"</span>;
-  <span class="hljs-built_in">color</span>: <span class="hljs-string">"#fff"</span>;
-  <span class="hljs-built_in">color</span>: <span class="hljs-string">"#000"</span>;
-}</pre>
-    
-  
-
-  
-
-  
-
-  
-</section>
-
-        
-      
-        
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
     <h3 class='fl m0' id='tocolorstring'>
       toColorString
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/toColorString.js#L71-L90'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/color/toColorString.js#L71-L90'>
       <span>src/color/toColorString.js</span>
       </a>
     
@@ -6970,7 +6970,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/helpers/modularScale.js#L5-L23'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/helpers/modularScale.js#L5-L23'>
       <span>src/helpers/modularScale.js</span>
       </a>
     
@@ -7019,7 +7019,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/timingFunctions.js#L4-L31'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/mixins/timingFunctions.js#L4-L31'>
       <span>src/mixins/timingFunctions.js</span>
       </a>
     
@@ -7068,7 +7068,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/triangle.js#L37-L42'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/af0b2e83020aa555978127ff18569fed794bcde2/src/mixins/triangle.js#L37-L42'>
       <span>src/mixins/triangle.js</span>
       </a>
     

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -185,16 +185,6 @@
             
               
               <li><a
-                href='#triangle'
-                class="">
-                triangle
-                
-              </a>
-              
-              </li>
-            
-              
-              <li><a
                 href='#wordwrap'
                 class="">
                 wordWrap
@@ -735,16 +725,6 @@
             
               
               <li><a
-                href='#ratio'
-                class="">
-                Ratio
-                
-              </a>
-              
-              </li>
-            
-              
-              <li><a
                 href='#rgbacolor'
                 class="">
                 RgbaColor
@@ -765,9 +745,9 @@
             
               
               <li><a
-                href='#timingfunction'
+                href='#readablecolor'
                 class="">
-                TimingFunction
+                readableColor
                 
               </a>
               
@@ -778,6 +758,36 @@
                 href='#tocolorstring'
                 class="">
                 toColorString
+                
+              </a>
+              
+              </li>
+            
+              
+              <li><a
+                href='#undefined'
+                class="">
+                
+                
+              </a>
+              
+              </li>
+            
+              
+              <li><a
+                href='#undefined'
+                class="">
+                
+                
+              </a>
+              
+              </li>
+            
+              
+              <li><a
+                href='#undefined'
+                class="">
+                
                 
               </a>
               
@@ -845,7 +855,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/mixins/clearFix.js#L26-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/clearFix.js#L26-L35'>
       <span>src/mixins/clearFix.js</span>
       </a>
     
@@ -855,7 +865,7 @@
   <p>CSS to contain a float (credit to CSSMojo).</p>
 
 
-  <div class='pre p1 fill-light mt0'>clearFix(parent: [<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>])</div>
+  <div class='pre p1 fill-light mt0'>clearFix(parent: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</div>
   
   
 
@@ -871,7 +881,7 @@
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>parent</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>]
+            <span class='code bold'>parent</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?
             = <code>&#39;&amp;&#39;</code>)</code>
 	    
           </div>
@@ -931,7 +941,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/mixins/ellipsis.js#L29-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/ellipsis.js#L29-L38'>
       <span>src/mixins/ellipsis.js</span>
       </a>
     
@@ -941,7 +951,7 @@
   <p>CSS to represent truncated text with an ellipsis.</p>
 
 
-  <div class='pre p1 fill-light mt0'>ellipsis(width: [<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>])</div>
+  <div class='pre p1 fill-light mt0'>ellipsis(width: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</div>
   
   
 
@@ -957,7 +967,7 @@
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>width</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>]
+            <span class='code bold'>width</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?
             = <code>&#39;100%&#39;</code>)</code>
 	    
           </div>
@@ -1020,7 +1030,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/mixins/fontFace.js#L72-L111'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/fontFace.js#L72-L111'>
       <span>src/mixins/fontFace.js</span>
       </a>
     
@@ -1064,43 +1074,43 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
             <tbody class='mt1'>
               
                 <tr>
-                  <td class='break-word'><span class='code bold'>$0.fontFamily</span> <code class='quiet'>Any</code>
+                  <td class='break-word'><span class='code bold'>$0.fontFamily</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
               
                 <tr>
-                  <td class='break-word'><span class='code bold'>$0.fontFilePath</span> <code class='quiet'>Any</code>
+                  <td class='break-word'><span class='code bold'>$0.fontFilePath</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
               
                 <tr>
-                  <td class='break-word'><span class='code bold'>$0.fontStretch</span> <code class='quiet'>Any</code>
+                  <td class='break-word'><span class='code bold'>$0.fontStretch</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
               
                 <tr>
-                  <td class='break-word'><span class='code bold'>$0.fontStyle</span> <code class='quiet'>Any</code>
+                  <td class='break-word'><span class='code bold'>$0.fontStyle</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
               
                 <tr>
-                  <td class='break-word'><span class='code bold'>$0.fontVariant</span> <code class='quiet'>Any</code>
+                  <td class='break-word'><span class='code bold'>$0.fontVariant</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
               
                 <tr>
-                  <td class='break-word'><span class='code bold'>$0.fontWeight</span> <code class='quiet'>Any</code>
+                  <td class='break-word'><span class='code bold'>$0.fontWeight</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
               
                 <tr>
-                  <td class='break-word'><span class='code bold'>$0.fileFormats</span> <code class='quiet'>Any</code>
+                  <td class='break-word'><span class='code bold'>$0.fileFormats</span> <code class='quiet'>any</code>
                   
                     (default <code>[&#39;eot&#39;, &#39;woff2&#39;, &#39;woff&#39;, &#39;ttf&#39;, &#39;svg&#39;]</code>)
                   </td>
@@ -1108,13 +1118,13 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
                 </tr>
               
                 <tr>
-                  <td class='break-word'><span class='code bold'>$0.localFonts</span> <code class='quiet'>Any</code>
+                  <td class='break-word'><span class='code bold'>$0.localFonts</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
               
                 <tr>
-                  <td class='break-word'><span class='code bold'>$0.unicodeRange</span> <code class='quiet'>Any</code>
+                  <td class='break-word'><span class='code bold'>$0.unicodeRange</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
@@ -1182,7 +1192,7 @@ injectGlobal`${
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/mixins/hiDPI.js#L32-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/hiDPI.js#L32-L40'>
       <span>src/mixins/hiDPI.js</span>
       </a>
     
@@ -1192,7 +1202,7 @@ injectGlobal`${
   <p>Generates a media query to target HiDPI devices.</p>
 
 
-  <div class='pre p1 fill-light mt0'>hiDPI(ratio: [<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>])</div>
+  <div class='pre p1 fill-light mt0'>hiDPI(ratio: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?)</div>
   
   
 
@@ -1208,7 +1218,7 @@ injectGlobal`${
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>ratio</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>]
+            <span class='code bold'>ratio</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?
             = <code>1.3</code>)</code>
 	    
           </div>
@@ -1274,7 +1284,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/mixins/hideText.js#L29-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/hideText.js#L29-L35'>
       <span>src/mixins/hideText.js</span>
       </a>
     
@@ -1349,7 +1359,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/mixins/normalize.js#L291-L294'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/normalize.js#L291-L294'>
       <span>src/mixins/normalize.js</span>
       </a>
     
@@ -1433,7 +1443,7 @@ html {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/mixins/placeholder.js#L35-L50'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/placeholder.js#L35-L50'>
       <span>src/mixins/placeholder.js</span>
       </a>
     
@@ -1443,7 +1453,7 @@ html {
   <p>CSS to style the selection psuedo-element.</p>
 
 
-  <div class='pre p1 fill-light mt0'>placeholder(styles: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>, parent: [<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>])</div>
+  <div class='pre p1 fill-light mt0'>placeholder(styles: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>, parent: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</div>
   
   
 
@@ -1467,7 +1477,7 @@ html {
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>parent</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>]
+            <span class='code bold'>parent</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?
             = <code>&#39;&amp;&#39;</code>)</code>
 	    
           </div>
@@ -1536,7 +1546,7 @@ const div = styled.input`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/mixins/radialGradient.js#L78-L94'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/radialGradient.js#L78-L94'>
       <span>src/mixins/radialGradient.js</span>
       </a>
     
@@ -1580,31 +1590,31 @@ const div = styled.input`
             <tbody class='mt1'>
               
                 <tr>
-                  <td class='break-word'><span class='code bold'>$0.colorStops</span> <code class='quiet'>Any</code>
+                  <td class='break-word'><span class='code bold'>$0.colorStops</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
               
                 <tr>
-                  <td class='break-word'><span class='code bold'>$0.extent</span> <code class='quiet'>Any</code>
+                  <td class='break-word'><span class='code bold'>$0.extent</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
               
                 <tr>
-                  <td class='break-word'><span class='code bold'>$0.fallback</span> <code class='quiet'>Any</code>
+                  <td class='break-word'><span class='code bold'>$0.fallback</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
               
                 <tr>
-                  <td class='break-word'><span class='code bold'>$0.position</span> <code class='quiet'>Any</code>
+                  <td class='break-word'><span class='code bold'>$0.position</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
               
                 <tr>
-                  <td class='break-word'><span class='code bold'>$0.shape</span> <code class='quiet'>Any</code>
+                  <td class='break-word'><span class='code bold'>$0.shape</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
@@ -1676,7 +1686,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/mixins/retinaImage.js#L33-L58'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/retinaImage.js#L33-L58'>
       <span>src/mixins/retinaImage.js</span>
       </a>
     
@@ -1688,7 +1698,7 @@ background image. The retina background image will output to a HiDPI media query
 a _2x.png filename suffix by default.</p>
 
 
-  <div class='pre p1 fill-light mt0'>retinaImage(filename: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, backgroundSize: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, extension: [<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>], retinaFilename: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, retinaSuffix: [<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>])</div>
+  <div class='pre p1 fill-light mt0'>retinaImage(filename: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, backgroundSize: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, extension: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?, retinaFilename: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, retinaSuffix: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</div>
   
   
 
@@ -1720,7 +1730,7 @@ a _2x.png filename suffix by default.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>extension</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>]
+            <span class='code bold'>extension</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?
             = <code>&#39;png&#39;</code>)</code>
 	    
           </div>
@@ -1737,7 +1747,7 @@ a _2x.png filename suffix by default.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>retinaSuffix</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>]
+            <span class='code bold'>retinaSuffix</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?
             = <code>&#39;_2x&#39;</code>)</code>
 	    
           </div>
@@ -1757,24 +1767,24 @@ a _2x.png filename suffix by default.</p>
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
+      <pre class='p1 overflow-auto round fill-light'>// <span class="hljs-type">Styles</span> <span class="hljs-keyword">as</span> <span class="hljs-keyword">object</span> usage
 <span class="hljs-keyword">const</span> styles = {
- ...retinaImage(<span class="hljs-string">'my-img'</span>)
+ ...retinaImage('my-img')
 }
 
-<span class="hljs-comment">// styled-components usage</span>
-<span class="hljs-keyword">const</span> div = styled.div`
-  ${retinaImage(<span class="hljs-string">'my-img'</span>)}
+// styled-components usage
+<span class="hljs-keyword">const</span> <span class="hljs-keyword">div</span> = styled.<span class="hljs-keyword">div</span>`
+  ${retinaImage('my-img')}
 `
 
-<span class="hljs-comment">// CSS as JS Output</span>
-div {
+// <span class="hljs-type">CSS</span> <span class="hljs-keyword">as</span> <span class="hljs-type">JS</span> <span class="hljs-type">Output</span>
+<span class="hljs-keyword">div</span> {
   backgroundImage: 'url(my-img.png)',
-  '@media only screen and (-webkit-min-device-pixel-ratio: 1.3),
-   only screen and (min--moz-device-pixel-ratio: 1.3),
-   only screen and (-o-min-device-pixel-ratio: 1.3/1),
-   only screen and (min-resolution: 144dpi),
-   only screen and (min-resolution: 1.5dppx)': {
+  '@media only screen <span class="hljs-keyword">and</span> (-webkit-min-device-pixel-ratio: <span class="hljs-number">1</span>.<span class="hljs-number">3</span>),
+   only screen <span class="hljs-keyword">and</span> (min--moz-device-pixel-ratio: <span class="hljs-number">1</span>.<span class="hljs-number">3</span>),
+   only screen <span class="hljs-keyword">and</span> (-o-min-device-pixel-ratio: <span class="hljs-number">1</span>.<span class="hljs-number">3</span>/<span class="hljs-number">1</span>),
+   only screen <span class="hljs-keyword">and</span> (min-resolution: <span class="hljs-number">144</span>dpi),
+   only screen <span class="hljs-keyword">and</span> (min-resolution: <span class="hljs-number">1</span>.<span class="hljs-number">5</span>dppx)': {
     backgroundImage: 'url(my-img_2x.png)',
   }
 }</pre>
@@ -1801,7 +1811,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/mixins/selection.js#L31-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/selection.js#L31-L40'>
       <span>src/mixins/selection.js</span>
       </a>
     
@@ -1811,7 +1821,7 @@ div {
   <p>CSS to style the selection psuedo-element.</p>
 
 
-  <div class='pre p1 fill-light mt0'>selection(styles: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>, parent: [<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>])</div>
+  <div class='pre p1 fill-light mt0'>selection(styles: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>, parent: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</div>
   
   
 
@@ -1835,7 +1845,7 @@ div {
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>parent</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>]
+            <span class='code bold'>parent</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?
             = <code>&#39;&#39;</code>)</code>
 	    
           </div>
@@ -1900,7 +1910,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/mixins/timingFunctions.js#L82-L84'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/timingFunctions.js#L82-L84'>
       <span>src/mixins/timingFunctions.js</span>
       </a>
     
@@ -1910,7 +1920,7 @@ const div = styled.div`
   <p>String to represent common easing functions as demonstrated here: (github.com/jaukia/easie).</p>
 
 
-  <div class='pre p1 fill-light mt0'>timingFunctions(timingFunction: <a href="#timingfunction">TimingFunction</a>)</div>
+  <div class='pre p1 fill-light mt0'>timingFunctions(timingFunction: TimingFunction)</div>
   
   
 
@@ -1926,7 +1936,7 @@ const div = styled.div`
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>timingFunction</span> <code class='quiet'>(<a href="#timingfunction">TimingFunction</a>)</code>
+            <span class='code bold'>timingFunction</span> <code class='quiet'>(TimingFunction)</code>
 	    
           </div>
           
@@ -1978,150 +1988,12 @@ const div = styled.div`
   
   <div class='clearfix'>
     
-    <h3 class='fl m0' id='triangle'>
-      triangle
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/mixins/triangle.js#L72-L104'>
-      <span>src/mixins/triangle.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>CSS to represent triangle with any pointing direction with an optional background color. Accepts number or px values for height and width.</p>
-
-
-  <div class='pre p1 fill-light mt0'>triangle($0: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</div>
-  
-  
-
-  
-  
-  
-  
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Parameters</div>
-    <div class='prose'>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>$0</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</code>
-	    
-          </div>
-          
-          <table class='mt1 mb2 fixed-table h5 col-12'>
-            <colgroup>
-              <col width='30%' />
-              <col width='70%' />
-            </colgroup>
-            <thead>
-              <tr class='bold fill-light'>
-                <th>Name</th>
-                <th>Description</th>
-              </tr>
-            </thead>
-            <tbody class='mt1'>
-              
-                <tr>
-                  <td class='break-word'><span class='code bold'>$0.pointingDirection</span> <code class='quiet'>Any</code>
-                  </td>
-                  <td class='break-word'><span></span></td>
-                </tr>
-              
-                <tr>
-                  <td class='break-word'><span class='code bold'>$0.height</span> <code class='quiet'>Any</code>
-                  </td>
-                  <td class='break-word'><span></span></td>
-                </tr>
-              
-                <tr>
-                  <td class='break-word'><span class='code bold'>$0.width</span> <code class='quiet'>Any</code>
-                  </td>
-                  <td class='break-word'><span></span></td>
-                </tr>
-              
-                <tr>
-                  <td class='break-word'><span class='code bold'>$0.foregroundColor</span> <code class='quiet'>Any</code>
-                  </td>
-                  <td class='break-word'><span></span></td>
-                </tr>
-              
-                <tr>
-                  <td class='break-word'><span class='code bold'>$0.backgroundColor</span> <code class='quiet'>Any</code>
-                  
-                    (default <code>&#39;transparent&#39;</code>)
-                  </td>
-                  <td class='break-word'><span></span></td>
-                </tr>
-              
-            </tbody>
-          </table>
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
-      <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
-
-const styles = {
-  ...triangle({ <span class="hljs-string">pointingDirection:</span> <span class="hljs-string">'right'</span>, <span class="hljs-string">width:</span> <span class="hljs-string">'100px'</span>, <span class="hljs-string">height:</span> <span class="hljs-string">'100px'</span>, <span class="hljs-string">foregroundColor:</span> <span class="hljs-string">'red'</span> })
-}
-
-
-<span class="hljs-comment">// styled-components usage</span>
-const div = styled.div`
-  ${triangle({ <span class="hljs-string">pointingDirection:</span> <span class="hljs-string">'right'</span>, <span class="hljs-string">width:</span> <span class="hljs-string">'100px'</span>, <span class="hljs-string">height:</span> <span class="hljs-string">'100px'</span>, <span class="hljs-string">foregroundColor:</span> <span class="hljs-string">'red'</span> })}
-
-
-<span class="hljs-comment">// CSS as JS Output</span>
-<span class="hljs-symbol">
-div:</span> {
- <span class="hljs-string">'border-color'</span>: <span class="hljs-string">'transparent'</span>,
- <span class="hljs-string">'border-left-color'</span>: <span class="hljs-string">'red !important'</span>,
- <span class="hljs-string">'border-style'</span>: <span class="hljs-string">'solid'</span>,
- <span class="hljs-string">'border-width'</span>: <span class="hljs-string">'50px 0 50px 100px'</span>,
- <span class="hljs-string">'height'</span>: <span class="hljs-string">'0'</span>,
- <span class="hljs-string">'width'</span>: <span class="hljs-string">'0'</span>,
-}</pre>
-    
-  
-
-  
-
-  
-
-  
-</section>
-
-        
-      
-        
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
     <h3 class='fl m0' id='wordwrap'>
       wordWrap
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/mixins/wordWrap.js#L26-L33'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/wordWrap.js#L26-L33'>
       <span>src/mixins/wordWrap.js</span>
       </a>
     
@@ -2131,7 +2003,7 @@ div:</span> {
   <p>Provides an easy way to change the <code>word-wrap</code> property.</p>
 
 
-  <div class='pre p1 fill-light mt0'>wordWrap(wrap: [<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>])</div>
+  <div class='pre p1 fill-light mt0'>wordWrap(wrap: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</div>
   
   
 
@@ -2147,7 +2019,7 @@ div:</span> {
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>wrap</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>]
+            <span class='code bold'>wrap</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?
             = <code>&#39;break-word&#39;</code>)</code>
 	    
           </div>
@@ -2219,7 +2091,7 @@ div:</span> {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/color/adjustHue.js#L31-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/adjustHue.js#L31-L37'>
       <span>src/color/adjustHue.js</span>
       </a>
     
@@ -2319,7 +2191,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/color/complement.js#L28-L34'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/complement.js#L28-L34'>
       <span>src/color/complement.js</span>
       </a>
     
@@ -2409,7 +2281,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/color/darken.js#L31-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/darken.js#L31-L37'>
       <span>src/color/darken.js</span>
       </a>
     
@@ -2508,7 +2380,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/color/desaturate.js#L32-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/desaturate.js#L32-L38'>
       <span>src/color/desaturate.js</span>
       </a>
     
@@ -2608,7 +2480,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/color/grayscale.js#L28-L33'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/grayscale.js#L28-L33'>
       <span>src/color/grayscale.js</span>
       </a>
     
@@ -2698,7 +2570,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/color/hsl.js#L29-L51'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/hsl.js#L29-L51'>
       <span>src/color/hsl.js</span>
       </a>
     
@@ -2805,7 +2677,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/color/hsla.js#L33-L62'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/hsla.js#L33-L62'>
       <span>src/color/hsla.js</span>
       </a>
     
@@ -2923,7 +2795,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/color/invert.js#L29-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/invert.js#L29-L38'>
       <span>src/color/invert.js</span>
       </a>
     
@@ -3014,7 +2886,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/color/lighten.js#L31-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/lighten.js#L31-L37'>
       <span>src/color/lighten.js</span>
       </a>
     
@@ -3113,7 +2985,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/color/mix.js#L38-L68'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/mix.js#L38-L68'>
       <span>src/color/mix.js</span>
       </a>
     
@@ -3127,7 +2999,7 @@ as the first argument. 0.25 means that a quarter of the first color and three qu
 of the second color should be used.</p>
 
 
-  <div class='pre p1 fill-light mt0'>mix(weight: [<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>], color: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, otherColor: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
+  <div class='pre p1 fill-light mt0'>mix(weight: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?, color: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, otherColor: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
   
   
 
@@ -3143,7 +3015,7 @@ of the second color should be used.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>weight</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>]
+            <span class='code bold'>weight</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?
             = <code>0.5</code>)</code>
 	    
           </div>
@@ -3228,7 +3100,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/color/opacify.js#L34-L44'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/opacify.js#L34-L44'>
       <span>src/color/opacify.js</span>
       </a>
     
@@ -3325,7 +3197,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/color/parseToHsl.js#L18-L22'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/parseToHsl.js#L18-L22'>
       <span>src/color/parseToHsl.js</span>
       </a>
     
@@ -3404,7 +3276,7 @@ const color2 = 'hsla(<span class="hljs-number">210</span>, <span class="hljs-num
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/color/parseToRgb.js#L25-L93'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/parseToRgb.js#L25-L93'>
       <span>src/color/parseToRgb.js</span>
       </a>
     
@@ -3483,7 +3355,7 @@ const color2 = 'hsla(<span class="hljs-number">210</span>, <span class="hljs-num
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/color/rgb.js#L30-L50'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/rgb.js#L30-L50'>
       <span>src/color/rgb.js</span>
       </a>
     
@@ -3590,7 +3462,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/color/rgba.js#L32-L61'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/rgba.js#L32-L61'>
       <span>src/color/rgba.js</span>
       </a>
     
@@ -3708,7 +3580,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/color/saturate.js#L33-L39'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/saturate.js#L33-L39'>
       <span>src/color/saturate.js</span>
       </a>
     
@@ -3809,7 +3681,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/color/setHue.js#L30-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/setHue.js#L30-L35'>
       <span>src/color/setHue.js</span>
       </a>
     
@@ -3908,7 +3780,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/color/setLightness.js#L30-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/setLightness.js#L30-L35'>
       <span>src/color/setLightness.js</span>
       </a>
     
@@ -4007,7 +3879,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/color/setSaturation.js#L30-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/setSaturation.js#L30-L35'>
       <span>src/color/setSaturation.js</span>
       </a>
     
@@ -4106,7 +3978,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/color/shade.js#L29-L41'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/shade.js#L29-L41'>
       <span>src/color/shade.js</span>
       </a>
     
@@ -4115,7 +3987,7 @@ element {
 
   <p>Shades a color by mixing it with black. <code>shade</code> can produce
 hue shifts, where as <code>darken</code> manipulates the luminance channel and therefore
-doesn&#x27;t produce hue shifts.</p>
+doesn't produce hue shifts.</p>
 
 
   <div class='pre p1 fill-light mt0'>shade(percentage: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, color: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</div>
@@ -4199,7 +4071,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/color/tint.js#L29-L41'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/tint.js#L29-L41'>
       <span>src/color/tint.js</span>
       </a>
     
@@ -4208,7 +4080,7 @@ element {
 
   <p>Tints a color by mixing it with white. <code>tint</code> can produce
 hue shifts, where as <code>lighten</code> manipulates the luminance channel and therefore
-doesn&#x27;t produce hue shifts.</p>
+doesn't produce hue shifts.</p>
 
 
   <div class='pre p1 fill-light mt0'>tint(percentage: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, color: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</div>
@@ -4292,7 +4164,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/color/transparentize.js#L34-L44'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/transparentize.js#L34-L44'>
       <span>src/color/transparentize.js</span>
       </a>
     
@@ -4401,7 +4273,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/shorthands/animation.js#L42-L75'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/animation.js#L42-L75'>
       <span>src/shorthands/animation.js</span>
       </a>
     
@@ -4412,7 +4284,7 @@ element {
 or a single animation spread over the arguments.</p>
 
 
-  <div class='pre p1 fill-light mt0'>animation(args: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="#animationproperty">AnimationProperty</a>&gt; | <a href="#animationproperty">AnimationProperty</a>)&gt;)</div>
+  <div class='pre p1 fill-light mt0'>animation(args: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#animationproperty">AnimationProperty</a>> | <a href="#animationproperty">AnimationProperty</a>)>)</div>
   
   
 
@@ -4428,7 +4300,7 @@ or a single animation spread over the arguments.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>args</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="#animationproperty">AnimationProperty</a>&gt; | <a href="#animationproperty">AnimationProperty</a>)&gt;)</code>
+            <span class='code bold'>args</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#animationproperty">AnimationProperty</a>> | <a href="#animationproperty">AnimationProperty</a>)>)</code>
 	    
           </div>
           
@@ -4502,7 +4374,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/shorthands/backgroundImages.js#L23-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/backgroundImages.js#L23-L27'>
       <span>src/shorthands/backgroundImages.js</span>
       </a>
     
@@ -4512,7 +4384,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
   <p>The backgroundImages shorthand accepts any number of backgroundImage values as parameters for creating a single background statement..</p>
 
 
-  <div class='pre p1 fill-light mt0'>backgroundImages(properties: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>&gt;)</div>
+  <div class='pre p1 fill-light mt0'>backgroundImages(properties: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>)</div>
   
   
 
@@ -4528,7 +4400,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>properties</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>&gt;)</code>
+            <span class='code bold'>properties</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>)</code>
 	    
           </div>
           
@@ -4585,7 +4457,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/shorthands/backgrounds.js#L22-L26'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/backgrounds.js#L22-L26'>
       <span>src/shorthands/backgrounds.js</span>
       </a>
     
@@ -4595,7 +4467,7 @@ div {
   <p>The backgrounds shorthand accepts any number of background values as parameters for creating a single background statement..</p>
 
 
-  <div class='pre p1 fill-light mt0'>backgrounds(properties: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>&gt;)</div>
+  <div class='pre p1 fill-light mt0'>backgrounds(properties: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>)</div>
   
   
 
@@ -4611,7 +4483,7 @@ div {
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>properties</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>&gt;)</code>
+            <span class='code bold'>properties</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>)</code>
 	    
           </div>
           
@@ -4668,7 +4540,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/shorthands/borderColor.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/borderColor.js#L27-L29'>
       <span>src/shorthands/borderColor.js</span>
       </a>
     
@@ -4678,7 +4550,7 @@ div {
   <p>The border-color shorthand accepts up to four values, including null to skip a value, and uses the directional-property mixin to map them to their respective directions.</p>
 
 
-  <div class='pre p1 fill-light mt0'>borderColor(values: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?&gt;)</div>
+  <div class='pre p1 fill-light mt0'>borderColor(values: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>)</div>
   
   
 
@@ -4694,7 +4566,7 @@ div {
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>values</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?&gt;)</code>
+            <span class='code bold'>values</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>)</code>
 	    
           </div>
           
@@ -4754,7 +4626,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/shorthands/borderRadius.js#L24-L47'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/borderRadius.js#L24-L47'>
       <span>src/shorthands/borderRadius.js</span>
       </a>
     
@@ -4846,7 +4718,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/shorthands/borderStyle.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/borderStyle.js#L27-L29'>
       <span>src/shorthands/borderStyle.js</span>
       </a>
     
@@ -4856,7 +4728,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
   <p>The border-style shorthand accepts up to four values, including null to skip a value, and uses the directional-property mixin to map them to their respective directions.</p>
 
 
-  <div class='pre p1 fill-light mt0'>borderStyle(values: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?&gt;)</div>
+  <div class='pre p1 fill-light mt0'>borderStyle(values: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>)</div>
   
   
 
@@ -4872,7 +4744,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>values</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?&gt;)</code>
+            <span class='code bold'>values</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>)</code>
 	    
           </div>
           
@@ -4932,7 +4804,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/shorthands/borderWidth.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/borderWidth.js#L27-L29'>
       <span>src/shorthands/borderWidth.js</span>
       </a>
     
@@ -4942,7 +4814,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
   <p>The border-width shorthand accepts up to four values, including null to skip a value, and uses the directional-property mixin to map them to their respective directions.</p>
 
 
-  <div class='pre p1 fill-light mt0'>borderWidth(values: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?&gt;)</div>
+  <div class='pre p1 fill-light mt0'>borderWidth(values: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>)</div>
   
   
 
@@ -4958,7 +4830,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>values</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?&gt;)</code>
+            <span class='code bold'>values</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>)</code>
 	    
           </div>
           
@@ -5018,7 +4890,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/shorthands/buttons.js#L43-L45'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/buttons.js#L43-L45'>
       <span>src/shorthands/buttons.js</span>
       </a>
     
@@ -5028,7 +4900,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
   <p>Populates selectors that target all buttons. You can pass optional states to append to the selectors.</p>
 
 
-  <div class='pre p1 fill-light mt0'>buttons(states: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="#buttonstate">ButtonState</a>&gt;)</div>
+  <div class='pre p1 fill-light mt0'>buttons(states: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#buttonstate">ButtonState</a>>)</div>
   
   
 
@@ -5044,7 +4916,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>states</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="#buttonstate">ButtonState</a>&gt;)</code>
+            <span class='code bold'>states</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#buttonstate">ButtonState</a>>)</code>
 	    
           </div>
           
@@ -5108,7 +4980,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/shorthands/margin.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/margin.js#L27-L29'>
       <span>src/shorthands/margin.js</span>
       </a>
     
@@ -5118,7 +4990,7 @@ const div = styled.div`
   <p>The margin shorthand accepts up to four values, including null to skip a value, and uses the directional-property mixin to map them to their respective directions.</p>
 
 
-  <div class='pre p1 fill-light mt0'>margin(values: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?&gt;)</div>
+  <div class='pre p1 fill-light mt0'>margin(values: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>)</div>
   
   
 
@@ -5134,7 +5006,7 @@ const div = styled.div`
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>values</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?&gt;)</code>
+            <span class='code bold'>values</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>)</code>
 	    
           </div>
           
@@ -5194,7 +5066,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/shorthands/padding.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/padding.js#L27-L29'>
       <span>src/shorthands/padding.js</span>
       </a>
     
@@ -5204,7 +5076,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
   <p>The padding shorthand accepts up to four values, including null to skip a value, and uses the directional-property mixin to map them to their respective directions.</p>
 
 
-  <div class='pre p1 fill-light mt0'>padding(values: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?&gt;)</div>
+  <div class='pre p1 fill-light mt0'>padding(values: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>)</div>
   
   
 
@@ -5220,7 +5092,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>values</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?&gt;)</code>
+            <span class='code bold'>values</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>)</code>
 	    
           </div>
           
@@ -5280,7 +5152,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/shorthands/position.js#L49-L59'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/position.js#L49-L59'>
       <span>src/shorthands/position.js</span>
       </a>
     
@@ -5290,7 +5162,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
   <p>The position shorthand accepts up to five values, including null to skip a value, and uses the directional-property mixin to map them to their respective directions. The first calue can optionally be a position keyword.</p>
 
 
-  <div class='pre p1 fill-light mt0'>position(positionKeyword: (<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | Any), values: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?&gt;)</div>
+  <div class='pre p1 fill-light mt0'>position(positionKeyword: (<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | null), values: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>)</div>
   
   
 
@@ -5306,7 +5178,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>positionKeyword</span> <code class='quiet'>((<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | Any))</code>
+            <span class='code bold'>positionKeyword</span> <code class='quiet'>((<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | null))</code>
 	    
           </div>
           
@@ -5314,7 +5186,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>values</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?&gt;)</code>
+            <span class='code bold'>values</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>)</code>
 	    
           </div>
           
@@ -5394,7 +5266,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/shorthands/size.js#L24-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/size.js#L24-L29'>
       <span>src/shorthands/size.js</span>
       </a>
     
@@ -5404,7 +5276,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
   <p>Mixin to set the height and width properties in a single statement.</p>
 
 
-  <div class='pre p1 fill-light mt0'>size(height: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, width: [<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>])</div>
+  <div class='pre p1 fill-light mt0'>size(height: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, width: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</div>
   
   
 
@@ -5428,7 +5300,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>width</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>]
+            <span class='code bold'>width</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?
             = <code>height</code>)</code>
 	    
           </div>
@@ -5487,7 +5359,7 @@ const <span class="hljs-keyword">div</span> = styled.<span class="hljs-keyword">
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/shorthands/textInputs.js#L67-L69'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/textInputs.js#L67-L69'>
       <span>src/shorthands/textInputs.js</span>
       </a>
     
@@ -5497,7 +5369,7 @@ const <span class="hljs-keyword">div</span> = styled.<span class="hljs-keyword">
   <p>Populates selectors that target all text inputs. You can pass optional states to append to the selectors.</p>
 
 
-  <div class='pre p1 fill-light mt0'>textInputs(states: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="#inputstate">InputState</a>&gt;)</div>
+  <div class='pre p1 fill-light mt0'>textInputs(states: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#inputstate">InputState</a>>)</div>
   
   
 
@@ -5513,7 +5385,7 @@ const <span class="hljs-keyword">div</span> = styled.<span class="hljs-keyword">
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>states</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="#inputstate">InputState</a>&gt;)</code>
+            <span class='code bold'>states</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#inputstate">InputState</a>>)</code>
 	    
           </div>
           
@@ -5589,7 +5461,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/shorthands/transitions.js#L23-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/transitions.js#L23-L27'>
       <span>src/shorthands/transitions.js</span>
       </a>
     
@@ -5599,7 +5471,7 @@ const div = styled.div`
   <p>The transitions shorthand accepts any number of transition values as parameters for creating a single transition statement..</p>
 
 
-  <div class='pre p1 fill-light mt0'>transitions(properties: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>&gt;)</div>
+  <div class='pre p1 fill-light mt0'>transitions(properties: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>)</div>
   
   
 
@@ -5615,7 +5487,7 @@ const div = styled.div`
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>properties</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>&gt;)</code>
+            <span class='code bold'>properties</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>)</code>
 	    
           </div>
           
@@ -5684,7 +5556,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/helpers/directionalProperty.js#L44-L50'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/helpers/directionalProperty.js#L44-L50'>
       <span>src/helpers/directionalProperty.js</span>
       </a>
     
@@ -5694,7 +5566,7 @@ div {
   <p>The directional property helper enables shorthand for direction based properties. It accepts a property and up to four values that map to top, right, bottom, and left, respectively. You can optionally pass an empty string to get only the directional values as properties. You can optionally pass a null argument for a directional value to ignore it.</p>
 
 
-  <div class='pre p1 fill-light mt0'>directionalProperty(property: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, values: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?&gt;)</div>
+  <div class='pre p1 fill-light mt0'>directionalProperty(property: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, values: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>)</div>
   
   
 
@@ -5718,7 +5590,7 @@ div {
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>values</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?&gt;)</code>
+            <span class='code bold'>values</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>)</code>
 	    
           </div>
           
@@ -5778,7 +5650,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/helpers/em.js#L29-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/helpers/em.js#L29-L29'>
       <span>src/helpers/em.js</span>
       </a>
     
@@ -5789,7 +5661,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
 second argument to the function.</p>
 
 
-  <div class='pre p1 fill-light mt0'>em(pxval: (<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>), base: [(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)])</div>
+  <div class='pre p1 fill-light mt0'>em(pxval: (<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>), base: (<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)?)</div>
   
   
 
@@ -5813,7 +5685,7 @@ second argument to the function.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>base</span> <code class='quiet'>([(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)]
+            <span class='code bold'>base</span> <code class='quiet'>((<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)?
             = <code>&#39;16px&#39;</code>)</code>
 	    
           </div>
@@ -5871,7 +5743,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/helpers/modularScale.js#L67-L93'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/helpers/modularScale.js#L67-L93'>
       <span>src/helpers/modularScale.js</span>
       </a>
     
@@ -5881,7 +5753,7 @@ element {
   <p>Establish consistent measurements and spacial relationships throughout your projects by incrementing up or down a defined scale. We provide a list of commonly used scales as pre-defined variables, see below.</p>
 
 
-  <div class='pre p1 fill-light mt0'>modularScale(steps: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, base: [(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)], ratio: [<a href="#ratio">Ratio</a>])</div>
+  <div class='pre p1 fill-light mt0'>modularScale(steps: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, base: (<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)?, ratio: Ratio?)</div>
   
   
 
@@ -5905,7 +5777,7 @@ element {
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>base</span> <code class='quiet'>([(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)]
+            <span class='code bold'>base</span> <code class='quiet'>((<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)?
             = <code>&#39;1em&#39;</code>)</code>
 	    
           </div>
@@ -5914,7 +5786,7 @@ element {
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>ratio</span> <code class='quiet'>([<a href="#ratio">Ratio</a>]
+            <span class='code bold'>ratio</span> <code class='quiet'>(Ratio?
             = <code>&#39;perfectFourth&#39;</code>)</code>
 	    
           </div>
@@ -5974,7 +5846,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/helpers/rem.js#L28-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/helpers/rem.js#L28-L28'>
       <span>src/helpers/rem.js</span>
       </a>
     
@@ -5985,7 +5857,7 @@ element {
 second argument to the function.</p>
 
 
-  <div class='pre p1 fill-light mt0'>rem(pxval: (<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>), base: [(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)])</div>
+  <div class='pre p1 fill-light mt0'>rem(pxval: (<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>), base: (<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)?)</div>
   
   
 
@@ -6009,7 +5881,7 @@ second argument to the function.</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>base</span> <code class='quiet'>([(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)]
+            <span class='code bold'>base</span> <code class='quiet'>((<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)?
             = <code>&#39;16px&#39;</code>)</code>
 	    
           </div>
@@ -6067,7 +5939,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/helpers/stripUnit.js#L24-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/helpers/stripUnit.js#L24-L28'>
       <span>src/helpers/stripUnit.js</span>
       </a>
     
@@ -6167,7 +6039,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/shorthands/animation.js#L4-L4'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/animation.js#L4-L4'>
       <span>src/shorthands/animation.js</span>
       </a>
     
@@ -6177,6 +6049,11 @@ element {
   
 
   <div class='pre p1 fill-light mt0'>AnimationProperty</div>
+  
+    <p>
+      Type:
+      (<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)
+    </p>
   
   
 
@@ -6216,7 +6093,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/shorthands/buttons.js#L14-L14'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/buttons.js#L14-L14'>
       <span>src/shorthands/buttons.js</span>
       </a>
     
@@ -6226,6 +6103,11 @@ element {
   
 
   <div class='pre p1 fill-light mt0'>ButtonState</div>
+  
+    <p>
+      Type:
+      (any | null | <code>"active"</code> | <code>"focus"</code> | <code>"hover"</code>)
+    </p>
   
   
 
@@ -6265,7 +6147,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/mixins/fontFace.js#L4-L14'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/fontFace.js#L4-L14'>
       <span>src/mixins/fontFace.js</span>
       </a>
     
@@ -6275,6 +6157,11 @@ element {
   
 
   <div class='pre p1 fill-light mt0'>FontFaceConfiguration</div>
+  
+    <p>
+      Type:
+      {fontFamily: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, fontFilePath: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?, fontStretch: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?, fontStyle: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?, fontVariant: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?, fontWeight: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?, fileFormats: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>?, localFonts: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>?, unicodeRange: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?}
+    </p>
   
   
 
@@ -6297,49 +6184,49 @@ element {
         </div>
       
         <div class='space-bottom0'>
-          <span class='code bold'>fontFilePath</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          <span class='code bold'>fontFilePath</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
           
           
         </div>
       
         <div class='space-bottom0'>
-          <span class='code bold'>fontStretch</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          <span class='code bold'>fontStretch</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
           
           
         </div>
       
         <div class='space-bottom0'>
-          <span class='code bold'>fontStyle</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          <span class='code bold'>fontStyle</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
           
           
         </div>
       
         <div class='space-bottom0'>
-          <span class='code bold'>fontVariant</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          <span class='code bold'>fontVariant</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
           
           
         </div>
       
         <div class='space-bottom0'>
-          <span class='code bold'>fontWeight</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          <span class='code bold'>fontWeight</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
           
           
         </div>
       
         <div class='space-bottom0'>
-          <span class='code bold'>fileFormats</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>&gt;)</code>
+          <span class='code bold'>fileFormats</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>?)</code>
           
           
         </div>
       
         <div class='space-bottom0'>
-          <span class='code bold'>localFonts</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>&gt;)</code>
+          <span class='code bold'>localFonts</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>?)</code>
           
           
         </div>
       
         <div class='space-bottom0'>
-          <span class='code bold'>unicodeRange</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          <span class='code bold'>unicodeRange</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
           
           
         </div>
@@ -6373,7 +6260,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/types/color.js#L11-L15'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/types/color.js#L11-L15'>
       <span>src/types/color.js</span>
       </a>
     
@@ -6383,6 +6270,11 @@ element {
   
 
   <div class='pre p1 fill-light mt0'>HslColor</div>
+  
+    <p>
+      Type:
+      {hue: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, saturation: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, lightness: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>}
+    </p>
   
   
 
@@ -6445,7 +6337,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/types/color.js#L23-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/types/color.js#L23-L28'>
       <span>src/types/color.js</span>
       </a>
     
@@ -6455,6 +6347,11 @@ element {
   
 
   <div class='pre p1 fill-light mt0'>HslaColor</div>
+  
+    <p>
+      Type:
+      {hue: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, saturation: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, lightness: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, alpha: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>}
+    </p>
   
   
 
@@ -6523,7 +6420,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/shorthands/textInputs.js#L26-L26'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/textInputs.js#L26-L26'>
       <span>src/shorthands/textInputs.js</span>
       </a>
     
@@ -6533,6 +6430,11 @@ element {
   
 
   <div class='pre p1 fill-light mt0'>InputState</div>
+  
+    <p>
+      Type:
+      (any | null | <code>"active"</code> | <code>"focus"</code> | <code>"hover"</code>)
+    </p>
   
   
 
@@ -6572,7 +6474,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/mixins/triangle.js#L4-L4'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/triangle.js#L4-L4'>
       <span>src/mixins/triangle.js</span>
       </a>
     
@@ -6582,6 +6484,11 @@ element {
   
 
   <div class='pre p1 fill-light mt0'>PointingDirection</div>
+  
+    <p>
+      Type:
+      (<code>"top"</code> | <code>"right"</code> | <code>"bottom"</code> | <code>"left"</code>)
+    </p>
   
   
 
@@ -6621,7 +6528,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/mixins/radialGradient.js#L4-L10'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/radialGradient.js#L4-L10'>
       <span>src/mixins/radialGradient.js</span>
       </a>
     
@@ -6631,6 +6538,11 @@ element {
   
 
   <div class='pre p1 fill-light mt0'>RadialGradientConfiguration</div>
+  
+    <p>
+      Type:
+      {colorStops: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>, extent: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?, fallback: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?, position: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?, shape: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?}
+    </p>
   
   
 
@@ -6647,31 +6559,31 @@ element {
     <div>
       
         <div class='space-bottom0'>
-          <span class='code bold'>colorStops</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&lt;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>&gt;)</code>
+          <span class='code bold'>colorStops</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>)</code>
           
           
         </div>
       
         <div class='space-bottom0'>
-          <span class='code bold'>extent</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          <span class='code bold'>extent</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
           
           
         </div>
       
         <div class='space-bottom0'>
-          <span class='code bold'>fallback</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          <span class='code bold'>fallback</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
           
           
         </div>
       
         <div class='space-bottom0'>
-          <span class='code bold'>position</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          <span class='code bold'>position</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
           
           
         </div>
       
         <div class='space-bottom0'>
-          <span class='code bold'>shape</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+          <span class='code bold'>shape</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
           
           
         </div>
@@ -6700,61 +6612,12 @@ element {
   
   <div class='clearfix'>
     
-    <h3 class='fl m0' id='ratio'>
-      Ratio
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/helpers/modularScale.js#L26-L44'>
-      <span>src/helpers/modularScale.js</span>
-      </a>
-    
-  </div>
-  
-
-  
-
-  <div class='pre p1 fill-light mt0'>Ratio</div>
-  
-  
-
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-        
-      
-        
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
     <h3 class='fl m0' id='rgbacolor'>
       RgbaColor
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/types/color.js#L47-L52'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/types/color.js#L47-L52'>
       <span>src/types/color.js</span>
       </a>
     
@@ -6764,6 +6627,11 @@ element {
   
 
   <div class='pre p1 fill-light mt0'>RgbaColor</div>
+  
+    <p>
+      Type:
+      {red: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, green: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, blue: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, alpha: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>}
+    </p>
   
   
 
@@ -6832,7 +6700,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/types/color.js#L35-L39'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/types/color.js#L35-L39'>
       <span>src/types/color.js</span>
       </a>
     
@@ -6842,6 +6710,11 @@ element {
   
 
   <div class='pre p1 fill-light mt0'>RgbColor</div>
+  
+    <p>
+      Type:
+      {red: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, green: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, blue: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>}
+    </p>
   
   
 
@@ -6899,38 +6772,81 @@ element {
   
   <div class='clearfix'>
     
-    <h3 class='fl m0' id='timingfunction'>
-      TimingFunction
+    <h3 class='fl m0' id='readablecolor'>
+      readableColor
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/mixins/timingFunctions.js#L35-L59'>
-      <span>src/mixins/timingFunctions.js</span>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/readableColor.js#L31-L44'>
+      <span>src/color/readableColor.js</span>
       </a>
     
   </div>
   
 
-  
+  <p>Selects black or white or best contrast depending on the luminosity of the supplied color.
+Follows W3C specs for readability</p>
 
-  <div class='pre p1 fill-light mt0'>TimingFunction</div>
-  
-  
 
-  
-  
-  
+  <div class='pre p1 fill-light mt0'>readableColor(color: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
   
   
 
   
+  
+  
+  
+  
 
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>color</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
+	    
+          </div>
+          
+        </div>
+      
+    </div>
   
 
   
 
   
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
+    
+  
 
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
+<span class="hljs-keyword">const</span> styles = {
+  <span class="hljs-built_in">color</span>: mostReadable(<span class="hljs-string">'#000'</span>),
+  <span class="hljs-built_in">color</span>: mostReadable(<span class="hljs-string">'rgb(255,0,0)'</span>),
+}
+
+<span class="hljs-comment">// styled-components usage</span>
+<span class="hljs-keyword">const</span> div = styled.div`
+  <span class="hljs-built_in">color</span>: ${mostReadable(<span class="hljs-string">'#000'</span>)};
+  <span class="hljs-built_in">color</span>: ${mostReadable(<span class="hljs-string">'rgb(255,0,0)'</span>)};
+`
+
+<span class="hljs-comment">// CSS in JS Output</span>
+
+element {
+  <span class="hljs-built_in">color</span>: <span class="hljs-string">"#fff"</span>;
+  <span class="hljs-built_in">color</span>: <span class="hljs-string">"#000"</span>;
+}</pre>
+    
   
 
   
@@ -6953,7 +6869,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/7db72653413358a0799e4ea1d3c92948630707d0/src/color/toColorString.js#L71-L90'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/toColorString.js#L71-L90'>
       <span>src/color/toColorString.js</span>
       </a>
     
@@ -7027,6 +6943,181 @@ element {
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"rgba(255,205,100,0.72)"</span>;
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"#00f"</span>;
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"rgba(179,25,25,0.72)"</span>;
+}</pre>
+    
+  
+
+  
+
+  
+
+  
+</section>
+
+        
+      
+        
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='undefined'>
+      
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/helpers/modularScale.js#L5-L23'>
+      <span>src/helpers/modularScale.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+
+  <div class='pre p1 fill-light mt0'></div>
+  
+  
+
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+        
+      
+        
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='undefined'>
+      
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/timingFunctions.js#L4-L31'>
+      <span>src/mixins/timingFunctions.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+
+  <div class='pre p1 fill-light mt0'></div>
+  
+  
+
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+        
+      
+        
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='undefined'>
+      
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/triangle.js#L37-L42'>
+      <span>src/mixins/triangle.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>CSS to represent triangle with any pointing direction with an optional background color. Accepts number or px values for height and width.</p>
+
+
+  <div class='pre p1 fill-light mt0'></div>
+  
+  
+
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
+
+const styles = {
+  ...triangle({ <span class="hljs-string">pointingDirection:</span> <span class="hljs-string">'right'</span>, <span class="hljs-string">width:</span> <span class="hljs-string">'100px'</span>, <span class="hljs-string">height:</span> <span class="hljs-string">'100px'</span>, <span class="hljs-string">foregroundColor:</span> <span class="hljs-string">'red'</span> })
+}
+
+
+<span class="hljs-comment">// styled-components usage</span>
+const div = styled.div`
+  ${triangle({ <span class="hljs-string">pointingDirection:</span> <span class="hljs-string">'right'</span>, <span class="hljs-string">width:</span> <span class="hljs-string">'100px'</span>, <span class="hljs-string">height:</span> <span class="hljs-string">'100px'</span>, <span class="hljs-string">foregroundColor:</span> <span class="hljs-string">'red'</span> })}
+
+
+<span class="hljs-comment">// CSS as JS Output</span>
+<span class="hljs-symbol">
+div:</span> {
+ <span class="hljs-string">'border-color'</span>: <span class="hljs-string">'transparent'</span>,
+ <span class="hljs-string">'border-left-color'</span>: <span class="hljs-string">'red !important'</span>,
+ <span class="hljs-string">'border-style'</span>: <span class="hljs-string">'solid'</span>,
+ <span class="hljs-string">'border-width'</span>: <span class="hljs-string">'50px 0 50px 100px'</span>,
+ <span class="hljs-string">'height'</span>: <span class="hljs-string">'0'</span>,
+ <span class="hljs-string">'width'</span>: <span class="hljs-string">'0'</span>,
 }</pre>
     
   

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -855,7 +855,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/clearFix.js#L26-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/clearFix.js#L26-L35'>
       <span>src/mixins/clearFix.js</span>
       </a>
     
@@ -941,7 +941,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/ellipsis.js#L29-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/ellipsis.js#L29-L38'>
       <span>src/mixins/ellipsis.js</span>
       </a>
     
@@ -1030,7 +1030,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/fontFace.js#L72-L111'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/fontFace.js#L72-L111'>
       <span>src/mixins/fontFace.js</span>
       </a>
     
@@ -1192,7 +1192,7 @@ injectGlobal`${
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/hiDPI.js#L32-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/hiDPI.js#L32-L40'>
       <span>src/mixins/hiDPI.js</span>
       </a>
     
@@ -1284,7 +1284,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/hideText.js#L29-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/hideText.js#L29-L35'>
       <span>src/mixins/hideText.js</span>
       </a>
     
@@ -1359,7 +1359,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/normalize.js#L291-L294'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/normalize.js#L291-L294'>
       <span>src/mixins/normalize.js</span>
       </a>
     
@@ -1443,7 +1443,7 @@ html {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/placeholder.js#L35-L50'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/placeholder.js#L35-L50'>
       <span>src/mixins/placeholder.js</span>
       </a>
     
@@ -1546,7 +1546,7 @@ const div = styled.input`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/radialGradient.js#L78-L94'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/radialGradient.js#L78-L94'>
       <span>src/mixins/radialGradient.js</span>
       </a>
     
@@ -1686,7 +1686,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/retinaImage.js#L33-L58'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/retinaImage.js#L33-L58'>
       <span>src/mixins/retinaImage.js</span>
       </a>
     
@@ -1811,7 +1811,7 @@ a _2x.png filename suffix by default.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/selection.js#L31-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/selection.js#L31-L40'>
       <span>src/mixins/selection.js</span>
       </a>
     
@@ -1910,7 +1910,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/timingFunctions.js#L82-L84'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/timingFunctions.js#L82-L84'>
       <span>src/mixins/timingFunctions.js</span>
       </a>
     
@@ -1993,7 +1993,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/wordWrap.js#L26-L33'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/wordWrap.js#L26-L33'>
       <span>src/mixins/wordWrap.js</span>
       </a>
     
@@ -2091,7 +2091,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/adjustHue.js#L31-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/adjustHue.js#L31-L37'>
       <span>src/color/adjustHue.js</span>
       </a>
     
@@ -2191,7 +2191,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/complement.js#L28-L34'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/complement.js#L28-L34'>
       <span>src/color/complement.js</span>
       </a>
     
@@ -2281,7 +2281,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/darken.js#L31-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/darken.js#L31-L37'>
       <span>src/color/darken.js</span>
       </a>
     
@@ -2380,7 +2380,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/desaturate.js#L32-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/desaturate.js#L32-L38'>
       <span>src/color/desaturate.js</span>
       </a>
     
@@ -2480,7 +2480,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/grayscale.js#L28-L33'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/grayscale.js#L28-L33'>
       <span>src/color/grayscale.js</span>
       </a>
     
@@ -2570,7 +2570,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/hsl.js#L29-L51'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/hsl.js#L29-L51'>
       <span>src/color/hsl.js</span>
       </a>
     
@@ -2677,7 +2677,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/hsla.js#L33-L62'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/hsla.js#L33-L62'>
       <span>src/color/hsla.js</span>
       </a>
     
@@ -2795,7 +2795,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/invert.js#L29-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/invert.js#L29-L38'>
       <span>src/color/invert.js</span>
       </a>
     
@@ -2886,7 +2886,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/lighten.js#L31-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/lighten.js#L31-L37'>
       <span>src/color/lighten.js</span>
       </a>
     
@@ -2985,7 +2985,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/mix.js#L38-L68'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/mix.js#L38-L68'>
       <span>src/color/mix.js</span>
       </a>
     
@@ -3100,7 +3100,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/opacify.js#L34-L44'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/opacify.js#L34-L44'>
       <span>src/color/opacify.js</span>
       </a>
     
@@ -3197,7 +3197,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/parseToHsl.js#L18-L22'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/parseToHsl.js#L18-L22'>
       <span>src/color/parseToHsl.js</span>
       </a>
     
@@ -3276,7 +3276,7 @@ const color2 = 'hsla(<span class="hljs-number">210</span>, <span class="hljs-num
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/parseToRgb.js#L25-L93'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/parseToRgb.js#L25-L93'>
       <span>src/color/parseToRgb.js</span>
       </a>
     
@@ -3355,7 +3355,7 @@ const color2 = 'hsla(<span class="hljs-number">210</span>, <span class="hljs-num
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/rgb.js#L30-L50'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/rgb.js#L30-L50'>
       <span>src/color/rgb.js</span>
       </a>
     
@@ -3462,7 +3462,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/rgba.js#L32-L61'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/rgba.js#L32-L61'>
       <span>src/color/rgba.js</span>
       </a>
     
@@ -3580,7 +3580,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/saturate.js#L33-L39'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/saturate.js#L33-L39'>
       <span>src/color/saturate.js</span>
       </a>
     
@@ -3681,7 +3681,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/setHue.js#L30-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/setHue.js#L30-L35'>
       <span>src/color/setHue.js</span>
       </a>
     
@@ -3780,7 +3780,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/setLightness.js#L30-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/setLightness.js#L30-L35'>
       <span>src/color/setLightness.js</span>
       </a>
     
@@ -3879,7 +3879,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/setSaturation.js#L30-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/setSaturation.js#L30-L35'>
       <span>src/color/setSaturation.js</span>
       </a>
     
@@ -3978,7 +3978,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/shade.js#L29-L41'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/shade.js#L29-L41'>
       <span>src/color/shade.js</span>
       </a>
     
@@ -4071,7 +4071,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/tint.js#L29-L41'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/tint.js#L29-L41'>
       <span>src/color/tint.js</span>
       </a>
     
@@ -4164,7 +4164,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/transparentize.js#L34-L44'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/transparentize.js#L34-L44'>
       <span>src/color/transparentize.js</span>
       </a>
     
@@ -4273,7 +4273,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/animation.js#L42-L75'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/animation.js#L42-L75'>
       <span>src/shorthands/animation.js</span>
       </a>
     
@@ -4374,7 +4374,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/backgroundImages.js#L23-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/backgroundImages.js#L23-L27'>
       <span>src/shorthands/backgroundImages.js</span>
       </a>
     
@@ -4457,7 +4457,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/backgrounds.js#L22-L26'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/backgrounds.js#L22-L26'>
       <span>src/shorthands/backgrounds.js</span>
       </a>
     
@@ -4540,7 +4540,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/borderColor.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/borderColor.js#L27-L29'>
       <span>src/shorthands/borderColor.js</span>
       </a>
     
@@ -4626,7 +4626,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/borderRadius.js#L24-L47'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/borderRadius.js#L24-L47'>
       <span>src/shorthands/borderRadius.js</span>
       </a>
     
@@ -4718,7 +4718,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/borderStyle.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/borderStyle.js#L27-L29'>
       <span>src/shorthands/borderStyle.js</span>
       </a>
     
@@ -4804,7 +4804,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/borderWidth.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/borderWidth.js#L27-L29'>
       <span>src/shorthands/borderWidth.js</span>
       </a>
     
@@ -4890,7 +4890,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/buttons.js#L43-L45'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/buttons.js#L43-L45'>
       <span>src/shorthands/buttons.js</span>
       </a>
     
@@ -4980,7 +4980,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/margin.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/margin.js#L27-L29'>
       <span>src/shorthands/margin.js</span>
       </a>
     
@@ -5066,7 +5066,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/padding.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/padding.js#L27-L29'>
       <span>src/shorthands/padding.js</span>
       </a>
     
@@ -5152,7 +5152,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/position.js#L49-L59'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/position.js#L49-L59'>
       <span>src/shorthands/position.js</span>
       </a>
     
@@ -5266,7 +5266,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/size.js#L24-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/size.js#L24-L29'>
       <span>src/shorthands/size.js</span>
       </a>
     
@@ -5359,7 +5359,7 @@ const <span class="hljs-keyword">div</span> = styled.<span class="hljs-keyword">
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/textInputs.js#L67-L69'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/textInputs.js#L67-L69'>
       <span>src/shorthands/textInputs.js</span>
       </a>
     
@@ -5461,7 +5461,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/transitions.js#L23-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/transitions.js#L23-L27'>
       <span>src/shorthands/transitions.js</span>
       </a>
     
@@ -5556,7 +5556,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/helpers/directionalProperty.js#L44-L50'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/helpers/directionalProperty.js#L44-L50'>
       <span>src/helpers/directionalProperty.js</span>
       </a>
     
@@ -5650,7 +5650,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/helpers/em.js#L29-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/helpers/em.js#L29-L29'>
       <span>src/helpers/em.js</span>
       </a>
     
@@ -5743,7 +5743,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/helpers/modularScale.js#L67-L93'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/helpers/modularScale.js#L67-L93'>
       <span>src/helpers/modularScale.js</span>
       </a>
     
@@ -5846,7 +5846,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/helpers/rem.js#L28-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/helpers/rem.js#L28-L28'>
       <span>src/helpers/rem.js</span>
       </a>
     
@@ -5939,7 +5939,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/helpers/stripUnit.js#L24-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/helpers/stripUnit.js#L24-L28'>
       <span>src/helpers/stripUnit.js</span>
       </a>
     
@@ -6039,7 +6039,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/animation.js#L4-L4'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/animation.js#L4-L4'>
       <span>src/shorthands/animation.js</span>
       </a>
     
@@ -6093,7 +6093,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/buttons.js#L14-L14'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/buttons.js#L14-L14'>
       <span>src/shorthands/buttons.js</span>
       </a>
     
@@ -6147,7 +6147,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/fontFace.js#L4-L14'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/fontFace.js#L4-L14'>
       <span>src/mixins/fontFace.js</span>
       </a>
     
@@ -6260,7 +6260,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/types/color.js#L11-L15'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/types/color.js#L11-L15'>
       <span>src/types/color.js</span>
       </a>
     
@@ -6337,7 +6337,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/types/color.js#L23-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/types/color.js#L23-L28'>
       <span>src/types/color.js</span>
       </a>
     
@@ -6420,7 +6420,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/shorthands/textInputs.js#L26-L26'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/shorthands/textInputs.js#L26-L26'>
       <span>src/shorthands/textInputs.js</span>
       </a>
     
@@ -6474,7 +6474,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/triangle.js#L4-L4'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/triangle.js#L4-L4'>
       <span>src/mixins/triangle.js</span>
       </a>
     
@@ -6528,7 +6528,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/radialGradient.js#L4-L10'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/radialGradient.js#L4-L10'>
       <span>src/mixins/radialGradient.js</span>
       </a>
     
@@ -6617,7 +6617,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/types/color.js#L47-L52'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/types/color.js#L47-L52'>
       <span>src/types/color.js</span>
       </a>
     
@@ -6700,7 +6700,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/types/color.js#L35-L39'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/types/color.js#L35-L39'>
       <span>src/types/color.js</span>
       </a>
     
@@ -6777,7 +6777,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/readableColor.js#L31-L44'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/readableColor.js#L41-L48'>
       <span>src/color/readableColor.js</span>
       </a>
     
@@ -6785,7 +6785,7 @@ element {
   
 
   <p>Selects black or white or best contrast depending on the luminosity of the supplied color.
-Follows W3C specs for readability</p>
+Follows W3C specs for readability at <a href="https://www.w3.org/TR/WCAG20-TECHS/G18.html">https://www.w3.org/TR/WCAG20-TECHS/G18.html</a></p>
 
 
   <div class='pre p1 fill-light mt0'>readableColor(color: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
@@ -6830,19 +6830,22 @@ Follows W3C specs for readability</p>
       
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
-  <span class="hljs-built_in">color</span>: mostReadable(<span class="hljs-string">'#000'</span>),
-  <span class="hljs-built_in">color</span>: mostReadable(<span class="hljs-string">'rgb(255,0,0)'</span>),
+  <span class="hljs-built_in">color</span>: readableColor(<span class="hljs-string">'#000'</span>),
+  <span class="hljs-built_in">color</span>: readableColor(<span class="hljs-string">'papayawhip'</span>),
+  <span class="hljs-built_in">color</span>: readableColor(<span class="hljs-string">'rgb(255,0,0)'</span>),
 }
 
 <span class="hljs-comment">// styled-components usage</span>
 <span class="hljs-keyword">const</span> div = styled.div`
-  <span class="hljs-built_in">color</span>: ${mostReadable(<span class="hljs-string">'#000'</span>)};
-  <span class="hljs-built_in">color</span>: ${mostReadable(<span class="hljs-string">'rgb(255,0,0)'</span>)};
+  <span class="hljs-built_in">color</span>: ${readableColor(<span class="hljs-string">'#000'</span>)};
+  <span class="hljs-built_in">color</span>: ${readableColor(<span class="hljs-string">'papayawhip'</span>)};
+  <span class="hljs-built_in">color</span>: ${readableColor(<span class="hljs-string">'rgb(255,0,0)'</span>)};
 `
 
 <span class="hljs-comment">// CSS in JS Output</span>
 
 element {
+  <span class="hljs-built_in">color</span>: <span class="hljs-string">"#fff"</span>;
   <span class="hljs-built_in">color</span>: <span class="hljs-string">"#fff"</span>;
   <span class="hljs-built_in">color</span>: <span class="hljs-string">"#000"</span>;
 }</pre>
@@ -6869,7 +6872,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/color/toColorString.js#L71-L90'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/color/toColorString.js#L71-L90'>
       <span>src/color/toColorString.js</span>
       </a>
     
@@ -6967,7 +6970,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/helpers/modularScale.js#L5-L23'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/helpers/modularScale.js#L5-L23'>
       <span>src/helpers/modularScale.js</span>
       </a>
     
@@ -7016,7 +7019,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/timingFunctions.js#L4-L31'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/timingFunctions.js#L4-L31'>
       <span>src/mixins/timingFunctions.js</span>
       </a>
     
@@ -7065,7 +7068,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/9d4b2037512bd34facf9785d8dfb708f9463481b/src/mixins/triangle.js#L37-L42'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/LawJolla/polished/blob/353c7e71a4c256f649ef22937a55568ee239864f/src/mixins/triangle.js#L37-L42'>
       <span>src/mixins/triangle.js</span>
       </a>
     

--- a/src/color/readableColor.js
+++ b/src/color/readableColor.js
@@ -3,38 +3,42 @@
 import parseToRgb from './parseToRgb'
 import curry from '../internalHelpers/_curry'
 
+const w3cConversion = (rgbColor: number): number => {
+  const colorZeroToOne = rgbColor / 255
+  return colorZeroToOne <= 0.03928
+    ? colorZeroToOne / 12.92
+    : ((colorZeroToOne + 0.055) / 1.055) ** 2.4
+}
+
 /**
  * Selects black or white or best contrast depending on the luminosity of the supplied color.
- * Follows W3C specs for readability
+ * Follows W3C specs for readability at https://www.w3.org/TR/WCAG20-TECHS/G18.html
  *
  * @example
  * // Styles as object usage
  * const styles = {
- *   color: mostReadable('#000'),
- *   color: mostReadable('rgb(255,0,0)'),
+ *   color: readableColor('#000'),
+ *   color: readableColor('papayawhip'),
+ *   color: readableColor('rgb(255,0,0)'),
  * }
  *
  * // styled-components usage
  * const div = styled.div`
- *   color: ${mostReadable('#000')};
- *   color: ${mostReadable('rgb(255,0,0)')};
+ *   color: ${readableColor('#000')};
+ *   color: ${readableColor('papayawhip')};
+ *   color: ${readableColor('rgb(255,0,0)')};
  * `
  *
  * // CSS in JS Output
  *
  * element {
  *   color: "#fff";
+ *   color: "#fff";
  *   color: "#000";
  * }
  */
 
 function readableColor(color: string): string {
-  const w3cConversion = (rgbColor: number): number => {
-    const colorZeroToOne = rgbColor / 255
-    return colorZeroToOne <= 0.03928
-      ? colorZeroToOne / 12.92
-      : ((colorZeroToOne + 0.055) / 1.055) ** 2.4
-  }
   const parsedColor = parseToRgb(color)
   const luminosity =
     w3cConversion(parsedColor.red) * 0.2126 +

--- a/src/color/readableColor.js
+++ b/src/color/readableColor.js
@@ -1,0 +1,46 @@
+// @flow
+
+import parseToRgb from './parseToRgb'
+import curry from '../internalHelpers/_curry'
+
+/**
+ * Selects black or white or best contrast depending on the luminosity of the supplied color.
+ * Follows W3C specs for readability
+ *
+ * @example
+ * // Styles as object usage
+ * const styles = {
+ *   color: mostReadable('#000'),
+ *   color: mostReadable('rgb(255,0,0)'),
+ * }
+ *
+ * // styled-components usage
+ * const div = styled.div`
+ *   color: ${mostReadable('#000')};
+ *   color: ${mostReadable('rgb(255,0,0)')};
+ * `
+ *
+ * // CSS in JS Output
+ *
+ * element {
+ *   color: "#fff";
+ *   color: "#000";
+ * }
+ */
+
+function readableColor(color: string): string {
+  const w3cConversion = (rgbColor: number): number => {
+    const colorZeroToOne = rgbColor / 255
+    return colorZeroToOne <= 0.03928
+      ? colorZeroToOne / 12.92
+      : ((colorZeroToOne + 0.055) / 1.055) ** 2.4
+  }
+  const parsedColor = parseToRgb(color)
+  const luminosity =
+    w3cConversion(parsedColor.red) * 0.2126 +
+    w3cConversion(parsedColor.green) * 0.7152 +
+    w3cConversion(parsedColor.blue) * 0.0722
+  return luminosity > 0.179 ? '#000' : '#fff'
+}
+
+export default curry(readableColor)

--- a/src/color/readableColor.js
+++ b/src/color/readableColor.js
@@ -3,15 +3,11 @@
 import parseToRgb from './parseToRgb'
 import curry from '../internalHelpers/_curry'
 
-const w3cConversion = (rgbColor: number): number => {
-  const colorZeroToOne = rgbColor / 255
-  return colorZeroToOne <= 0.03928
-    ? colorZeroToOne / 12.92
-    : ((colorZeroToOne + 0.055) / 1.055) ** 2.4
-}
+const h = (c: number): number =>
+  c / 255 <= 0.03928 ? c / 255 / 12.92 : ((c / 255 + 0.055) / 1.055) ** 2.4
 
 /**
- * Selects black or white or best contrast depending on the luminosity of the supplied color.
+ * Selects black or white for best contrast depending on the luminosity of the given color.
  * Follows W3C specs for readability at https://www.w3.org/TR/WCAG20-TECHS/G18.html
  *
  * @example
@@ -39,12 +35,10 @@ const w3cConversion = (rgbColor: number): number => {
  */
 
 function readableColor(color: string): string {
-  const parsedColor = parseToRgb(color)
-  const luminosity =
-    w3cConversion(parsedColor.red) * 0.2126 +
-    w3cConversion(parsedColor.green) * 0.7152 +
-    w3cConversion(parsedColor.blue) * 0.0722
-  return luminosity > 0.179 ? '#000' : '#fff'
+  const c = parseToRgb(color)
+  return h(c.red) * 0.2126 + h(c.green) * 0.7152 + h(c.blue) * 0.0722 > 0.179
+    ? '#000'
+    : '#fff'
 }
 
 export default curry(readableColor)

--- a/src/color/test/__snapshots__/readableColor.test.js.snap
+++ b/src/color/test/__snapshots__/readableColor.test.js.snap
@@ -1,4 +1,10 @@
-exports[`readableColor should return black given papayawhip 1`] = `"#000"`;
+exports[`readableColor should return black given gray, #787878 1`] = `"#000"`;
+
+exports[`readableColor should return black given gray, hsl(0, 0%, 47%) 1`] = `"#000"`;
+
+exports[`readableColor should return black given palevioletred, "palevioletred" 1`] = `"#000"`;
+
+exports[`readableColor should return black given papayawhip, "papayawhip" 1`] = `"#000"`;
 
 exports[`readableColor should return black given red, #FF0000 1`] = `"#000"`;
 
@@ -6,13 +12,13 @@ exports[`readableColor should return black given red, hsl(0, 100%, 50%) 1`] = `"
 
 exports[`readableColor should return black given rgb(120,120,120) 1`] = `"#000"`;
 
-exports[`readableColor should return black given white 1`] = `"#000"`;
-
-exports[`readableColor should return black given white 2`] = `"#000"`;
-
 exports[`readableColor should return black given white hex, #fff 1`] = `"#000"`;
 
+exports[`readableColor should return black given white, "white" 1`] = `"#000"`;
+
 exports[`readableColor should return black given white, rgb(255,255,255) 1`] = `"#000"`;
+
+exports[`readableColor should return white given black, "black" 1`] = `"#fff"`;
 
 exports[`readableColor should return white given black, #000 1`] = `"#fff"`;
 
@@ -27,5 +33,9 @@ exports[`readableColor should return white given blue, #0000FF 1`] = `"#fff"`;
 exports[`readableColor should return white given blue, hsl(250, 100%, 50%) 1`] = `"#fff"`;
 
 exports[`readableColor should return white given blue, hsla(250, 100%, 50%, 0.2) 1`] = `"#fff"`;
+
+exports[`readableColor should return white given gray, #757575 1`] = `"#fff"`;
+
+exports[`readableColor should return white given gray, hsl(0, 0%, 45%) 1`] = `"#fff"`;
 
 exports[`readableColor should return white given rgb(117,117,117) 1`] = `"#fff"`;

--- a/src/color/test/__snapshots__/readableColor.test.js.snap
+++ b/src/color/test/__snapshots__/readableColor.test.js.snap
@@ -1,15 +1,31 @@
-exports[`readableColor should return black given red 1`] = `"#000"`;
+exports[`readableColor should return black given papayawhip 1`] = `"#000"`;
 
-exports[`readableColor should return black given this gray 1`] = `"#000"`;
+exports[`readableColor should return black given red, #FF0000 1`] = `"#000"`;
+
+exports[`readableColor should return black given red, hsl(0, 100%, 50%) 1`] = `"#000"`;
+
+exports[`readableColor should return black given rgb(120,120,120) 1`] = `"#000"`;
 
 exports[`readableColor should return black given white 1`] = `"#000"`;
 
-exports[`readableColor should return black given white hex 1`] = `"#000"`;
+exports[`readableColor should return black given white 2`] = `"#000"`;
 
-exports[`readableColor should return white given black 1`] = `"#fff"`;
+exports[`readableColor should return black given white hex, #fff 1`] = `"#000"`;
 
-exports[`readableColor should return white given black hex 1`] = `"#fff"`;
+exports[`readableColor should return black given white, rgb(255,255,255) 1`] = `"#000"`;
 
-exports[`readableColor should return white given blue 1`] = `"#fff"`;
+exports[`readableColor should return white given black, #000 1`] = `"#fff"`;
 
-exports[`readableColor should return white given this gray 1`] = `"#000"`;
+exports[`readableColor should return white given black, rgb(0,0,0) 1`] = `"#fff"`;
+
+exports[`readableColor should return white given black, rgba(0,0,0,0.1) 1`] = `"#fff"`;
+
+exports[`readableColor should return white given black, rgba(0,0,0,0.7) 1`] = `"#fff"`;
+
+exports[`readableColor should return white given blue, #0000FF 1`] = `"#fff"`;
+
+exports[`readableColor should return white given blue, hsl(250, 100%, 50%) 1`] = `"#fff"`;
+
+exports[`readableColor should return white given blue, hsla(250, 100%, 50%, 0.2) 1`] = `"#fff"`;
+
+exports[`readableColor should return white given rgb(117,117,117) 1`] = `"#fff"`;

--- a/src/color/test/__snapshots__/readableColor.test.js.snap
+++ b/src/color/test/__snapshots__/readableColor.test.js.snap
@@ -1,0 +1,15 @@
+exports[`readableColor should return black given red 1`] = `"#000"`;
+
+exports[`readableColor should return black given this gray 1`] = `"#000"`;
+
+exports[`readableColor should return black given white 1`] = `"#000"`;
+
+exports[`readableColor should return black given white hex 1`] = `"#000"`;
+
+exports[`readableColor should return white given black 1`] = `"#fff"`;
+
+exports[`readableColor should return white given black hex 1`] = `"#fff"`;
+
+exports[`readableColor should return white given blue 1`] = `"#fff"`;
+
+exports[`readableColor should return white given this gray 1`] = `"#000"`;

--- a/src/color/test/readableColor.test.js
+++ b/src/color/test/readableColor.test.js
@@ -2,35 +2,59 @@
 import readableColor from '../readableColor'
 
 describe('readableColor', () => {
-  it('should return black given white', () => {
+  it('should return black given white, rgb(255,255,255)', () => {
     expect(readableColor('rgb(255,255,255)')).toMatchSnapshot()
   })
 
-  it('should return white given black', () => {
+  it('should return white given black, rgb(0,0,0)', () => {
     expect(readableColor('rgb(0,0,0)')).toMatchSnapshot()
   })
 
-  it('should return black given white hex', () => {
+  it('should return black given white hex, #fff', () => {
     expect(readableColor('#fff')).toMatchSnapshot()
   })
 
-  it('should return white given black hex', () => {
+  it('should return white given black, #000', () => {
     expect(readableColor('#000')).toMatchSnapshot()
   })
 
-  it('should return black given red', () => {
+  it('should return black given red, #FF0000', () => {
     expect(readableColor('#FF0000')).toMatchSnapshot()
   })
 
-  it('should return white given blue', () => {
+  it('should return white given blue, #0000FF', () => {
     expect(readableColor('#0000FF')).toMatchSnapshot()
   })
 
-  it('should return white given this gray', () => {
-    expect(readableColor('rgb(118,118,118)')).toMatchSnapshot()
+  it('should return black given rgb(120,120,120)', () => {
+    expect(readableColor('rgb(120,120,120)')).toMatchSnapshot()
   })
 
-  it('should return black given this gray', () => {
-    expect(readableColor('rgb(117,118,118)')).toMatchSnapshot()
+  it('should return white given rgb(117,117,117)', () => {
+    expect(readableColor('rgb(117,117,117)')).toMatchSnapshot()
+  })
+  it('should return white given black, rgba(0,0,0,0.7)', () => {
+    expect(readableColor('rgba(0,0,0,0.7)')).toMatchSnapshot()
+  })
+  it('should return white given black, rgba(0,0,0,0.1)', () => {
+    expect(readableColor('rgba(0,0,0,0.1)')).toMatchSnapshot()
+  })
+  it('should return black given white', () => {
+    expect(readableColor('white')).toMatchSnapshot()
+  })
+  it('should return black given papayawhip', () => {
+    expect(readableColor('papayawhip')).toMatchSnapshot()
+  })
+  it('should return black given white', () => {
+    expect(readableColor('white')).toMatchSnapshot()
+  })
+  it('should return black given red, hsl(0, 100%, 50%)', () => {
+    expect(readableColor('hsl(0, 100%, 50%)')).toMatchSnapshot()
+  })
+  it('should return white given blue, hsl(250, 100%, 50%)', () => {
+    expect(readableColor('hsl(250, 100%, 50%)')).toMatchSnapshot()
+  })
+  it('should return white given blue, hsla(250, 100%, 50%, 0.2)', () => {
+    expect(readableColor('hsla(250, 100%, 50%, 0.2)')).toMatchSnapshot()
   })
 })

--- a/src/color/test/readableColor.test.js
+++ b/src/color/test/readableColor.test.js
@@ -2,14 +2,6 @@
 import readableColor from '../readableColor'
 
 describe('readableColor', () => {
-  it('should return black given white, rgb(255,255,255)', () => {
-    expect(readableColor('rgb(255,255,255)')).toMatchSnapshot()
-  })
-
-  it('should return white given black, rgb(0,0,0)', () => {
-    expect(readableColor('rgb(0,0,0)')).toMatchSnapshot()
-  })
-
   it('should return black given white hex, #fff', () => {
     expect(readableColor('#fff')).toMatchSnapshot()
   })
@@ -21,11 +13,21 @@ describe('readableColor', () => {
   it('should return black given red, #FF0000', () => {
     expect(readableColor('#FF0000')).toMatchSnapshot()
   })
-
   it('should return white given blue, #0000FF', () => {
     expect(readableColor('#0000FF')).toMatchSnapshot()
   })
-
+  it('should return black given gray, #787878', () => {
+    expect(readableColor('#787878')).toMatchSnapshot()
+  })
+  it('should return white given gray, #757575', () => {
+    expect(readableColor('#757575')).toMatchSnapshot()
+  })
+  it('should return black given white, rgb(255,255,255)', () => {
+    expect(readableColor('rgb(255,255,255)')).toMatchSnapshot()
+  })
+  it('should return white given black, rgb(0,0,0)', () => {
+    expect(readableColor('rgb(0,0,0)')).toMatchSnapshot()
+  })
   it('should return black given rgb(120,120,120)', () => {
     expect(readableColor('rgb(120,120,120)')).toMatchSnapshot()
   })
@@ -39,13 +41,16 @@ describe('readableColor', () => {
   it('should return white given black, rgba(0,0,0,0.1)', () => {
     expect(readableColor('rgba(0,0,0,0.1)')).toMatchSnapshot()
   })
-  it('should return black given white', () => {
-    expect(readableColor('white')).toMatchSnapshot()
+  it('should return white given black, "black"', () => {
+    expect(readableColor('black')).toMatchSnapshot()
   })
-  it('should return black given papayawhip', () => {
+  it('should return black given papayawhip, "papayawhip"', () => {
     expect(readableColor('papayawhip')).toMatchSnapshot()
   })
-  it('should return black given white', () => {
+  it('should return black given palevioletred, "palevioletred"', () => {
+    expect(readableColor('palevioletred')).toMatchSnapshot()
+  })
+  it('should return black given white, "white"', () => {
     expect(readableColor('white')).toMatchSnapshot()
   })
   it('should return black given red, hsl(0, 100%, 50%)', () => {
@@ -53,6 +58,12 @@ describe('readableColor', () => {
   })
   it('should return white given blue, hsl(250, 100%, 50%)', () => {
     expect(readableColor('hsl(250, 100%, 50%)')).toMatchSnapshot()
+  })
+  it('should return black given gray, hsl(0, 0%, 47%)', () => {
+    expect(readableColor('hsl(0, 0%, 47%)')).toMatchSnapshot()
+  })
+  it('should return white given gray, hsl(0, 0%, 45%)', () => {
+    expect(readableColor('hsl(0, 0%, 45%)')).toMatchSnapshot()
   })
   it('should return white given blue, hsla(250, 100%, 50%, 0.2)', () => {
     expect(readableColor('hsla(250, 100%, 50%, 0.2)')).toMatchSnapshot()

--- a/src/color/test/readableColor.test.js
+++ b/src/color/test/readableColor.test.js
@@ -1,0 +1,36 @@
+// @flow
+import readableColor from '../readableColor'
+
+describe('readableColor', () => {
+  it('should return black given white', () => {
+    expect(readableColor('rgb(255,255,255)')).toMatchSnapshot()
+  })
+
+  it('should return white given black', () => {
+    expect(readableColor('rgb(0,0,0)')).toMatchSnapshot()
+  })
+
+  it('should return black given white hex', () => {
+    expect(readableColor('#fff')).toMatchSnapshot()
+  })
+
+  it('should return white given black hex', () => {
+    expect(readableColor('#000')).toMatchSnapshot()
+  })
+
+  it('should return black given red', () => {
+    expect(readableColor('#FF0000')).toMatchSnapshot()
+  })
+
+  it('should return white given blue', () => {
+    expect(readableColor('#0000FF')).toMatchSnapshot()
+  })
+
+  it('should return white given this gray', () => {
+    expect(readableColor('rgb(118,118,118)')).toMatchSnapshot()
+  })
+
+  it('should return black given this gray', () => {
+    expect(readableColor('rgb(117,118,118)')).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
Uses W3C convention to determine if black or white is more readable (greater luminosity difference)
from a given color

The git hooks returned the following error (so I used --no-verify)

```
/polished/docs-theme/index.js:34
        let prefix = ''
        ^^^
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode

```

As part of the precommit build, docs/assets/polished.js and docs/docs/index.html were modified.  I hope that's expected behavior.

Thanks for all of your time and hard work!
