### PR TITLE
build(documentation.js): Pin documentation.js due to a build issue.

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "babel-preset-latest": "^6.16.0",
     "concat-stream": "^1.5.2",
     "cz-conventional-changelog": "^1.2.0",
-    "documentation": "^4.0.0-beta.18",
+    "documentation": "4.0.0-beta.18",
     "eslint": "^3.9.1",
     "eslint-config-airbnb-base": "^10.0.1",
     "eslint-plugin-import": "^2.2.0",


### PR DESCRIPTION
Later versions of documentation.js introduced a breaking change that is affecting our theme. Until
this can be addressed, pinning this at beta 18.