### PR TITLE
feat(typings): Generate typescript definition files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ script:
   - npm test
   - npm run lint
   - npm run flow
+  - npm run build:flow
+  - npm run build:typescript
+  - npm run typescript
 after_success:
   - codecov
   - 'curl -Lo travis_after_all.py https://git.io/travis_after_all'

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ In the documentation you will see examples using [object spread properties](http
     <li><a href="http://polished.js.org/docs/#retinaimage">retinaImage</a></li>
     <li><a href="http://polished.js.org/docs/#selection">selection</a></li>
     <li><a href="http://polished.js.org/docs/#timingfunctions">timingFunctions</a></li>
-    <li><a href="http://polished.js.org/docs/#triangle">triangle</a></li>
     <li><a href="http://polished.js.org/docs/#wordwrap">wordWrap</a></li>
   </ul>
 </details>
@@ -130,11 +129,12 @@ In the documentation you will see examples using [object spread properties](http
     <li><a href="http://polished.js.org/docs/#inputstate">InputState</a></li>
     <li><a href="http://polished.js.org/docs/#pointingdirection">PointingDirection</a></li>
     <li><a href="http://polished.js.org/docs/#radialgradientconfiguration">RadialGradientConfiguration</a></li>
-    <li><a href="http://polished.js.org/docs/#ratio">Ratio</a></li>
     <li><a href="http://polished.js.org/docs/#rgbacolor">RgbaColor</a></li>
     <li><a href="http://polished.js.org/docs/#rgbcolor">RgbColor</a></li>
-    <li><a href="http://polished.js.org/docs/#timingfunction">TimingFunction</a></li>
     <li><a href="http://polished.js.org/docs/#tocolorstring">toColorString</a></li>
+    <li><a href="http://polished.js.org/docs/#">undefined</a></li>
+    <li><a href="http://polished.js.org/docs/#-1">undefined</a></li>
+    <li><a href="http://polished.js.org/docs/#-2">undefined</a></li>
   </ul>
 </details>
 <!-- INJECT DOCS END -->

--- a/docs/assets/polished.js
+++ b/docs/assets/polished.js
@@ -169,7 +169,7 @@ var pxtoFactory$1 = function pxtoFactory$1(to) {
  */
 
 // Don’t inline this variable into export because Rollup will remove the /*#__PURE__*/ comment
-var em = /*#__PURE__*/pxtoFactory$1('em');
+var em = /*#__PURE__*/pxtoFactory$1('em'); // eslint-disable-line spaced-comment
 
 //      
 
@@ -191,32 +191,31 @@ var ratioNames = {
   majorEleventh: 2.667,
   majorTwelfth: 3,
   doubleOctave: 4
-};
 
-/** */
+  /** */
 
-/**
- * Establish consistent measurements and spacial relationships throughout your projects by incrementing up or down a defined scale. We provide a list of commonly used scales as pre-defined variables, see below.
- * @example
- * // Styles as object usage
- * const styles = {
- *    // Increment two steps up the default scale
- *   'font-size': modularScale(2)
- * }
- *
- * // styled-components usage
- * const div = styled.div`
- *    // Increment two steps up the default scale
- *   font-size: ${modularScale(2)}
- * `
- *
- * // CSS in JS Output
- *
- * element {
- *   'font-size': '1.77689em'
- * }
- */
-function modularScale(steps) {
+  /**
+   * Establish consistent measurements and spacial relationships throughout your projects by incrementing up or down a defined scale. We provide a list of commonly used scales as pre-defined variables, see below.
+   * @example
+   * // Styles as object usage
+   * const styles = {
+   *    // Increment two steps up the default scale
+   *   'font-size': modularScale(2)
+   * }
+   *
+   * // styled-components usage
+   * const div = styled.div`
+   *    // Increment two steps up the default scale
+   *   font-size: ${modularScale(2)}
+   * `
+   *
+   * // CSS in JS Output
+   *
+   * element {
+   *   'font-size': '1.77689em'
+   * }
+   */
+};function modularScale(steps) {
   var base = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '1em';
   var ratio = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 'perfectFourth';
 
@@ -264,7 +263,7 @@ function modularScale(steps) {
  */
 
 // Don’t inline this variable into export because Rollup will remove the /*#__PURE__*/ comment
-var rem = /*#__PURE__*/pxtoFactory$1('rem');
+var rem = /*#__PURE__*/pxtoFactory$1('rem'); // eslint-disable-line spaced-comment
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) {
   return typeof obj;
@@ -552,10 +551,9 @@ function fontFace(_ref) {
       'font-variant': fontVariant,
       'font-weight': fontWeight
     }
-  };
 
-  // Removes undefined fields for cleaner css object.
-  return JSON.parse(JSON.stringify(fontFaceDeclaration));
+    // Removes undefined fields for cleaner css object.
+  };return JSON.parse(JSON.stringify(fontFaceDeclaration));
 }
 
 //      
@@ -1038,33 +1036,32 @@ var functionsMap = {
   'easeInOutQuart': 'cubic-bezier(0.770,  0.000, 0.175, 1.000)',
   'easeInOutQuint': 'cubic-bezier(0.860,  0.000, 0.070, 1.000)',
   'easeInOutSine': 'cubic-bezier(0.445,  0.050, 0.550, 0.950)'
-};
-/* eslint-enable key-spacing */
+  /* eslint-enable key-spacing */
 
-/** */
+  /** */
 
-/**
- * String to represent common easing functions as demonstrated here: (github.com/jaukia/easie).
- *
- * @example
- * // Styles as object usage
- * const styles = {
- *   'transition-timing-function': timingFunctions('easeInQuad')
- * }
- *
- * // styled-components usage
- *  const div = styled.div`
- *   transition-timing-function: ${timingFunctions('easeInQuad')};
- * `
- *
- * // CSS as JS Output
- *
- * 'div': {
- *   'transition-timing-function': 'cubic-bezier(0.550,  0.085, 0.680, 0.530)',
- * }
- */
+  /**
+   * String to represent common easing functions as demonstrated here: (github.com/jaukia/easie).
+   *
+   * @example
+   * // Styles as object usage
+   * const styles = {
+   *   'transition-timing-function': timingFunctions('easeInQuad')
+   * }
+   *
+   * // styled-components usage
+   *  const div = styled.div`
+   *   transition-timing-function: ${timingFunctions('easeInQuad')};
+   * `
+   *
+   * // CSS as JS Output
+   *
+   * 'div': {
+   *   'transition-timing-function': 'cubic-bezier(0.550,  0.085, 0.680, 0.530)',
+   * }
+   */
 
-function timingFunctions(timingFunction) {
+};function timingFunctions(timingFunction) {
   return functionsMap[timingFunction];
 }
 
@@ -1094,37 +1091,36 @@ var reverseDirection = {
   right: 'left',
   top: 'bottom',
   bottom: 'top'
-};
 
-/**
- * CSS to represent triangle with any pointing direction with an optional background color. Accepts number or px values for height and width.
- *
- * @example
- * // Styles as object usage
- *
- * const styles = {
- *   ...triangle({ pointingDirection: 'right', width: '100px', height: '100px', foregroundColor: 'red' })
- * }
- *
- *
- * // styled-components usage
- * const div = styled.div`
- *   ${triangle({ pointingDirection: 'right', width: '100px', height: '100px', foregroundColor: 'red' })}
- *
- *
- * // CSS as JS Output
- *
- * div: {
- *  'border-color': 'transparent',
- *  'border-left-color': 'red !important',
- *  'border-style': 'solid',
- *  'border-width': '50px 0 50px 100px',
- *  'height': '0',
- *  'width': '0',
- * }
- */
+  /**
+   * CSS to represent triangle with any pointing direction with an optional background color. Accepts number or px values for height and width.
+   *
+   * @example
+   * // Styles as object usage
+   *
+   * const styles = {
+   *   ...triangle({ pointingDirection: 'right', width: '100px', height: '100px', foregroundColor: 'red' })
+   * }
+   *
+   *
+   * // styled-components usage
+   * const div = styled.div`
+   *   ${triangle({ pointingDirection: 'right', width: '100px', height: '100px', foregroundColor: 'red' })}
+   *
+   *
+   * // CSS as JS Output
+   *
+   * div: {
+   *  'border-color': 'transparent',
+   *  'border-left-color': 'red !important',
+   *  'border-style': 'solid',
+   *  'border-width': '50px 0 50px 100px',
+   *  'height': '0',
+   *  'width': '0',
+   * }
+   */
 
-function triangle(_ref) {
+};function triangle(_ref) {
   var pointingDirection = _ref.pointingDirection,
       height = _ref.height,
       width = _ref.width,
@@ -1388,13 +1384,12 @@ var namedColorMap = {
   'whitesmoke': 'f5f5f5',
   'yellow': 'ff0',
   'yellowgreen': '9acd32'
-};
 
-/**
- * Checks if a string is a CSS named color and returns its equivalent hex value, otherwise returns the original color.
- * @private
- */
-function nameToHex(color) {
+  /**
+   * Checks if a string is a CSS named color and returns its equivalent hex value, otherwise returns the original color.
+   * @private
+   */
+};function nameToHex(color) {
   if (typeof color !== 'string') return color;
   var normalizedColorName = color.toLowerCase();
   return namedColorMap[normalizedColorName] ? '#' + namedColorMap[normalizedColorName] : color;
@@ -1872,7 +1867,7 @@ function adjustHue(degree, color) {
 }
 
 // Don’t inline this variable into export because Rollup will remove the /*#__PURE__*/ comment
-var curriedAdjustHue = /*#__PURE__*/curry(adjustHue);
+var curriedAdjustHue = /*#__PURE__*/curry(adjustHue); // eslint-disable-line spaced-comment
 
 //      
 
@@ -1944,7 +1939,7 @@ function darken(amount, color) {
 }
 
 // Don’t inline this variable into export because Rollup will remove the /*#__PURE__*/ comment
-var curriedDarken = /*#__PURE__*/curry(darken);
+var curriedDarken = /*#__PURE__*/curry(darken); // eslint-disable-line spaced-comment
 
 //      
 
@@ -1980,7 +1975,7 @@ function desaturate(amount, color) {
 }
 
 // Don’t inline this variable into export because Rollup will remove the /*#__PURE__*/ comment
-var curriedDesaturate = /*#__PURE__*/curry(desaturate);
+var curriedDesaturate = /*#__PURE__*/curry(desaturate); // eslint-disable-line spaced-comment
 
 //      
 
@@ -2080,7 +2075,7 @@ function lighten(amount, color) {
 }
 
 // Don’t inline this variable into export because Rollup will remove the /*#__PURE__*/ comment
-var curriedLighten = /*#__PURE__*/curry(lighten);
+var curriedLighten = /*#__PURE__*/curry(lighten); // eslint-disable-line spaced-comment
 
 //      
 
@@ -2128,11 +2123,10 @@ function mix() {
   var parsedColor2 = parseToRgb(otherColor);
   var color2 = _extends({}, parsedColor2, {
     alpha: typeof parsedColor2.alpha === 'number' ? parsedColor2.alpha : 1
-  });
 
-  // The formular is copied from the original Sass implementation:
-  // http://sass-lang.com/documentation/Sass/Script/Functions.html#mix-instance_method
-  var alphaDelta = color1.alpha - color2.alpha;
+    // The formular is copied from the original Sass implementation:
+    // http://sass-lang.com/documentation/Sass/Script/Functions.html#mix-instance_method
+  });var alphaDelta = color1.alpha - color2.alpha;
   var x = weight * 2 - 1;
   var y = x * alphaDelta === -1 ? x : x + alphaDelta;
   var z = 1 + x * alphaDelta;
@@ -2150,7 +2144,7 @@ function mix() {
 }
 
 // Don’t inline this variable into export because Rollup will remove the /*#__PURE__*/ comment
-var curriedMix = /*#__PURE__*/curry(mix);
+var curriedMix = /*#__PURE__*/curry(mix); // eslint-disable-line spaced-comment
 
 //      
 /**
@@ -2190,7 +2184,7 @@ function opacify(amount, color) {
 }
 
 // Don’t inline this variable into export because Rollup will remove the /*#__PURE__*/ comment
-var curriedOpacify = /*#__PURE__*/curry(opacify);
+var curriedOpacify = /*#__PURE__*/curry(opacify); // eslint-disable-line spaced-comment
 
 //      
 
@@ -2227,7 +2221,7 @@ function saturate(amount, color) {
 }
 
 // Don’t inline this variable into export because Rollup will remove the /*#__PURE__*/ comment
-var curriedSaturate = /*#__PURE__*/curry(saturate);
+var curriedSaturate = /*#__PURE__*/curry(saturate); // eslint-disable-line spaced-comment
 
 //      
 
@@ -2261,7 +2255,7 @@ function setHue(hue, color) {
 }
 
 // Don’t inline this variable into export because Rollup will remove the /*#__PURE__*/ comment
-var curriedSetHue = /*#__PURE__*/curry(setHue);
+var curriedSetHue = /*#__PURE__*/curry(setHue); // eslint-disable-line spaced-comment
 
 //      
 
@@ -2295,7 +2289,7 @@ function setLightness(lightness, color) {
 }
 
 // Don’t inline this variable into export because Rollup will remove the /*#__PURE__*/ comment
-var curriedSetLightness = /*#__PURE__*/curry(setLightness);
+var curriedSetLightness = /*#__PURE__*/curry(setLightness); // eslint-disable-line spaced-comment
 
 //      
 
@@ -2329,7 +2323,7 @@ function setSaturation(saturation, color) {
 }
 
 // Don’t inline this variable into export because Rollup will remove the /*#__PURE__*/ comment
-var curriedSetSaturation = /*#__PURE__*/curry(setSaturation);
+var curriedSetSaturation = /*#__PURE__*/curry(setSaturation); // eslint-disable-line spaced-comment
 
 //      
 
@@ -2363,7 +2357,7 @@ function shade(percentage, color) {
 }
 
 // Don’t inline this variable into export because Rollup will remove the /*#__PURE__*/ comment
-var curriedShade = /*#__PURE__*/curry(shade);
+var curriedShade = /*#__PURE__*/curry(shade); // eslint-disable-line spaced-comment
 
 //      
 
@@ -2397,7 +2391,7 @@ function tint(percentage, color) {
 }
 
 // Don’t inline this variable into export because Rollup will remove the /*#__PURE__*/ comment
-var curriedTint = /*#__PURE__*/curry(tint);
+var curriedTint = /*#__PURE__*/curry(tint); // eslint-disable-line spaced-comment
 
 //      
 /**
@@ -2437,7 +2431,7 @@ function transparentize(amount, color) {
 }
 
 // Don’t inline this variable into export because Rollup will remove the /*#__PURE__*/ comment
-var curriedTransparentize = /*#__PURE__*/curry(transparentize);
+var curriedTransparentize = /*#__PURE__*/curry(transparentize); // eslint-disable-line spaced-comment
 
 //      
 

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -185,16 +185,6 @@
             
               
               <li><a
-                href='#triangle'
-                class="">
-                triangle
-                
-              </a>
-              
-              </li>
-            
-              
-              <li><a
                 href='#wordwrap'
                 class="">
                 wordWrap
@@ -735,16 +725,6 @@
             
               
               <li><a
-                href='#ratio'
-                class="">
-                Ratio
-                
-              </a>
-              
-              </li>
-            
-              
-              <li><a
                 href='#rgbacolor'
                 class="">
                 RgbaColor
@@ -765,9 +745,9 @@
             
               
               <li><a
-                href='#timingfunction'
+                href='#tocolorstring'
                 class="">
-                TimingFunction
+                toColorString
                 
               </a>
               
@@ -775,9 +755,29 @@
             
               
               <li><a
-                href='#tocolorstring'
+                href='#undefined'
                 class="">
-                toColorString
+                
+                
+              </a>
+              
+              </li>
+            
+              
+              <li><a
+                href='#undefined'
+                class="">
+                
+                
+              </a>
+              
+              </li>
+            
+              
+              <li><a
+                href='#undefined'
+                class="">
+                
                 
               </a>
               
@@ -845,7 +845,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/mixins/clearFix.js#L26-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/mixins/clearFix.js#L26-L35'>
       <span>src/mixins/clearFix.js</span>
       </a>
     
@@ -855,7 +855,7 @@
   <p>CSS to contain a float (credit to CSSMojo).</p>
 
 
-  <div class='pre p1 fill-light mt0'>clearFix(parent: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</div>
+  <div class='pre p1 fill-light mt0'>clearFix(parent: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
   
   
 
@@ -883,6 +883,11 @@
 
   
 
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></code>
+    
   
 
   
@@ -931,7 +936,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/mixins/ellipsis.js#L29-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/mixins/ellipsis.js#L29-L38'>
       <span>src/mixins/ellipsis.js</span>
       </a>
     
@@ -941,7 +946,7 @@
   <p>CSS to represent truncated text with an ellipsis.</p>
 
 
-  <div class='pre p1 fill-light mt0'>ellipsis(width: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</div>
+  <div class='pre p1 fill-light mt0'>ellipsis(width: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
   
   
 
@@ -969,6 +974,11 @@
 
   
 
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></code>
+    
   
 
   
@@ -1020,7 +1030,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/mixins/fontFace.js#L61-L92'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/mixins/fontFace.js#L61-L92'>
       <span>src/mixins/fontFace.js</span>
       </a>
     
@@ -1030,7 +1040,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
   <p>CSS for a @font-face declaration.</p>
 
 
-  <div class='pre p1 fill-light mt0'>fontFace($0: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</div>
+  <div class='pre p1 fill-light mt0'>fontFace($0: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
   
   
 
@@ -1130,6 +1140,11 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
   
 
   
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></code>
+    
+  
 
   
 
@@ -1182,7 +1197,7 @@ injectGlobal`${
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/mixins/hiDPI.js#L32-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/mixins/hiDPI.js#L32-L40'>
       <span>src/mixins/hiDPI.js</span>
       </a>
     
@@ -1192,7 +1207,7 @@ injectGlobal`${
   <p>Generates a media query to target HiDPI devices.</p>
 
 
-  <div class='pre p1 fill-light mt0'>hiDPI(ratio: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?)</div>
+  <div class='pre p1 fill-light mt0'>hiDPI(ratio: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
   
   
 
@@ -1220,6 +1235,11 @@ injectGlobal`${
 
   
 
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
+    
   
 
   
@@ -1274,7 +1294,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/mixins/hideText.js#L29-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/mixins/hideText.js#L29-L35'>
       <span>src/mixins/hideText.js</span>
       </a>
     
@@ -1284,7 +1304,7 @@ const div = styled.div`
   <p>CSS to hide text to show a background image in a SEO-friendly way.</p>
 
 
-  <div class='pre p1 fill-light mt0'>hideText()</div>
+  <div class='pre p1 fill-light mt0'>hideText(): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
   
   
 
@@ -1298,6 +1318,11 @@ const div = styled.div`
 
   
 
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></code>
+    
   
 
   
@@ -1349,7 +1374,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/mixins/normalize.js#L41-L295'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/mixins/normalize.js#L41-L295'>
       <span>src/mixins/normalize.js</span>
       </a>
     
@@ -1359,7 +1384,7 @@ const div = styled.div`
   <p>CSS to normalize abnormalities across browsers (normalize.css v5.0.0 | MIT License | github.com/necolas/normalize.css)</p>
 
 
-  <div class='pre p1 fill-light mt0'>normalize(excludeOpinionated: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>)</div>
+  <div class='pre p1 fill-light mt0'>normalize(excludeOpinionated: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
   
   
 
@@ -1386,6 +1411,11 @@ const div = styled.div`
 
   
 
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></code>
+    
   
 
   
@@ -1433,7 +1463,7 @@ html {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/mixins/placeholder.js#L35-L50'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/mixins/placeholder.js#L35-L50'>
       <span>src/mixins/placeholder.js</span>
       </a>
     
@@ -1443,7 +1473,7 @@ html {
   <p>CSS to style the selection psuedo-element.</p>
 
 
-  <div class='pre p1 fill-light mt0'>placeholder(styles: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>, parent: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</div>
+  <div class='pre p1 fill-light mt0'>placeholder(styles: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>, parent: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
   
   
 
@@ -1479,6 +1509,11 @@ html {
 
   
 
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></code>
+    
   
 
   
@@ -1536,7 +1571,7 @@ const div = styled.input`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/mixins/radialGradient.js#L67-L79'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/mixins/radialGradient.js#L67-L79'>
       <span>src/mixins/radialGradient.js</span>
       </a>
     
@@ -1546,7 +1581,7 @@ const div = styled.input`
   <p>CSS for declaring a radial gradient, including a fallback background-color. The fallback is either the first color-stop or an explicitly passed fallback color.</p>
 
 
-  <div class='pre p1 fill-light mt0'>radialGradient($0: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</div>
+  <div class='pre p1 fill-light mt0'>radialGradient($0: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
   
   
 
@@ -1620,6 +1655,11 @@ const div = styled.input`
   
 
   
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></code>
+    
+  
 
   
 
@@ -1676,7 +1716,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/mixins/retinaImage.js#L33-L48'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/mixins/retinaImage.js#L33-L48'>
       <span>src/mixins/retinaImage.js</span>
       </a>
     
@@ -1688,7 +1728,7 @@ background image. The retina background image will output to a HiDPI media query
 a _2x.png filename suffix by default.</p>
 
 
-  <div class='pre p1 fill-light mt0'>retinaImage(filename: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, backgroundSize: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, extension: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?, retinaFilename: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, retinaSuffix: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</div>
+  <div class='pre p1 fill-light mt0'>retinaImage(filename: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, backgroundSize: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, extension: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?, retinaFilename: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, retinaSuffix: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
   
   
 
@@ -1750,6 +1790,11 @@ a _2x.png filename suffix by default.</p>
   
 
   
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></code>
+    
+  
 
   
 
@@ -1757,24 +1802,24 @@ a _2x.png filename suffix by default.</p>
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
+      <pre class='p1 overflow-auto round fill-light'>// <span class="hljs-type">Styles</span> <span class="hljs-keyword">as</span> <span class="hljs-keyword">object</span> usage
 <span class="hljs-keyword">const</span> styles = {
- ...retinaImage(<span class="hljs-string">'my-img'</span>)
+ ...retinaImage('my-img')
 }
 
-<span class="hljs-comment">// styled-components usage</span>
-<span class="hljs-keyword">const</span> div = styled.div`
-  ${retinaImage(<span class="hljs-string">'my-img'</span>)}
+// styled-components usage
+<span class="hljs-keyword">const</span> <span class="hljs-keyword">div</span> = styled.<span class="hljs-keyword">div</span>`
+  ${retinaImage('my-img')}
 `
 
-<span class="hljs-comment">// CSS as JS Output</span>
-div {
+// <span class="hljs-type">CSS</span> <span class="hljs-keyword">as</span> <span class="hljs-type">JS</span> <span class="hljs-type">Output</span>
+<span class="hljs-keyword">div</span> {
   backgroundImage: 'url(my-img.png)',
-  '@media only screen and (-webkit-min-device-pixel-ratio: 1.3),
-   only screen and (min--moz-device-pixel-ratio: 1.3),
-   only screen and (-o-min-device-pixel-ratio: 1.3/1),
-   only screen and (min-resolution: 144dpi),
-   only screen and (min-resolution: 1.5dppx)': {
+  '@media only screen <span class="hljs-keyword">and</span> (-webkit-min-device-pixel-ratio: <span class="hljs-number">1</span>.<span class="hljs-number">3</span>),
+   only screen <span class="hljs-keyword">and</span> (min--moz-device-pixel-ratio: <span class="hljs-number">1</span>.<span class="hljs-number">3</span>),
+   only screen <span class="hljs-keyword">and</span> (-o-min-device-pixel-ratio: <span class="hljs-number">1</span>.<span class="hljs-number">3</span>/<span class="hljs-number">1</span>),
+   only screen <span class="hljs-keyword">and</span> (min-resolution: <span class="hljs-number">144</span>dpi),
+   only screen <span class="hljs-keyword">and</span> (min-resolution: <span class="hljs-number">1</span>.<span class="hljs-number">5</span>dppx)': {
     backgroundImage: 'url(my-img_2x.png)',
   }
 }</pre>
@@ -1801,7 +1846,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/mixins/selection.js#L31-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/mixins/selection.js#L31-L40'>
       <span>src/mixins/selection.js</span>
       </a>
     
@@ -1811,7 +1856,7 @@ div {
   <p>CSS to style the selection psuedo-element.</p>
 
 
-  <div class='pre p1 fill-light mt0'>selection(styles: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>, parent: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</div>
+  <div class='pre p1 fill-light mt0'>selection(styles: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>, parent: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
   
   
 
@@ -1847,6 +1892,11 @@ div {
 
   
 
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></code>
+    
   
 
   
@@ -1900,7 +1950,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/mixins/timingFunctions.js#L82-L84'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/mixins/timingFunctions.js#L82-L84'>
       <span>src/mixins/timingFunctions.js</span>
       </a>
     
@@ -1910,7 +1960,7 @@ const div = styled.div`
   <p>String to represent common easing functions as demonstrated here: (github.com/jaukia/easie).</p>
 
 
-  <div class='pre p1 fill-light mt0'>timingFunctions(timingFunction: <a href="#timingfunction">TimingFunction</a>)</div>
+  <div class='pre p1 fill-light mt0'>timingFunctions(timingFunction: TimingFunction): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
   
   
 
@@ -1926,7 +1976,7 @@ const div = styled.div`
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>timingFunction</span> <code class='quiet'>(<a href="#timingfunction">TimingFunction</a>)</code>
+            <span class='code bold'>timingFunction</span> <code class='quiet'>(TimingFunction)</code>
 	    
           </div>
           
@@ -1937,6 +1987,11 @@ const div = styled.div`
 
   
 
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
+    
   
 
   
@@ -1978,151 +2033,12 @@ const div = styled.div`
   
   <div class='clearfix'>
     
-    <h3 class='fl m0' id='triangle'>
-      triangle
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/mixins/triangle.js#L61-L81'>
-      <span>src/mixins/triangle.js</span>
-      </a>
-    
-  </div>
-  
-
-  <p>CSS to represent triangle with any pointing direction with an optional background color. Accepts number or px values for height and width.</p>
-
-
-  <div class='pre p1 fill-light mt0'>triangle($0: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</div>
-  
-  
-
-  
-  
-  
-  
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Parameters</div>
-    <div class='prose'>
-      
-        <div class='space-bottom0'>
-          <div>
-            <span class='code bold'>$0</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</code>
-	    
-          </div>
-          
-          <table class='mt1 mb2 fixed-table h5 col-12'>
-            <colgroup>
-              <col width='30%' />
-              <col width='70%' />
-            </colgroup>
-            <thead>
-              <tr class='bold fill-light'>
-                <th>Name</th>
-                <th>Description</th>
-              </tr>
-            </thead>
-            <tbody class='mt1'>
-              
-                <tr>
-                  <td class='break-word'><span class='code bold'>$0.pointingDirection</span> <code class='quiet'>any</code>
-                  </td>
-                  <td class='break-word'><span></span></td>
-                </tr>
-              
-                <tr>
-                  <td class='break-word'><span class='code bold'>$0.height</span> <code class='quiet'>any</code>
-                  </td>
-                  <td class='break-word'><span></span></td>
-                </tr>
-              
-                <tr>
-                  <td class='break-word'><span class='code bold'>$0.width</span> <code class='quiet'>any</code>
-                  </td>
-                  <td class='break-word'><span></span></td>
-                </tr>
-              
-                <tr>
-                  <td class='break-word'><span class='code bold'>$0.foregroundColor</span> <code class='quiet'>any</code>
-                  </td>
-                  <td class='break-word'><span></span></td>
-                </tr>
-              
-                <tr>
-                  <td class='break-word'><span class='code bold'>$0.backgroundColor</span> <code class='quiet'>any</code>
-                  
-                    (default <code>&#39;transparent&#39;</code>)
-                  </td>
-                  <td class='break-word'><span></span></td>
-                </tr>
-              
-            </tbody>
-          </table>
-          
-        </div>
-      
-    </div>
-  
-
-  
-
-  
-
-  
-
-  
-    <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
-      <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
-
-const styles = {
-  ...triangle({ <span class="hljs-string">pointingDirection:</span> <span class="hljs-string">'right'</span>, <span class="hljs-string">width:</span> <span class="hljs-string">'100px'</span>, <span class="hljs-string">height:</span> <span class="hljs-string">'100px'</span>, <span class="hljs-string">foregroundColor:</span> <span class="hljs-string">'red'</span> })
-}
-
-
-<span class="hljs-comment">// styled-components usage</span>
-const div = styled.div`
-  ${triangle({ <span class="hljs-string">pointingDirection:</span> <span class="hljs-string">'right'</span>, <span class="hljs-string">width:</span> <span class="hljs-string">'100px'</span>, <span class="hljs-string">height:</span> <span class="hljs-string">'100px'</span>, <span class="hljs-string">foregroundColor:</span> <span class="hljs-string">'red'</span> })}
-
-
-<span class="hljs-comment">// CSS as JS Output</span>
-<span class="hljs-symbol">
-
-div:</span> {
- <span class="hljs-string">'border-color'</span>: <span class="hljs-string">'transparent'</span>,
- <span class="hljs-string">'border-left-color'</span>: <span class="hljs-string">'red !important'</span>,
- <span class="hljs-string">'border-style'</span>: <span class="hljs-string">'solid'</span>,
- <span class="hljs-string">'border-width'</span>: <span class="hljs-string">'50px 0 50px 100px'</span>,
- <span class="hljs-string">'height'</span>: <span class="hljs-string">'0'</span>,
- <span class="hljs-string">'width'</span>: <span class="hljs-string">'0'</span>,
-}</pre>
-    
-  
-
-  
-
-  
-
-  
-</section>
-
-        
-      
-        
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
     <h3 class='fl m0' id='wordwrap'>
       wordWrap
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/mixins/wordWrap.js#L26-L33'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/mixins/wordWrap.js#L26-L33'>
       <span>src/mixins/wordWrap.js</span>
       </a>
     
@@ -2132,7 +2048,7 @@ div:</span> {
   <p>Provides an easy way to change the <code>word-wrap</code> property.</p>
 
 
-  <div class='pre p1 fill-light mt0'>wordWrap(wrap: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</div>
+  <div class='pre p1 fill-light mt0'>wordWrap(wrap: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
   
   
 
@@ -2160,6 +2076,11 @@ div:</span> {
 
   
 
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></code>
+    
   
 
   
@@ -2220,7 +2141,7 @@ div:</span> {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/color/adjustHue.js#L31-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/color/adjustHue.js#L31-L37'>
       <span>src/color/adjustHue.js</span>
       </a>
     
@@ -2320,7 +2241,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/color/complement.js#L28-L34'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/color/complement.js#L28-L34'>
       <span>src/color/complement.js</span>
       </a>
     
@@ -2410,7 +2331,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/color/darken.js#L31-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/color/darken.js#L31-L37'>
       <span>src/color/darken.js</span>
       </a>
     
@@ -2509,7 +2430,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/color/desaturate.js#L32-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/color/desaturate.js#L32-L38'>
       <span>src/color/desaturate.js</span>
       </a>
     
@@ -2609,7 +2530,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/color/grayscale.js#L28-L33'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/color/grayscale.js#L28-L33'>
       <span>src/color/grayscale.js</span>
       </a>
     
@@ -2699,7 +2620,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/color/hsl.js#L29-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/color/hsl.js#L29-L37'>
       <span>src/color/hsl.js</span>
       </a>
     
@@ -2806,7 +2727,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/color/hsla.js#L33-L55'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/color/hsla.js#L33-L55'>
       <span>src/color/hsla.js</span>
       </a>
     
@@ -2924,7 +2845,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/color/invert.js#L29-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/color/invert.js#L29-L38'>
       <span>src/color/invert.js</span>
       </a>
     
@@ -3015,7 +2936,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/color/lighten.js#L31-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/color/lighten.js#L31-L37'>
       <span>src/color/lighten.js</span>
       </a>
     
@@ -3114,7 +3035,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/color/mix.js#L38-L68'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/color/mix.js#L38-L68'>
       <span>src/color/mix.js</span>
       </a>
     
@@ -3229,7 +3150,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/color/opacify.js#L34-L44'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/color/opacify.js#L34-L44'>
       <span>src/color/opacify.js</span>
       </a>
     
@@ -3239,7 +3160,7 @@ element {
   <p>Increases the opacity of a color. Its range for the amount is between 0 to 1.</p>
 
 
-  <div class='pre p1 fill-light mt0'>opacify(amount: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, color: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</div>
+  <div class='pre p1 fill-light mt0'>opacify(amount: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, color: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
   
   
 
@@ -3274,6 +3195,11 @@ element {
 
   
 
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
+    
   
 
   
@@ -3326,7 +3252,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/color/parseToHsl.js#L18-L22'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/color/parseToHsl.js#L18-L22'>
       <span>src/color/parseToHsl.js</span>
       </a>
     
@@ -3405,7 +3331,7 @@ const color2 = 'hsla(<span class="hljs-number">210</span>, <span class="hljs-num
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/color/parseToRgb.js#L25-L87'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/color/parseToRgb.js#L25-L87'>
       <span>src/color/parseToRgb.js</span>
       </a>
     
@@ -3484,7 +3410,7 @@ const color2 = 'hsla(<span class="hljs-number">210</span>, <span class="hljs-num
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/color/rgb.js#L30-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/color/rgb.js#L30-L38'>
       <span>src/color/rgb.js</span>
       </a>
     
@@ -3591,7 +3517,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/color/rgba.js#L41-L57'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/color/rgba.js#L41-L57'>
       <span>src/color/rgba.js</span>
       </a>
     
@@ -3716,7 +3642,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/color/saturate.js#L33-L39'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/color/saturate.js#L33-L39'>
       <span>src/color/saturate.js</span>
       </a>
     
@@ -3817,7 +3743,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/color/setHue.js#L30-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/color/setHue.js#L30-L35'>
       <span>src/color/setHue.js</span>
       </a>
     
@@ -3916,7 +3842,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/color/setLightness.js#L30-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/color/setLightness.js#L30-L35'>
       <span>src/color/setLightness.js</span>
       </a>
     
@@ -4015,7 +3941,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/color/setSaturation.js#L30-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/color/setSaturation.js#L30-L35'>
       <span>src/color/setSaturation.js</span>
       </a>
     
@@ -4114,7 +4040,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/color/shade.js#L29-L33'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/color/shade.js#L29-L33'>
       <span>src/color/shade.js</span>
       </a>
     
@@ -4126,7 +4052,7 @@ hue shifts, where as <code>darken</code> manipulates the luminance channel and t
 doesn't produce hue shifts.</p>
 
 
-  <div class='pre p1 fill-light mt0'>shade(percentage: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, color: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</div>
+  <div class='pre p1 fill-light mt0'>shade(percentage: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, color: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
   
   
 
@@ -4161,6 +4087,11 @@ doesn't produce hue shifts.</p>
 
   
 
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
+    
   
 
   
@@ -4207,7 +4138,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/color/tint.js#L29-L33'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/color/tint.js#L29-L33'>
       <span>src/color/tint.js</span>
       </a>
     
@@ -4219,7 +4150,7 @@ hue shifts, where as <code>lighten</code> manipulates the luminance channel and 
 doesn't produce hue shifts.</p>
 
 
-  <div class='pre p1 fill-light mt0'>tint(percentage: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, color: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</div>
+  <div class='pre p1 fill-light mt0'>tint(percentage: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, color: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
   
   
 
@@ -4254,6 +4185,11 @@ doesn't produce hue shifts.</p>
 
   
 
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
+    
   
 
   
@@ -4300,7 +4236,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/color/transparentize.js#L34-L44'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/color/transparentize.js#L34-L44'>
       <span>src/color/transparentize.js</span>
       </a>
     
@@ -4310,7 +4246,7 @@ element {
   <p>Decreases the opacity of a color. Its range for the amount is between 0 to 1.</p>
 
 
-  <div class='pre p1 fill-light mt0'>transparentize(amount: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, color: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</div>
+  <div class='pre p1 fill-light mt0'>transparentize(amount: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, color: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
   
   
 
@@ -4345,6 +4281,11 @@ element {
 
   
 
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
+    
   
 
   
@@ -4409,7 +4350,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/shorthands/animation.js#L42-L62'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/shorthands/animation.js#L42-L62'>
       <span>src/shorthands/animation.js</span>
       </a>
     
@@ -4420,7 +4361,7 @@ element {
 or a single animation spread over the arguments.</p>
 
 
-  <div class='pre p1 fill-light mt0'>animation(args: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#animationproperty">AnimationProperty</a>> | <a href="#animationproperty">AnimationProperty</a>)>)</div>
+  <div class='pre p1 fill-light mt0'>animation(args: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#animationproperty">AnimationProperty</a>> | <a href="#animationproperty">AnimationProperty</a>)>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
   
   
 
@@ -4447,6 +4388,11 @@ or a single animation spread over the arguments.</p>
 
   
 
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></code>
+    
   
 
   
@@ -4510,7 +4456,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/shorthands/backgroundImages.js#L23-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/shorthands/backgroundImages.js#L23-L27'>
       <span>src/shorthands/backgroundImages.js</span>
       </a>
     
@@ -4520,7 +4466,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
   <p>The backgroundImages shorthand accepts any number of backgroundImage values as parameters for creating a single background statement..</p>
 
 
-  <div class='pre p1 fill-light mt0'>backgroundImages(properties: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>)</div>
+  <div class='pre p1 fill-light mt0'>backgroundImages(properties: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
   
   
 
@@ -4547,6 +4493,11 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
 
   
 
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></code>
+    
   
 
   
@@ -4593,7 +4544,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/shorthands/backgrounds.js#L22-L26'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/shorthands/backgrounds.js#L22-L26'>
       <span>src/shorthands/backgrounds.js</span>
       </a>
     
@@ -4603,7 +4554,7 @@ div {
   <p>The backgrounds shorthand accepts any number of background values as parameters for creating a single background statement..</p>
 
 
-  <div class='pre p1 fill-light mt0'>backgrounds(properties: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>)</div>
+  <div class='pre p1 fill-light mt0'>backgrounds(properties: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
   
   
 
@@ -4630,6 +4581,11 @@ div {
 
   
 
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></code>
+    
   
 
   
@@ -4676,7 +4632,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/shorthands/borderColor.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/shorthands/borderColor.js#L27-L29'>
       <span>src/shorthands/borderColor.js</span>
       </a>
     
@@ -4686,7 +4642,7 @@ div {
   <p>The border-color shorthand accepts up to four values, including null to skip a value, and uses the directional-property mixin to map them to their respective directions.</p>
 
 
-  <div class='pre p1 fill-light mt0'>borderColor(values: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>)</div>
+  <div class='pre p1 fill-light mt0'>borderColor(values: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
   
   
 
@@ -4713,6 +4669,11 @@ div {
 
   
 
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></code>
+    
   
 
   
@@ -4762,7 +4723,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/shorthands/borderRadius.js#L24-L41'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/shorthands/borderRadius.js#L24-L41'>
       <span>src/shorthands/borderRadius.js</span>
       </a>
     
@@ -4772,7 +4733,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
   <p>The border-radius shorthand accepts a value for side and a value for radius and applies the radius value to both corners of the side.</p>
 
 
-  <div class='pre p1 fill-light mt0'>borderRadius(side: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, radius: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</div>
+  <div class='pre p1 fill-light mt0'>borderRadius(side: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, radius: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
   
   
 
@@ -4807,6 +4768,11 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
 
   
 
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></code>
+    
   
 
   
@@ -4854,7 +4820,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/shorthands/borderStyle.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/shorthands/borderStyle.js#L27-L29'>
       <span>src/shorthands/borderStyle.js</span>
       </a>
     
@@ -4864,7 +4830,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
   <p>The border-style shorthand accepts up to four values, including null to skip a value, and uses the directional-property mixin to map them to their respective directions.</p>
 
 
-  <div class='pre p1 fill-light mt0'>borderStyle(values: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>)</div>
+  <div class='pre p1 fill-light mt0'>borderStyle(values: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
   
   
 
@@ -4891,6 +4857,11 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
 
   
 
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></code>
+    
   
 
   
@@ -4940,7 +4911,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/shorthands/borderWidth.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/shorthands/borderWidth.js#L27-L29'>
       <span>src/shorthands/borderWidth.js</span>
       </a>
     
@@ -4950,7 +4921,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
   <p>The border-width shorthand accepts up to four values, including null to skip a value, and uses the directional-property mixin to map them to their respective directions.</p>
 
 
-  <div class='pre p1 fill-light mt0'>borderWidth(values: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>)</div>
+  <div class='pre p1 fill-light mt0'>borderWidth(values: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
   
   
 
@@ -4977,6 +4948,11 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
 
   
 
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></code>
+    
   
 
   
@@ -5026,7 +5002,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/shorthands/buttons.js#L48-L50'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/shorthands/buttons.js#L48-L50'>
       <span>src/shorthands/buttons.js</span>
       </a>
     
@@ -5036,7 +5012,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
   <p>Populates selectors that target all buttons. You can pass optional states to append to the selectors.</p>
 
 
-  <div class='pre p1 fill-light mt0'>buttons(states: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#buttonstate">ButtonState</a>>)</div>
+  <div class='pre p1 fill-light mt0'>buttons(states: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#buttonstate">ButtonState</a>>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
   
   
 
@@ -5063,6 +5039,11 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
 
   
 
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
+    
   
 
   
@@ -5116,7 +5097,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/shorthands/margin.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/shorthands/margin.js#L27-L29'>
       <span>src/shorthands/margin.js</span>
       </a>
     
@@ -5126,7 +5107,7 @@ const div = styled.div`
   <p>The margin shorthand accepts up to four values, including null to skip a value, and uses the directional-property mixin to map them to their respective directions.</p>
 
 
-  <div class='pre p1 fill-light mt0'>margin(values: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>)</div>
+  <div class='pre p1 fill-light mt0'>margin(values: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
   
   
 
@@ -5153,6 +5134,11 @@ const div = styled.div`
 
   
 
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></code>
+    
   
 
   
@@ -5202,7 +5188,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/shorthands/padding.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/shorthands/padding.js#L27-L29'>
       <span>src/shorthands/padding.js</span>
       </a>
     
@@ -5212,7 +5198,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
   <p>The padding shorthand accepts up to four values, including null to skip a value, and uses the directional-property mixin to map them to their respective directions.</p>
 
 
-  <div class='pre p1 fill-light mt0'>padding(values: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>)</div>
+  <div class='pre p1 fill-light mt0'>padding(values: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
   
   
 
@@ -5239,6 +5225,11 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
 
   
 
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></code>
+    
   
 
   
@@ -5288,7 +5279,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/shorthands/position.js#L49-L59'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/shorthands/position.js#L49-L59'>
       <span>src/shorthands/position.js</span>
       </a>
     
@@ -5298,7 +5289,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
   <p>The position shorthand accepts up to five values, including null to skip a value, and uses the directional-property mixin to map them to their respective directions. The first calue can optionally be a position keyword.</p>
 
 
-  <div class='pre p1 fill-light mt0'>position(positionKeyword: (<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | null), values: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>)</div>
+  <div class='pre p1 fill-light mt0'>position(positionKeyword: (<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | null), values: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
   
   
 
@@ -5333,6 +5324,11 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
 
   
 
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></code>
+    
   
 
   
@@ -5402,7 +5398,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/shorthands/size.js#L24-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/shorthands/size.js#L24-L29'>
       <span>src/shorthands/size.js</span>
       </a>
     
@@ -5412,7 +5408,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
   <p>Mixin to set the height and width properties in a single statement.</p>
 
 
-  <div class='pre p1 fill-light mt0'>size(height: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, width: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</div>
+  <div class='pre p1 fill-light mt0'>size(height: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, width: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
   
   
 
@@ -5448,6 +5444,11 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
 
   
 
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></code>
+    
   
 
   
@@ -5495,7 +5496,7 @@ const <span class="hljs-keyword">div</span> = styled.<span class="hljs-keyword">
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/shorthands/textInputs.js#L72-L74'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/shorthands/textInputs.js#L72-L74'>
       <span>src/shorthands/textInputs.js</span>
       </a>
     
@@ -5505,7 +5506,7 @@ const <span class="hljs-keyword">div</span> = styled.<span class="hljs-keyword">
   <p>Populates selectors that target all text inputs. You can pass optional states to append to the selectors.</p>
 
 
-  <div class='pre p1 fill-light mt0'>textInputs(states: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#inputstate">InputState</a>>)</div>
+  <div class='pre p1 fill-light mt0'>textInputs(states: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#inputstate">InputState</a>>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
   
   
 
@@ -5532,6 +5533,11 @@ const <span class="hljs-keyword">div</span> = styled.<span class="hljs-keyword">
 
   
 
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
+    
   
 
   
@@ -5597,7 +5603,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/shorthands/transitions.js#L23-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/shorthands/transitions.js#L23-L27'>
       <span>src/shorthands/transitions.js</span>
       </a>
     
@@ -5607,7 +5613,7 @@ const div = styled.div`
   <p>The transitions shorthand accepts any number of transition values as parameters for creating a single transition statement..</p>
 
 
-  <div class='pre p1 fill-light mt0'>transitions(properties: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>)</div>
+  <div class='pre p1 fill-light mt0'>transitions(properties: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
   
   
 
@@ -5634,6 +5640,11 @@ const div = styled.div`
 
   
 
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></code>
+    
   
 
   
@@ -5692,7 +5703,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/helpers/directionalProperty.js#L44-L49'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/helpers/directionalProperty.js#L44-L49'>
       <span>src/helpers/directionalProperty.js</span>
       </a>
     
@@ -5702,7 +5713,7 @@ div {
   <p>The directional property helper enables shorthand for direction based properties. It accepts a property and up to four values that map to top, right, bottom, and left, respectively. You can optionally pass an empty string to get only the directional values as properties. You can optionally pass a null argument for a directional value to ignore it.</p>
 
 
-  <div class='pre p1 fill-light mt0'>directionalProperty(property: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, values: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>)</div>
+  <div class='pre p1 fill-light mt0'>directionalProperty(property: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, values: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
   
   
 
@@ -5737,6 +5748,11 @@ div {
 
   
 
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></code>
+    
   
 
   
@@ -5786,7 +5802,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/helpers/em.js#L30-L30'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/helpers/em.js#L30-L30'>
       <span>src/helpers/em.js</span>
       </a>
     
@@ -5798,6 +5814,11 @@ second argument to the function.</p>
 
 
   <div class='pre p1 fill-light mt0'>em(pxval: (<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>), base: (<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)?)</div>
+  
+    <p>
+      Type:
+      function (value: (<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>), base: (<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
+    </p>
   
   
 
@@ -5879,7 +5900,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/helpers/modularScale.js#L67-L83'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/helpers/modularScale.js#L67-L83'>
       <span>src/helpers/modularScale.js</span>
       </a>
     
@@ -5889,7 +5910,7 @@ element {
   <p>Establish consistent measurements and spacial relationships throughout your projects by incrementing up or down a defined scale. We provide a list of commonly used scales as pre-defined variables, see below.</p>
 
 
-  <div class='pre p1 fill-light mt0'>modularScale(steps: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, base: (<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)?, ratio: <a href="#ratio">Ratio</a>?)</div>
+  <div class='pre p1 fill-light mt0'>modularScale(steps: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, base: (<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)?, ratio: Ratio?): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
   
   
 
@@ -5922,7 +5943,7 @@ element {
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>ratio</span> <code class='quiet'>(<a href="#ratio">Ratio</a>?
+            <span class='code bold'>ratio</span> <code class='quiet'>(Ratio?
             = <code>&#39;perfectFourth&#39;</code>)</code>
 	    
           </div>
@@ -5934,6 +5955,11 @@ element {
 
   
 
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
+    
   
 
   
@@ -5982,7 +6008,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/helpers/rem.js#L30-L30'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/helpers/rem.js#L30-L30'>
       <span>src/helpers/rem.js</span>
       </a>
     
@@ -5994,6 +6020,11 @@ second argument to the function.</p>
 
 
   <div class='pre p1 fill-light mt0'>rem(pxval: (<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>), base: (<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)?)</div>
+  
+    <p>
+      Type:
+      function (value: (<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>), base: (<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
+    </p>
   
   
 
@@ -6075,7 +6106,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/helpers/stripUnit.js#L24-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/helpers/stripUnit.js#L24-L28'>
       <span>src/helpers/stripUnit.js</span>
       </a>
     
@@ -6175,7 +6206,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/shorthands/animation.js#L4-L4'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/shorthands/animation.js#L4-L4'>
       <span>src/shorthands/animation.js</span>
       </a>
     
@@ -6229,7 +6260,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/shorthands/buttons.js#L14-L19'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/shorthands/buttons.js#L14-L19'>
       <span>src/shorthands/buttons.js</span>
       </a>
     
@@ -6283,7 +6314,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/mixins/fontFace.js#L4-L14'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/mixins/fontFace.js#L4-L14'>
       <span>src/mixins/fontFace.js</span>
       </a>
     
@@ -6396,7 +6427,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/types/color.js#L11-L15'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/types/color.js#L11-L15'>
       <span>src/types/color.js</span>
       </a>
     
@@ -6473,7 +6504,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/types/color.js#L23-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/types/color.js#L23-L28'>
       <span>src/types/color.js</span>
       </a>
     
@@ -6556,7 +6587,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/shorthands/textInputs.js#L26-L31'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/shorthands/textInputs.js#L26-L31'>
       <span>src/shorthands/textInputs.js</span>
       </a>
     
@@ -6610,7 +6641,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/mixins/triangle.js#L4-L4'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/mixins/triangle.js#L4-L4'>
       <span>src/mixins/triangle.js</span>
       </a>
     
@@ -6664,7 +6695,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/mixins/radialGradient.js#L4-L10'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/mixins/radialGradient.js#L4-L10'>
       <span>src/mixins/radialGradient.js</span>
       </a>
     
@@ -6748,66 +6779,12 @@ element {
   
   <div class='clearfix'>
     
-    <h3 class='fl m0' id='ratio'>
-      Ratio
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/helpers/modularScale.js#L26-L44'>
-      <span>src/helpers/modularScale.js</span>
-      </a>
-    
-  </div>
-  
-
-  
-
-  <div class='pre p1 fill-light mt0'>Ratio</div>
-  
-    <p>
-      Type:
-      (<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <code>"minorSecond"</code> | <code>"majorSecond"</code> | <code>"minorThird"</code> | <code>"majorThird"</code> | <code>"perfectFourth"</code> | <code>"augFourth"</code> | <code>"perfectFifth"</code> | <code>"minorSixth"</code> | <code>"goldenSection"</code> | <code>"majorSixth"</code> | <code>"minorSeventh"</code> | <code>"majorSeventh"</code> | <code>"octave"</code> | <code>"majorTenth"</code> | <code>"majorEleventh"</code> | <code>"majorTwelfth"</code> | <code>"doubleOctave"</code>)
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-        
-      
-        
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
     <h3 class='fl m0' id='rgbacolor'>
       RgbaColor
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/types/color.js#L47-L52'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/types/color.js#L47-L52'>
       <span>src/types/color.js</span>
       </a>
     
@@ -6890,7 +6867,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/types/color.js#L35-L39'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/types/color.js#L35-L39'>
       <span>src/types/color.js</span>
       </a>
     
@@ -6962,66 +6939,12 @@ element {
   
   <div class='clearfix'>
     
-    <h3 class='fl m0' id='timingfunction'>
-      TimingFunction
-    </h3>
-    
-    
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/mixins/timingFunctions.js#L35-L59'>
-      <span>src/mixins/timingFunctions.js</span>
-      </a>
-    
-  </div>
-  
-
-  
-
-  <div class='pre p1 fill-light mt0'>TimingFunction</div>
-  
-    <p>
-      Type:
-      (<code>"easeInBack"</code> | <code>"easeInCirc"</code> | <code>"easeInCubic"</code> | <code>"easeInExpo"</code> | <code>"easeInQuad"</code> | <code>"easeInQuart"</code> | <code>"easeInQuint"</code> | <code>"easeInSine"</code> | <code>"easeOutBack"</code> | <code>"easeOutCubic"</code> | <code>"easeOutCirc"</code> | <code>"easeOutExpo"</code> | <code>"easeOutQuad"</code> | <code>"easeOutQuart"</code> | <code>"easeOutQuint"</code> | <code>"easeOutSine"</code> | <code>"easeInOutBack"</code> | <code>"easeInOutCirc"</code> | <code>"easeInOutCubic"</code> | <code>"easeInOutExpo"</code> | <code>"easeInOutQuad"</code> | <code>"easeInOutQuart"</code> | <code>"easeInOutQuint"</code> | <code>"easeInOutSine"</code>)
-    </p>
-  
-  
-
-  
-  
-  
-  
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-
-  
-</section>
-
-        
-      
-        
-          <section class='p2 mb2 clearfix bg-white minishadow'>
-
-  
-  <div class='clearfix'>
-    
     <h3 class='fl m0' id='tocolorstring'>
       toColorString
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/220e40259294570e42ee5ee713402eb43b5f11e2/src/color/toColorString.js#L75-L90'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/color/toColorString.js#L75-L90'>
       <span>src/color/toColorString.js</span>
       </a>
     
@@ -7095,6 +7018,181 @@ element {
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"rgba(255,205,100,0.72)"</span>;
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"#00f"</span>;
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"rgba(179,25,25,0.72)"</span>;
+}</pre>
+    
+  
+
+  
+
+  
+
+  
+</section>
+
+        
+      
+        
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='undefined'>
+      
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/helpers/modularScale.js#L5-L23'>
+      <span>src/helpers/modularScale.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+
+  <div class='pre p1 fill-light mt0'></div>
+  
+  
+
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+        
+      
+        
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='undefined'>
+      
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/mixins/timingFunctions.js#L4-L31'>
+      <span>src/mixins/timingFunctions.js</span>
+      </a>
+    
+  </div>
+  
+
+  
+
+  <div class='pre p1 fill-light mt0'></div>
+  
+  
+
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+        
+      
+        
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='undefined'>
+      
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/ForbesLindesay/polished/blob/7343037d37f87e45391bfb4ae1b824302821d9b2/src/mixins/triangle.js#L26-L31'>
+      <span>src/mixins/triangle.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>CSS to represent triangle with any pointing direction with an optional background color. Accepts number or px values for height and width.</p>
+
+
+  <div class='pre p1 fill-light mt0'></div>
+  
+  
+
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
+
+const styles = {
+  ...triangle({ <span class="hljs-string">pointingDirection:</span> <span class="hljs-string">'right'</span>, <span class="hljs-string">width:</span> <span class="hljs-string">'100px'</span>, <span class="hljs-string">height:</span> <span class="hljs-string">'100px'</span>, <span class="hljs-string">foregroundColor:</span> <span class="hljs-string">'red'</span> })
+}
+
+
+<span class="hljs-comment">// styled-components usage</span>
+const div = styled.div`
+  ${triangle({ <span class="hljs-string">pointingDirection:</span> <span class="hljs-string">'right'</span>, <span class="hljs-string">width:</span> <span class="hljs-string">'100px'</span>, <span class="hljs-string">height:</span> <span class="hljs-string">'100px'</span>, <span class="hljs-string">foregroundColor:</span> <span class="hljs-string">'red'</span> })}
+
+
+<span class="hljs-comment">// CSS as JS Output</span>
+<span class="hljs-symbol">
+div:</span> {
+ <span class="hljs-string">'border-color'</span>: <span class="hljs-string">'transparent'</span>,
+ <span class="hljs-string">'border-left-color'</span>: <span class="hljs-string">'red !important'</span>,
+ <span class="hljs-string">'border-style'</span>: <span class="hljs-string">'solid'</span>,
+ <span class="hljs-string">'border-width'</span>: <span class="hljs-string">'50px 0 50px 100px'</span>,
+ <span class="hljs-string">'height'</span>: <span class="hljs-string">'0'</span>,
+ <span class="hljs-string">'width'</span>: <span class="hljs-string">'0'</span>,
 }</pre>
     
   

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "main": "lib/index.js",
   "jsnext:main": "dist/polished.es.js",
   "module": "dist/polished.es.js",
+  "types": "lib/index.d.ts",
   "scripts": {
-    "build": "npm run build:lib && npm run build:dist && npm run build:flow && npm run build:docs",
+    "build": "npm run build:lib && npm run build:dist && npm run build:flow && npm run build:docs && npm run build:typescript",
     "prebuild:lib": "shx rm -rf lib/*",
     "build:lib": "babel --out-dir lib src --ignore test.js",
     "prebuild:umd": "shx rm -rf dist/*",
@@ -13,17 +14,19 @@
     "build:dist": "rollup -c && rollup -c --environment PRODUCTION",
     "build:docs": "npm run build:docs:site && npm run build:docs:readme",
     "build:docs:readme": "documentation build src/** -t docs-theme/markdown.js --github -o docs -f html -c ./.documentation.json",
+    "build:typescript": "tsgen \"lib/**/*.js.flow\" --ignore \"lib/**/_*.js.flow\"",
     "prebuild:docs:site": "shx rm -rf docs/*",
     "build:docs:site": "documentation build src/** -t docs-theme --github -o docs -f html -c ./.documentation.json",
     "postbuild:docs:site": "shx cp CNAME docs/CNAME && shx cp dist/polished.js docs/assets/",
     "build:watch": "npm-watch",
     "build:flow": "flow-copy-source -v -i '{**/test/*.js,**/*.test.js}' src lib",
     "test": "jest src",
+    "typescript": "tsc ./typescript-test.ts --noEmit --target es6 --module es2015 --moduleResolution node",
     "postcommit": "validate-commit-msg",
     "lint": "eslint src",
     "flow": "flow check",
     "docs": "pushstate-server docs",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build && npm run typescript"
   },
   "watch": {
     "build:docs": "src/**/*.js",
@@ -84,6 +87,8 @@
     "rollup-plugin-replace": "^1.1.1",
     "rollup-plugin-uglify": "^1.0.1",
     "shx": "^0.2.2",
+    "tsgen": "^1.0.0",
+    "typescript": "^2.4.1",
     "validate-commit-msg": "^2.8.2",
     "vinyl": "^2.0.1",
     "vinyl-fs": "^2.4.4"

--- a/src/color/opacify.js
+++ b/src/color/opacify.js
@@ -31,7 +31,7 @@ import curry from '../internalHelpers/_curry'
  *   background: "rgba(255,0,0,0.7)";
  * }
  */
-function opacify(amount: number, color: string) {
+function opacify(amount: number, color: string): string {
   const parsedColor = parseToRgb(color)
   const alpha: number = typeof parsedColor.alpha === 'number' ? parsedColor.alpha : 1
   const colorWithAlpha = {

--- a/src/color/shade.js
+++ b/src/color/shade.js
@@ -26,7 +26,7 @@ import curry from '../internalHelpers/_curry'
  * }
  */
 
-function shade(percentage: number, color: string) {
+function shade(percentage: number, color: string): string {
   if (typeof percentage !== 'number' || percentage > 1 || percentage < -1) throw new Error('Passed an incorrect argument to shade, please pass a percentage less than or equal to 1 and larger than or equal to -1.')
   if (typeof color !== 'string') throw new Error('Passed an incorrect argument to a color function, please pass a string representation of a color.')
   return mix(percentage, color, 'rgb(0, 0, 0)')

--- a/src/color/tint.js
+++ b/src/color/tint.js
@@ -26,7 +26,7 @@ import curry from '../internalHelpers/_curry'
  * }
  */
 
-function tint(percentage: number, color: string) {
+function tint(percentage: number, color: string): string {
   if (typeof percentage !== 'number' || percentage > 1 || percentage < -1) throw new Error('Passed an incorrect argument to tint, please pass a percentage less than or equal to 1 and larger than or equal to -1.')
   if (typeof color !== 'string') throw new Error('Passed an incorrect argument to a color function, please pass a string representation of a color.')
   return mix(percentage, color, 'rgb(255, 255, 255)')

--- a/src/color/transparentize.js
+++ b/src/color/transparentize.js
@@ -31,7 +31,7 @@ import curry from '../internalHelpers/_curry'
  *   background: "rgba(255,0,0,0.3)";
  * }
  */
-function transparentize(amount: number, color: string) {
+function transparentize(amount: number, color: string): string {
   const parsedColor = parseToRgb(color)
   const alpha: number = typeof parsedColor.alpha === 'number' ? parsedColor.alpha : 1
   const colorWithAlpha = {

--- a/src/helpers/directionalProperty.js
+++ b/src/helpers/directionalProperty.js
@@ -41,7 +41,7 @@ function generateStyles(property: string, valuesWithDefaults: Array<?string>) {
  * }
  */
 
-function directionalProperty(property: string, ...values: Array<?string>) {
+function directionalProperty(property: string, ...values: Array<?string>): Object {
   // $FlowIgnoreNextLine doesn't understand destructuring with chained defaults.
   const [firstValue, secondValue = firstValue, thirdValue = firstValue, fourthValue = secondValue] = values
   const valuesWithDefaults = [firstValue, secondValue, thirdValue, fourthValue]

--- a/src/helpers/em.js
+++ b/src/helpers/em.js
@@ -27,5 +27,5 @@ import pixelsto from '../internalHelpers/_pxto'
  */
 
 // Don’t inline this variable into export because Rollup will remove the /*#__PURE__*/ comment
-const em = /*#__PURE__*/pixelsto('em') // eslint-disable-line spaced-comment
+const em: (value: string | number, base?: string | number) => string = /*#__PURE__*/pixelsto('em') // eslint-disable-line spaced-comment
 export default em

--- a/src/helpers/modularScale.js
+++ b/src/helpers/modularScale.js
@@ -64,7 +64,7 @@ type Ratio =
  *   'font-size': '1.77689em'
  * }
  */
-function modularScale(steps: number, base?: number|string = '1em', ratio?: Ratio = 'perfectFourth') {
+function modularScale(steps: number, base?: number|string = '1em', ratio?: Ratio = 'perfectFourth'): string {
   if (typeof steps !== 'number') {
     throw new Error('Please provide a number of steps to the modularScale helper.')
   }

--- a/src/helpers/rem.js
+++ b/src/helpers/rem.js
@@ -27,5 +27,5 @@ import pixelsto from '../internalHelpers/_pxto'
  */
 
 // Don’t inline this variable into export because Rollup will remove the /*#__PURE__*/ comment
-const rem = /*#__PURE__*/pixelsto('rem') // eslint-disable-line spaced-comment
+const rem: (value: string | number, base?: string | number) => string = /*#__PURE__*/pixelsto('rem') // eslint-disable-line spaced-comment
 export default rem

--- a/src/mixins/clearFix.js
+++ b/src/mixins/clearFix.js
@@ -23,7 +23,7 @@
  * }
  */
 
-function clearFix(parent: string = '&') {
+function clearFix(parent: string = '&'): Object {
   const pseudoSelector = `${parent}::after`
   return {
     [pseudoSelector]: {

--- a/src/mixins/ellipsis.js
+++ b/src/mixins/ellipsis.js
@@ -26,7 +26,7 @@
  * }
  */
 
-function ellipsis(width: string = '100%') {
+function ellipsis(width: string = '100%'): Object {
   return {
     'display': 'inline-block',
     'max-width': width,

--- a/src/mixins/fontFace.js
+++ b/src/mixins/fontFace.js
@@ -68,7 +68,7 @@ function fontFace({
     fileFormats = ['eot', 'woff2', 'woff', 'ttf', 'svg'],
     localFonts,
     unicodeRange,
-  }: FontFaceConfiguration) {
+  }: FontFaceConfiguration): Object {
   // Error Handling
   if (!fontFamily) throw new Error('fontFace expects a name of a font-family.')
   if (!fontFilePath && !localFonts) throw new Error('fontFace expects either the path to the font file(s) or a name of a local copy.')

--- a/src/mixins/hiDPI.js
+++ b/src/mixins/hiDPI.js
@@ -29,7 +29,7 @@
  * }
  */
 
-function hiDPI(ratio: number = 1.3) {
+function hiDPI(ratio: number = 1.3): string {
   return `
     @media only screen and (-webkit-min-device-pixel-ratio: ${ratio}),
     only screen and (min--moz-device-pixel-ratio: ${ratio}),

--- a/src/mixins/hideText.js
+++ b/src/mixins/hideText.js
@@ -26,7 +26,7 @@
  * }
  */
 
-function hideText() {
+function hideText(): Object {
   return {
     'text-indent': '101%',
     'overflow': 'hidden',

--- a/src/mixins/normalize.js
+++ b/src/mixins/normalize.js
@@ -38,7 +38,7 @@ function mergeRules(baseRules: Object, additionalRules: Object) {
  * } ...
  */
 
-function normalize(excludeOpinionated?: boolean) {
+function normalize(excludeOpinionated?: boolean): Object {
   const opinionatedRules = {
     'html': {
       'font-family': 'sans-serif',

--- a/src/mixins/placeholder.js
+++ b/src/mixins/placeholder.js
@@ -32,7 +32,7 @@
  * },
  */
 
-function placeholder(styles: Object, parent: string = '&') {
+function placeholder(styles: Object, parent: string = '&'): Object {
   return {
     [`${parent}::-webkit-input-placeholder`]: {
       ...styles,

--- a/src/mixins/radialGradient.js
+++ b/src/mixins/radialGradient.js
@@ -70,7 +70,7 @@ function radialGradient({
   fallback,
   position,
   shape,
-}: RadialGradientConfiguration) {
+}: RadialGradientConfiguration): Object {
   if (!colorStops || colorStops.length < 2) throw new Error('radialGradient requries at least 2 color-stops to properly render.')
   return {
     'background-color': fallback || parseFallback(colorStops),

--- a/src/mixins/retinaImage.js
+++ b/src/mixins/retinaImage.js
@@ -30,7 +30,7 @@ import hiDPI from './hiDPI'
  *   }
  * }
  */
-function retinaImage(filename: string, backgroundSize?: string, extension?: string = 'png', retinaFilename?: string, retinaSuffix?: string = '_2x') {
+function retinaImage(filename: string, backgroundSize?: string, extension?: string = 'png', retinaFilename?: string, retinaSuffix?: string = '_2x'): Object {
   if (!filename) {
     throw new Error('Please supply a filename to retinaImage() as the first argument.')
   }

--- a/src/mixins/selection.js
+++ b/src/mixins/selection.js
@@ -28,7 +28,7 @@
  * }
  */
 
-function selection(styles: Object, parent: string = '') {
+function selection(styles: Object, parent: string = ''): Object {
   return {
     [`${parent}::-moz-selection`]: {
       ...styles,

--- a/src/mixins/timingFunctions.js
+++ b/src/mixins/timingFunctions.js
@@ -79,7 +79,7 @@ type TimingFunction =
  * }
  */
 
-function timingFunctions(timingFunction: TimingFunction) {
+function timingFunctions(timingFunction: TimingFunction): string {
   return functionsMap[timingFunction]
 }
 

--- a/src/mixins/triangle.js
+++ b/src/mixins/triangle.js
@@ -58,7 +58,7 @@ const reverseDirection = {
  * }
  */
 
-function triangle({ pointingDirection, height, width, foregroundColor, backgroundColor = 'transparent' } : TriangleArgs) {
+function triangle({ pointingDirection, height, width, foregroundColor, backgroundColor = 'transparent' } : TriangleArgs): Object {
   const unitlessHeight = parseFloat(height)
   const unitlessWidth = parseFloat(width)
   if (isNaN(unitlessHeight) || isNaN(unitlessWidth)) {

--- a/src/mixins/wordWrap.js
+++ b/src/mixins/wordWrap.js
@@ -23,7 +23,7 @@
  * }
  */
 
-function wordWrap(wrap: string = 'break-word') {
+function wordWrap(wrap: string = 'break-word'): Object {
   const wordBreak = wrap === 'break-word' ? 'break-all' : wrap
   return {
     'overflow-wrap': wrap,

--- a/src/shorthands/animation.js
+++ b/src/shorthands/animation.js
@@ -39,7 +39,7 @@ type AnimationProperty = string|number
  *   'animation': 'rotate 1s ease-in-out'
  * }
  */
-function animation(...args: Array<Array<AnimationProperty>|AnimationProperty>) {
+function animation(...args: Array<Array<AnimationProperty>|AnimationProperty>): Object {
   // Allow single or multiple animations passed
   const multiMode = Array.isArray(args[0])
   if (!multiMode && args.length > 8) {

--- a/src/shorthands/backgroundImages.js
+++ b/src/shorthands/backgroundImages.js
@@ -20,7 +20,7 @@
  * }
  */
 
-function backgroundImages(...properties: Array<string>) {
+function backgroundImages(...properties: Array<string>): Object {
   return {
     'background-image': properties.join(', '),
   }

--- a/src/shorthands/backgrounds.js
+++ b/src/shorthands/backgrounds.js
@@ -19,7 +19,7 @@
  *   'background': 'url("/image/background.jpg"), linear-gradient(red, green), center no-repeat'
  * }
  */
-function backgrounds(...properties: Array<string>) {
+function backgrounds(...properties: Array<string>): Object {
   return {
     'background': properties.join(', '),
   }

--- a/src/shorthands/borderColor.js
+++ b/src/shorthands/borderColor.js
@@ -24,7 +24,7 @@ import directionalProperty from '../helpers/directionalProperty'
  * }
  */
 
-function borderColor(...values: Array<?string>) {
+function borderColor(...values: Array<?string>): Object {
   return directionalProperty('border-color', ...values)
 }
 

--- a/src/shorthands/borderRadius.js
+++ b/src/shorthands/borderRadius.js
@@ -21,7 +21,7 @@
  * }
  */
 
-function borderRadius(side:string, radius:string) {
+function borderRadius(side:string, radius:string): Object {
   if (!radius || typeof radius !== 'string') throw new Error('borderRadius expects a radius value as a string as the second argument.')
   if (side === 'top' || side === 'bottom') {
     return {

--- a/src/shorthands/borderStyle.js
+++ b/src/shorthands/borderStyle.js
@@ -24,7 +24,7 @@ import directionalProperty from '../helpers/directionalProperty'
  * }
  */
 
-function borderStyle(...values: Array<?string>) {
+function borderStyle(...values: Array<?string>): Object {
   return directionalProperty('border-style', ...values)
 }
 

--- a/src/shorthands/borderWidth.js
+++ b/src/shorthands/borderWidth.js
@@ -24,7 +24,7 @@ import directionalProperty from '../helpers/directionalProperty'
  * }
  */
 
-function borderWidth(...values: Array<?string>) {
+function borderWidth(...values: Array<?string>): Object {
   return directionalProperty('border-width', ...values)
 }
 

--- a/src/shorthands/buttons.js
+++ b/src/shorthands/buttons.js
@@ -45,7 +45,7 @@ type ButtonState =
  * }
  */
 
-function buttons(...states: Array<ButtonState>) {
+function buttons(...states: Array<ButtonState>): string {
   return statefulSelectors(states, template, stateMap)
 }
 

--- a/src/shorthands/margin.js
+++ b/src/shorthands/margin.js
@@ -24,7 +24,7 @@ import directionalProperty from '../helpers/directionalProperty'
  * }
  */
 
-function margin(...values: Array<?string>) {
+function margin(...values: Array<?string>): Object {
   return directionalProperty('margin', ...values)
 }
 

--- a/src/shorthands/padding.js
+++ b/src/shorthands/padding.js
@@ -24,7 +24,7 @@ import directionalProperty from '../helpers/directionalProperty'
  * }
  */
 
-function padding(...values: Array<?string>) {
+function padding(...values: Array<?string>): Object {
   return directionalProperty('padding', ...values)
 }
 

--- a/src/shorthands/position.js
+++ b/src/shorthands/position.js
@@ -46,7 +46,7 @@ const positionMap = ['absolute', 'fixed', 'relative', 'static', 'sticky']
  * }
  */
 
-function position(positionKeyword: string|null, ...values: Array<?string>) {
+function position(positionKeyword: string|null, ...values: Array<?string>): Object {
   if (positionMap.indexOf(positionKeyword) >= 0) {
     return {
       position: positionKeyword,

--- a/src/shorthands/size.js
+++ b/src/shorthands/size.js
@@ -21,7 +21,7 @@
  * }
  */
 
-function size(height: string, width: string = height) {
+function size(height: string, width: string = height): Object {
   return {
     height,
     width,

--- a/src/shorthands/textInputs.js
+++ b/src/shorthands/textInputs.js
@@ -69,7 +69,7 @@ type InputState =
  * }
  */
 
-function textInputs(...states: Array<InputState>) {
+function textInputs(...states: Array<InputState>): string {
   return statefulSelectors(states, template, stateMap)
 }
 

--- a/src/shorthands/transitions.js
+++ b/src/shorthands/transitions.js
@@ -20,7 +20,7 @@
  * }
  */
 
-function transitions(...properties: Array<string>) {
+function transitions(...properties: Array<string>): Object {
   return {
     'transition': properties.join(', '),
   }

--- a/typescript-test.ts
+++ b/typescript-test.ts
@@ -1,0 +1,153 @@
+import * as polished from "./lib/index";
+
+/*
+ * Mixins
+ */
+let clearFix: object = polished.clearFix();
+clearFix = polished.clearFix("&");
+
+let ellipsis: object = polished.ellipsis();
+ellipsis = polished.ellipsis("250px");
+
+const fontFace: object = polished.fontFace({
+  fontFamily: "Sans-Pro",
+  fontFilePath: "path/to/file",
+  fontStretch: "",
+  fontStyle: "",
+  fontVariant: "",
+  fontWeight: "",
+  fileFormats: [""],
+  localFonts: [""],
+  unicodeRange: ""
+});
+
+const hideText: object = polished.hideText();
+
+let hiDPI: string = polished.hiDPI();
+hiDPI = polished.hiDPI(1.5);
+
+let normalize: object = polished.normalize();
+normalize = polished.normalize(true);
+
+let placeholder: object = polished.placeholder({});
+placeholder = polished.placeholder({}, "");
+
+const radialGradient: object = polished.radialGradient({
+  colorStops: ["#00FFFF 0%", "rgba(0, 0, 255, 0) 50%", "#0000FF 95%"],
+  extent: "farthest-corner at 45px 45px",
+  position: "center",
+  shape: "ellipse",
+  fallback: ""
+});
+
+let retinaImage: object = polished.retinaImage("");
+retinaImage = polished.retinaImage("", "");
+retinaImage = polished.retinaImage("", "", "");
+retinaImage = polished.retinaImage("", "", "", "");
+retinaImage = polished.retinaImage("", "", "", "", "");
+
+let selection: object = polished.selection({});
+selection = polished.selection({}, "");
+
+
+const timingFunctions = polished.timingFunctions("easeInBack");
+
+
+const triangle = polished.triangle({
+  backgroundColor: "red",
+  foregroundColor: "red",
+  pointingDirection: "right",
+  width: 100,
+  height: 100,
+});
+
+let wordWrap: object = polished.wordWrap();
+wordWrap = polished.wordWrap("");
+
+/*
+ * Colors
+ */
+const adjustHue: string = polished.adjustHue(180, "#448");
+const complement: string = polished.complement("#448");
+const darken: string = polished.darken(0.2, "#FFCD64");
+const desaturate: string = polished.desaturate(0.2, "#CCCD64");
+const grayscale: string = polished.grayscale("#CCCD64");
+
+let hsl: string = polished.hsl(359, 0.75, 0.4);
+hsl = polished.hsl({ hue: 360, saturation: 0.75, lightness: 0.4 });
+
+let hsla: string = polished.hsla(359, 0.75, 0.4, 0.7);
+hsla = polished.hsla({ hue: 360, saturation: 0.75, lightness: 0.4, alpha: 0.7 });
+
+const invert: string = polished.invert("#CCCD64");
+const lighten: string = polished.lighten(0.2, "#CCCD64");
+const mix: string = polished.mix(0.5, "#f00", "#00f");
+const opacify: string = polished.opacify(0.1, "rgba(255, 255, 255, 0.9)");
+const parseToHsl = polished.parseToHsl("rgb(255, 0, 0)");
+const parseToRgb = polished.parseToRgb("rgb(255, 0, 0)");
+
+let rgb: string = polished.rgb(255, 205, 100);
+rgb = polished.rgb({ red: 255, green: 205, blue: 100 });
+
+let rgba: string = polished.rgba(255, 205, 100, 0.7);
+rgba = polished.rgba({ red: 255, green: 205, blue: 100, alpha: 0.7 });
+
+const saturate: string = polished.saturate(0.2, "#CCCD64");
+const setHue: string = polished.setHue(42, "#CCCD64");
+const setLightness: string = polished.setLightness(0.2, "#CCCD64");
+const setSaturation: string = polished.setSaturation(0.2, "#CCCD64");
+const shade: string = polished.shade(0.25, "#00f");
+const tint: string = polished.tint(0.25, "#00f");
+
+let toColorString: string = polished.toColorString({ red: 255, green: 205, blue: 100 });
+toColorString = polished.toColorString({ red: 255, green: 205, blue: 100, alpha: 0.72 });
+toColorString = polished.toColorString({ hue: 240, saturation: 1, lightness: 0.5 });
+toColorString = polished.toColorString({ hue: 360, saturation: 0.75, lightness: 0.4, alpha: 0.72 });
+
+const transparentize: string = polished.transparentize(0.1, "#fff");
+
+/*
+ * Shorthands
+ */
+
+const animation: object = polished.animation(["rotate", 1, "ease-in-out"], ["colorchange", "2s"]);
+const backgroundImages: object = polished.backgroundImages("url('/image/background.jpg')", "linear-gradient(red, green)");
+const backgrounds: object = polished.backgrounds("url('/image/background.jpg')", "linear-gradient(red, green)", "center no-repeat");
+const borderColor: object = polished.borderColor("red", null, undefined, "green");
+const borderRadius: object = polished.borderRadius("top", "5px");
+const borderStyle: object = polished.borderStyle("solid", null, undefined, "dashed");
+const borderWidth: object = polished.borderWidth("12px", null, undefined, "24px");
+const buttons: string = polished.buttons(null, undefined, "active");
+const margin: object = polished.margin("12px", null, undefined, "24px");
+const padding: object = polished.padding("12px", null, undefined, "24px");
+
+let position: object = polished.position(null);
+polished.position("absolute", "12px", null, undefined, "24px");
+position = polished.position(null, "12px", null, undefined, "24px");
+position = polished.position(undefined, "12px", null, undefined, "24px");
+
+let size: object = polished.size("");
+size = polished.size("", "");
+
+const textInputs: string = polished.textInputs("active", null, undefined);
+const transitions: object = polished.transitions("opacity 1.0s ease-in 0s", "width 2.0s ease-in 2s");
+
+/*
+ * Shorthands
+ */
+
+const directionalProperty: object = polished.directionalProperty("padding", "12px", null, undefined, "24px");
+
+let em: string = polished.em("12px");
+em = polished.em(12);
+
+let rem: string = polished.rem("12px");
+em = polished.rem(12);
+
+let modularScale: string = polished.modularScale(2);
+modularScale = polished.modularScale(2, 2);
+modularScale = polished.modularScale(2, "");
+modularScale = polished.modularScale(2, 2, 5);
+modularScale = polished.modularScale(2, 2, "minorSecond");
+
+const stripUnit: number | string = polished.stripUnit("100px");


### PR DESCRIPTION
This is a duplicate of/alternative to #154.  Instead of hand-writing declarations for typescript, I wrote a tool to auto-generate typescript definitions from flow type definitions.

I've only tested it against the polished codebase, so it will probably need extending over time.

This implementation has the advantage of being slightly more complete (I built proper currying support, and files remain typed even if you require them individually as 'polished/lib/whatever'). It is also guaranteed to be kept up to date as the source code changes.

It does force you to add some extra flow annotations, as it will not infer anything much.