### PR TITLE
Use 'break-word' as value in wordWrap example.

### DIFF
--- a/src/mixins/wordWrap.js
+++ b/src/mixins/wordWrap.js
@@ -6,19 +6,19 @@
  * @example
  * // Styles as object usage
  * const styles = {
- *   ...wordWrap('break-all')
+ *   ...wordWrap('break-word')
  * }
  *
  * // styled-components usage
  * const div = styled.div`
- *   ${wordWrap('break-all')}
+ *   ${wordWrap('break-word')}
  * `
  *
  * // CSS as JS Output
  *
  * const styles = {
- *   overflowWrap: 'break-all',
- *   wordWrap: 'break-all',
+ *   overflowWrap: 'break-word',
+ *   wordWrap: 'break-word',
  *   wordBreak: 'break-all',
  * }
  */


### PR DESCRIPTION
"break-all" is not a valid value for overflow-wrap and its alias word-wrap. It's only applicable to the non-standard word-break property. The example in the docs was inconsistent with the logic which accounted for this.