### PR TITLE
build(travis): Update travis build to use yarn/node 8 fully.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,17 @@ cache: yarn
 notifications:
   email: false
 node_js:
-  - '6'
+  - '8'
 before_script:
   - yarn global add codecov
   - yarn global add semantic-release
 script:
-  - npm test
-  - npm run lint
-  - npm run flow
-  - npm run build:flow
-  - npm run build:typescript
-  - npm run typescript
+  - yarn test
+  - yarn lint
+  - yarn flow
+  - yarn build:flow
+  - yarn build:typescript
+  - yarn typescript
 after_success:
   - codecov
   - 'curl -Lo travis_after_all.py https://git.io/travis_after_all'


### PR DESCRIPTION
Addresses build issue caused by semantic-release moving to support only node 8 (specific to yarn): https://github.com/semantic-release/semantic-release/issues/433