### PR TITLE
feat(shorthands): Shorthands now fully accept integers

### DIFF
--- a/src/helpers/directionalProperty.js
+++ b/src/helpers/directionalProperty.js
@@ -14,7 +14,10 @@ function generateProperty(property: string, position: string) {
   return property === joinedProperty ? `${property}${position}` : joinedProperty
 }
 
-function generateStyles(property: string, valuesWithDefaults: Array<?string>) {
+function generateStyles(
+  property: string,
+  valuesWithDefaults: Array<?string | ?number>,
+) {
   const styles = {}
   for (let i = 0; i < valuesWithDefaults.length; i += 1) {
     if (valuesWithDefaults[i]) {
@@ -49,7 +52,7 @@ function generateStyles(property: string, valuesWithDefaults: Array<?string>) {
 
 function directionalProperty(
   property: string,
-  ...values: Array<?string>
+  ...values: Array<?string | ?number>
 ): Object {
   //  prettier-ignore
   const [firstValue, secondValue = firstValue, thirdValue = firstValue, fourthValue = secondValue] = values

--- a/src/helpers/test/__snapshots__/directionalProperty.test.js.snap
+++ b/src/helpers/test/__snapshots__/directionalProperty.test.js.snap
@@ -1,9 +1,35 @@
+exports[`directionalProperty properly applies a integer value when passed only one 1`] = `
+Object {
+  "borderBottom": 12,
+  "borderLeft": 12,
+  "borderRight": 12,
+  "borderTop": 12,
+}
+`;
+
 exports[`directionalProperty properly applies a value when passed only one 1`] = `
 Object {
   "borderBottom": "12px",
   "borderLeft": "12px",
   "borderRight": "12px",
   "borderTop": "12px",
+}
+`;
+
+exports[`directionalProperty properly applies values when passed a mixture of three value types 1`] = `
+Object {
+  "borderLeft": "24px",
+  "borderRight": "24px",
+  "borderTop": 12,
+}
+`;
+
+exports[`directionalProperty properly applies values when passed a string and an integer 1`] = `
+Object {
+  "borderBottom": 12,
+  "borderLeft": "24px",
+  "borderRight": "24px",
+  "borderTop": 12,
 }
 `;
 
@@ -31,6 +57,23 @@ Object {
   "borderLeft": "24px",
   "borderRight": "24px",
   "borderTop": "12px",
+}
+`;
+
+exports[`directionalProperty properly applies values when passed two integers 1`] = `
+Object {
+  "borderBottom": 12,
+  "borderLeft": 24,
+  "borderRight": 24,
+  "borderTop": 12,
+}
+`;
+
+exports[`directionalProperty properly applies valuew when passed a mixture of four value types 1`] = `
+Object {
+  "borderBottom": 36,
+  "borderRight": "24px",
+  "borderTop": 12,
 }
 `;
 

--- a/src/helpers/test/directionalProperty.test.js
+++ b/src/helpers/test/directionalProperty.test.js
@@ -19,9 +19,19 @@ describe('directionalProperty', () => {
     expect(directionalProperty('border', '12px')).toMatchSnapshot()
   })
 
+  it('properly applies a integer value when passed only one', () => {
+    expect(directionalProperty('border', 12)).toMatchSnapshot()
+  })
+
   // Two Params
   it('properly applies values when passed two', () => {
     expect(directionalProperty('border', '12px', '24px')).toMatchSnapshot()
+  })
+  it('properly applies values when passed two integers', () => {
+    expect(directionalProperty('border', 12, 24)).toMatchSnapshot()
+  })
+  it('properly applies values when passed a string and an integer', () => {
+    expect(directionalProperty('border', 12, '24px')).toMatchSnapshot()
   })
   it('properly skips top and bottom properties when first value is null', () => {
     expect(directionalProperty('border', null, '12px')).toMatchSnapshot()
@@ -51,6 +61,9 @@ describe('directionalProperty', () => {
       directionalProperty('border', '12px', '24px', null),
     ).toMatchSnapshot()
   })
+  it('properly applies values when passed a mixture of three value types', () => {
+    expect(directionalProperty('border', 12, '24px', null)).toMatchSnapshot()
+  })
 
   // Four Params
   it('properly applies values when passed four', () => {
@@ -76,6 +89,11 @@ describe('directionalProperty', () => {
   it('properly skips left property when fourth value is null', () => {
     expect(
       directionalProperty('border', '12px', '24px', '36px', null),
+    ).toMatchSnapshot()
+  })
+  it('properly applies valuew when passed a mixture of four value types', () => {
+    expect(
+      directionalProperty('border', 12, '24px', 36, null),
     ).toMatchSnapshot()
   })
 })

--- a/src/mixins/ellipsis.js
+++ b/src/mixins/ellipsis.js
@@ -26,7 +26,7 @@
  * }
  */
 
-function ellipsis(width?: string = '100%'): Object {
+function ellipsis(width?: string | number = '100%'): Object {
   return {
     display: 'inline-block',
     maxWidth: width,

--- a/src/mixins/test/__snapshots__/ellipsis.test.js.snap
+++ b/src/mixins/test/__snapshots__/ellipsis.test.js.snap
@@ -9,10 +9,10 @@ Object {
 }
 `;
 
-exports[`ellipsis should pass parameter to the value of max-width 1`] = `
+exports[`ellipsis should pass parameter of type integer to the value of max-width 1`] = `
 Object {
   "display": "inline-block",
-  "maxWidth": "300px",
+  "maxWidth": 300,
   "overflow": "hidden",
   "textOverflow": "ellipsis",
   "whiteSpace": "nowrap",
@@ -20,9 +20,8 @@ Object {
 }
 `;
 
-exports[`ellipsis should properly add rules when block has existing rules 1`] = `
+exports[`ellipsis should pass parameter to the value of max-width 1`] = `
 Object {
-  "background": "red",
   "display": "inline-block",
   "maxWidth": "300px",
   "overflow": "hidden",

--- a/src/mixins/test/ellipsis.test.js
+++ b/src/mixins/test/ellipsis.test.js
@@ -6,11 +6,8 @@ describe('ellipsis', () => {
     expect({ ...ellipsis('300px') }).toMatchSnapshot()
   })
 
-  it('should properly add rules when block has existing rules', () => {
-    expect({
-      background: 'red',
-      ...ellipsis('300px'),
-    }).toMatchSnapshot()
+  it('should pass parameter of type integer to the value of max-width', () => {
+    expect({ ...ellipsis(300) }).toMatchSnapshot()
   })
 
   it('should default max-width to 100%', () => {

--- a/src/shorthands/borderRadius.js
+++ b/src/shorthands/borderRadius.js
@@ -22,11 +22,11 @@ import capitalizeString from '../internalHelpers/_capitalizeString'
  * }
  */
 
-function borderRadius(side: string, radius: string): Object {
+function borderRadius(side: string, radius: string | number): Object {
   const uppercaseSide = capitalizeString(side)
-  if (!radius || typeof radius !== 'string') {
+  if (!radius) {
     throw new Error(
-      'borderRadius expects a radius value as a string as the second argument.',
+      'borderRadius expects a radius value as a string or number as the second argument.',
     )
   }
   if (uppercaseSide === 'Top' || uppercaseSide === 'Bottom') {

--- a/src/shorthands/borderWidth.js
+++ b/src/shorthands/borderWidth.js
@@ -23,7 +23,7 @@ import directionalProperty from '../helpers/directionalProperty'
  *   'borderLeftWidth': '48px'
  * }
  */
-function borderWidth(...values: Array<?string>): Object {
+function borderWidth(...values: Array<?string | ?number>): Object {
   return directionalProperty('borderWidth', ...values)
 }
 

--- a/src/shorthands/margin.js
+++ b/src/shorthands/margin.js
@@ -24,7 +24,7 @@ import directionalProperty from '../helpers/directionalProperty'
  * }
  */
 
-function margin(...values: Array<?string>): Object {
+function margin(...values: Array<?string | ?number>): Object {
   return directionalProperty('margin', ...values)
 }
 

--- a/src/shorthands/padding.js
+++ b/src/shorthands/padding.js
@@ -24,7 +24,7 @@ import directionalProperty from '../helpers/directionalProperty'
  * }
  */
 
-function padding(...values: Array<?string>): Object {
+function padding(...values: Array<?string | ?number>): Object {
   return directionalProperty('padding', ...values)
 }
 

--- a/src/shorthands/position.js
+++ b/src/shorthands/position.js
@@ -48,7 +48,7 @@ const positionMap = ['absolute', 'fixed', 'relative', 'static', 'sticky']
 
 function position(
   positionKeyword: string | null,
-  ...values: Array<?string>
+  ...values: Array<?string | ?number>
 ): Object {
   if (positionMap.indexOf(positionKeyword) >= 0) {
     return {

--- a/src/shorthands/size.js
+++ b/src/shorthands/size.js
@@ -21,7 +21,10 @@
  * }
  */
 
-function size(height: string, width?: string = height): Object {
+function size(
+  height: string | number,
+  width?: string | number = height,
+): Object {
   return {
     height,
     width,

--- a/src/shorthands/test/__snapshots__/borderRadius.test.js.snap
+++ b/src/shorthands/test/__snapshots__/borderRadius.test.js.snap
@@ -25,3 +25,10 @@ Object {
   "borderTopRightRadius": "5px",
 }
 `;
+
+exports[`borderRadius returns the proper values when passed an integer 1`] = `
+Object {
+  "borderBottomLeftRadius": 5,
+  "borderTopLeftRadius": 5,
+}
+`;

--- a/src/shorthands/test/__snapshots__/borderWidth.test.js.snap
+++ b/src/shorthands/test/__snapshots__/borderWidth.test.js.snap
@@ -16,6 +16,15 @@ Object {
 }
 `;
 
+exports[`borderWidth properly applies values when passed integers 1`] = `
+Object {
+  "borderBottomWidth": 36,
+  "borderLeftWidth": 48,
+  "borderRightWidth": 24,
+  "borderTopWidth": 12,
+}
+`;
+
 exports[`borderWidth properly applies values when passed three 1`] = `
 Object {
   "borderBottomWidth": "36px",

--- a/src/shorthands/test/__snapshots__/margin.test.js.snap
+++ b/src/shorthands/test/__snapshots__/margin.test.js.snap
@@ -16,6 +16,15 @@ Object {
 }
 `;
 
+exports[`margin properly applies values when passed four 2`] = `
+Object {
+  "marginBottom": 36,
+  "marginLeft": 48,
+  "marginRight": 24,
+  "marginTop": 12,
+}
+`;
+
 exports[`margin properly applies values when passed three 1`] = `
 Object {
   "marginBottom": "36px",

--- a/src/shorthands/test/__snapshots__/padding.test.js.snap
+++ b/src/shorthands/test/__snapshots__/padding.test.js.snap
@@ -16,6 +16,15 @@ Object {
 }
 `;
 
+exports[`padding properly applies values when passed four 2`] = `
+Object {
+  "paddingBottom": 36,
+  "paddingLeft": 48,
+  "paddingRight": 24,
+  "paddingTop": 12,
+}
+`;
+
 exports[`padding properly applies values when passed three 1`] = `
 Object {
   "paddingBottom": "36px",

--- a/src/shorthands/test/__snapshots__/position.test.js.snap
+++ b/src/shorthands/test/__snapshots__/position.test.js.snap
@@ -18,6 +18,16 @@ Object {
 }
 `;
 
+exports[`position properly applies values when passed four integers 1`] = `
+Object {
+  "bottom": 36,
+  "left": 48,
+  "position": "relative",
+  "right": 24,
+  "top": 12,
+}
+`;
+
 exports[`position properly applies values when passed three 1`] = `
 Object {
   "bottom": "36px",

--- a/src/shorthands/test/__snapshots__/size.test.js.snap
+++ b/src/shorthands/test/__snapshots__/size.test.js.snap
@@ -5,11 +5,10 @@ Object {
 }
 `;
 
-exports[`size should properly add rules when block has existing rules 1`] = `
+exports[`size should pass parameters to the values of height and width when passed integers 1`] = `
 Object {
-  "background": "red",
-  "height": "300px",
-  "width": "250px",
+  "height": 300,
+  "width": 250,
 }
 `;
 

--- a/src/shorthands/test/borderRadius.test.js
+++ b/src/shorthands/test/borderRadius.test.js
@@ -14,20 +14,15 @@ describe('borderRadius', () => {
   it('returns the proper values for the left side', () => {
     expect(borderRadius('left', '5px')).toMatchSnapshot()
   })
-  it('should throw an error when an invalid radius value is provided', () => {
-    expect(() => {
-      // $FlowFixMe
-      borderRadius('top')
-    }).toThrow(
-      'borderRadius expects a radius value as a string as the second argument.',
-    )
+  it('returns the proper values when passed an integer', () => {
+    expect(borderRadius('left', 5)).toMatchSnapshot()
   })
   it('should throw an error when no radius value is provided', () => {
     expect(() => {
       // $FlowFixMe
-      borderRadius('top', 100)
+      borderRadius('top')
     }).toThrow(
-      'borderRadius expects a radius value as a string as the second argument.',
+      'borderRadius expects a radius value as a string or number as the second argument.',
     )
   })
   it('should throw an error when an invalid side value is provided', () => {

--- a/src/shorthands/test/borderWidth.test.js
+++ b/src/shorthands/test/borderWidth.test.js
@@ -14,4 +14,7 @@ describe('borderWidth', () => {
   it('properly applies values when passed four', () => {
     expect(borderWidth('12px', '24px', '36px', '48px')).toMatchSnapshot()
   })
+  it('properly applies values when passed integers', () => {
+    expect(borderWidth(12, 24, 36, 48)).toMatchSnapshot()
+  })
 })

--- a/src/shorthands/test/margin.test.js
+++ b/src/shorthands/test/margin.test.js
@@ -14,4 +14,7 @@ describe('margin', () => {
   it('properly applies values when passed four', () => {
     expect(margin('12px', '24px', '36px', '48px')).toMatchSnapshot()
   })
+  it('properly applies values when passed four', () => {
+    expect(margin(12, 24, 36, 48)).toMatchSnapshot()
+  })
 })

--- a/src/shorthands/test/padding.test.js
+++ b/src/shorthands/test/padding.test.js
@@ -14,4 +14,7 @@ describe('padding', () => {
   it('properly applies values when passed four', () => {
     expect(padding('12px', '24px', '36px', '48px')).toMatchSnapshot()
   })
+  it('properly applies values when passed four', () => {
+    expect(padding(12, 24, 36, 48)).toMatchSnapshot()
+  })
 })

--- a/src/shorthands/test/position.test.js
+++ b/src/shorthands/test/position.test.js
@@ -19,4 +19,7 @@ describe('position', () => {
   it('properly ignores position property, when not passed one', () => {
     expect(position('12px', '24px', '36px', '48px')).toMatchSnapshot()
   })
+  it('properly applies values when passed four integers', () => {
+    expect(position('relative', 12, 24, 36, 48)).toMatchSnapshot()
+  })
 })

--- a/src/shorthands/test/size.test.js
+++ b/src/shorthands/test/size.test.js
@@ -6,14 +6,11 @@ describe('size', () => {
     expect({ ...size('300px', '250px') }).toMatchSnapshot()
   })
 
-  it('should properly add rules when block has existing rules', () => {
-    expect({
-      background: 'red',
-      ...size('300px', '250px'),
-    }).toMatchSnapshot()
-  })
-
   it('should set height and width to the same value when only one parameter is passed', () => {
     expect({ ...size('300px') }).toMatchSnapshot()
+  })
+
+  it('should pass parameters to the values of height and width when passed integers', () => {
+    expect({ ...size(300, 250) }).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
Shorthand modules have been updated to allow unitless values as integers for better ReactNative
compatibility. Flow types now also reflect this.

Addresses: #246