### PR TITLE
Permit zero for directionalProperty, borderRadius

### DIFF
--- a/src/helpers/directionalProperty.js
+++ b/src/helpers/directionalProperty.js
@@ -20,7 +20,7 @@ function generateStyles(
 ) {
   const styles = {}
   for (let i = 0; i < valuesWithDefaults.length; i += 1) {
-    if (valuesWithDefaults[i]) {
+    if (valuesWithDefaults[i] || valuesWithDefaults[i] === 0) {
       styles[generateProperty(property, positionMap[i])] = valuesWithDefaults[i]
     }
   }

--- a/src/helpers/test/__snapshots__/directionalProperty.test.js.snap
+++ b/src/helpers/test/__snapshots__/directionalProperty.test.js.snap
@@ -104,6 +104,15 @@ Object {
 }
 `;
 
+exports[`directionalProperty properly sets unitless 0 1`] = `
+Object {
+  "bottom": 0,
+  "left": 0,
+  "right": 0,
+  "top": 0,
+}
+`;
+
 exports[`directionalProperty properly skips bottom property when last value is null 1`] = `
 Object {
   "borderLeft": "24px",

--- a/src/helpers/test/directionalProperty.test.js
+++ b/src/helpers/test/directionalProperty.test.js
@@ -14,6 +14,10 @@ describe('directionalProperty', () => {
     expect(directionalProperty('', '12px')).toMatchSnapshot()
   })
 
+  it('properly sets unitless 0', () => {
+    expect(directionalProperty('', 0)).toMatchSnapshot()
+  })
+
   // One Param
   it('properly applies a value when passed only one', () => {
     expect(directionalProperty('border', '12px')).toMatchSnapshot()

--- a/src/shorthands/borderRadius.js
+++ b/src/shorthands/borderRadius.js
@@ -24,7 +24,7 @@ import capitalizeString from '../internalHelpers/_capitalizeString'
 
 function borderRadius(side: string, radius: string | number): Object {
   const uppercaseSide = capitalizeString(side)
-  if (!radius) {
+  if (!radius && radius !== 0) {
     throw new Error(
       'borderRadius expects a radius value as a string or number as the second argument.',
     )

--- a/src/shorthands/test/__snapshots__/borderRadius.test.js.snap
+++ b/src/shorthands/test/__snapshots__/borderRadius.test.js.snap
@@ -32,3 +32,10 @@ Object {
   "borderTopLeftRadius": 5,
 }
 `;
+
+exports[`borderRadius returns the proper values when passed zero 1`] = `
+Object {
+  "borderBottomLeftRadius": 0,
+  "borderTopLeftRadius": 0,
+}
+`;

--- a/src/shorthands/test/__snapshots__/borderWidth.test.js.snap
+++ b/src/shorthands/test/__snapshots__/borderWidth.test.js.snap
@@ -42,3 +42,12 @@ Object {
   "borderTopWidth": "12px",
 }
 `;
+
+exports[`borderWidth properly applies values when passed zero 1`] = `
+Object {
+  "borderBottomWidth": 0,
+  "borderLeftWidth": 0,
+  "borderRightWidth": 0,
+  "borderTopWidth": 0,
+}
+`;

--- a/src/shorthands/test/__snapshots__/margin.test.js.snap
+++ b/src/shorthands/test/__snapshots__/margin.test.js.snap
@@ -42,3 +42,12 @@ Object {
   "marginTop": "12px",
 }
 `;
+
+exports[`margin properly applies zero value 1`] = `
+Object {
+  "marginBottom": 0,
+  "marginLeft": 0,
+  "marginRight": 0,
+  "marginTop": 0,
+}
+`;

--- a/src/shorthands/test/__snapshots__/padding.test.js.snap
+++ b/src/shorthands/test/__snapshots__/padding.test.js.snap
@@ -42,3 +42,12 @@ Object {
   "paddingTop": "12px",
 }
 `;
+
+exports[`padding properly applies zero value 1`] = `
+Object {
+  "paddingBottom": 0,
+  "paddingLeft": 0,
+  "paddingRight": 0,
+  "paddingTop": 0,
+}
+`;

--- a/src/shorthands/test/__snapshots__/position.test.js.snap
+++ b/src/shorthands/test/__snapshots__/position.test.js.snap
@@ -48,6 +48,16 @@ Object {
 }
 `;
 
+exports[`position properly applies zero value 1`] = `
+Object {
+  "bottom": 0,
+  "left": 0,
+  "position": "relative",
+  "right": 0,
+  "top": 0,
+}
+`;
+
 exports[`position properly ignores position property, when not passed one 1`] = `
 Object {
   "bottom": "36px",

--- a/src/shorthands/test/__snapshots__/size.test.js.snap
+++ b/src/shorthands/test/__snapshots__/size.test.js.snap
@@ -12,6 +12,13 @@ Object {
 }
 `;
 
+exports[`size should pass parameters to the values of height and width when passed zero 1`] = `
+Object {
+  "height": 0,
+  "width": 0,
+}
+`;
+
 exports[`size should set height and width to the same value when only one parameter is passed 1`] = `
 Object {
   "height": "300px",

--- a/src/shorthands/test/borderRadius.test.js
+++ b/src/shorthands/test/borderRadius.test.js
@@ -17,6 +17,9 @@ describe('borderRadius', () => {
   it('returns the proper values when passed an integer', () => {
     expect(borderRadius('left', 5)).toMatchSnapshot()
   })
+  it('returns the proper values when passed zero', () => {
+    expect(borderRadius('left', 0)).toMatchSnapshot()
+  })
   it('should throw an error when no radius value is provided', () => {
     expect(() => {
       // $FlowFixMe

--- a/src/shorthands/test/borderWidth.test.js
+++ b/src/shorthands/test/borderWidth.test.js
@@ -17,4 +17,7 @@ describe('borderWidth', () => {
   it('properly applies values when passed integers', () => {
     expect(borderWidth(12, 24, 36, 48)).toMatchSnapshot()
   })
+  it('properly applies values when passed zero', () => {
+    expect(borderWidth(0)).toMatchSnapshot()
+  })
 })

--- a/src/shorthands/test/margin.test.js
+++ b/src/shorthands/test/margin.test.js
@@ -17,4 +17,7 @@ describe('margin', () => {
   it('properly applies values when passed four', () => {
     expect(margin(12, 24, 36, 48)).toMatchSnapshot()
   })
+  it('properly applies zero value', () => {
+    expect(margin(0)).toMatchSnapshot()
+  })
 })

--- a/src/shorthands/test/padding.test.js
+++ b/src/shorthands/test/padding.test.js
@@ -17,4 +17,7 @@ describe('padding', () => {
   it('properly applies values when passed four', () => {
     expect(padding(12, 24, 36, 48)).toMatchSnapshot()
   })
+  it('properly applies zero value', () => {
+    expect(padding(0)).toMatchSnapshot()
+  })
 })

--- a/src/shorthands/test/position.test.js
+++ b/src/shorthands/test/position.test.js
@@ -22,4 +22,7 @@ describe('position', () => {
   it('properly applies values when passed four integers', () => {
     expect(position('relative', 12, 24, 36, 48)).toMatchSnapshot()
   })
+  it('properly applies zero value', () => {
+    expect(position('relative', 0)).toMatchSnapshot()
+  })
 })

--- a/src/shorthands/test/size.test.js
+++ b/src/shorthands/test/size.test.js
@@ -13,4 +13,8 @@ describe('size', () => {
   it('should pass parameters to the values of height and width when passed integers', () => {
     expect({ ...size(300, 250) }).toMatchSnapshot()
   })
+
+  it('should pass parameters to the values of height and width when passed zero', () => {
+    expect({ ...size(0) }).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
https://github.com/styled-components/polished/pull/255 introduced integer values for many shorthand functions. However many of these disallow zero because `0` isn't truthy.

This changes updates `directionalProperty` and `borderRadius` helpers to allow zero, as well as adding several tests.