### PR TITLE
Feature/shorthand for border

### DIFF
--- a/src/shorthands/border.js
+++ b/src/shorthands/border.js
@@ -3,7 +3,7 @@ import directionalProperty from '../helpers/directionalProperty'
 const propertyMap = ['borderWidth', 'borderStyle', 'borderColor']
 
 /**
- * Shorthand that accepts up to four values, including null to skip a value, and maps them to their respective directions.
+ * Shorthand that accepts three values, one of each of the properties borderWidth, borderStyle and borderColor.
  * @example
  * // Styles as object usage
  * const styles = {

--- a/src/shorthands/border.js
+++ b/src/shorthands/border.js
@@ -1,0 +1,44 @@
+import directionalProperty from '../helpers/directionalProperty'
+
+const propertyMap = ['borderWidth', 'borderStyle', 'borderColor']
+
+/**
+ * Shorthand that accepts up to four values, including null to skip a value, and maps them to their respective directions.
+ * @example
+ * // Styles as object usage
+ * const styles = {
+ *   ...border('2px', 'solid', '#000')
+ * }
+ *
+ * // styled-components usage
+ * const div = styled.div`
+ *   ${borderWidth('2px', 'solid', '#000')}
+ * `
+ *
+ * // CSS as JS Output
+ *
+ * div {
+ *   'borderBottomColor': '#000',
+ *   'borderBottomStyle': 'solid',
+ *   'borderBottomWidth': '2px',
+ *   'borderLeftColor': '#000',
+ *   'borderLeftStyle': 'solid',
+ *   'borderLeftWidth': '2px',
+ *   'borderRightColor': '#000',
+ *   'borderRightStyle': 'solid',
+ *   'borderRightWidth': '2px',
+ *   'borderTopColor': '#000',
+ *   'borderTopStyle': 'solid',
+ *   'borderTopWidth': '2px',
+ * }
+ */
+function border(...values: Array<?string | ?number>): Object {
+  let styles = {}
+  for (let i = 0; i < Math.min(values.length, propertyMap.length); i += 1) {
+    styles = { ...styles, ...directionalProperty(propertyMap[i], values[i]) }
+  }
+
+  return styles
+}
+
+export default border

--- a/src/shorthands/test/__snapshots__/border.test.js.snap
+++ b/src/shorthands/test/__snapshots__/border.test.js.snap
@@ -1,0 +1,38 @@
+exports[`border properly applies a value when passed only borderWidth 1`] = `
+Object {
+  "borderBottomWidth": "2px",
+  "borderLeftWidth": "2px",
+  "borderRightWidth": "2px",
+  "borderTopWidth": "2px",
+}
+`;
+
+exports[`border properly applies values when passed borderWidth and borderStyle 1`] = `
+Object {
+  "borderBottomStyle": "solid",
+  "borderBottomWidth": "2px",
+  "borderLeftStyle": "solid",
+  "borderLeftWidth": "2px",
+  "borderRightStyle": "solid",
+  "borderRightWidth": "2px",
+  "borderTopStyle": "solid",
+  "borderTopWidth": "2px",
+}
+`;
+
+exports[`border properly applies values when passed borderWidth, borderStyle and borderColor 1`] = `
+Object {
+  "borderBottomColor": "#000",
+  "borderBottomStyle": "dashed",
+  "borderBottomWidth": "2px",
+  "borderLeftColor": "#000",
+  "borderLeftStyle": "dashed",
+  "borderLeftWidth": "2px",
+  "borderRightColor": "#000",
+  "borderRightStyle": "dashed",
+  "borderRightWidth": "2px",
+  "borderTopColor": "#000",
+  "borderTopStyle": "dashed",
+  "borderTopWidth": "2px",
+}
+`;

--- a/src/shorthands/test/border.test.js
+++ b/src/shorthands/test/border.test.js
@@ -1,0 +1,13 @@
+import border from '../border'
+
+describe('border', () => {
+  it('properly applies a value when passed only borderWidth', () => {
+    expect(border('2px')).toMatchSnapshot()
+  })
+  it('properly applies values when passed borderWidth and borderStyle', () => {
+    expect(border('2px', 'solid')).toMatchSnapshot()
+  })
+  it('properly applies values when passed borderWidth, borderStyle and borderColor', () => {
+    expect(border('2px', 'dashed', '#000')).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
I use this shorthand for border in CSS a lot.
```css
border: 1px solid #000;
```
It would be really convenient to have a function like this.
```javascript
...border('1px', 'solid', '#000')
```
That outputs something like this.
```javascript
'borderWidth': '1px';
'borderStyle': 'solid';
'borderColor': '#000';
```
And/Or functions for each of the four directions like this.
```javascript
...borderTop('1px', 'solid', '#000')
...borderRight('1px', 'solid', '#000')
...borderBottom('1px', 'solid', '#000')
...borderLeft('1px', 'solid', '#000')
```

This PR could help with this issue ( #264 )
If this change can be helpful, I could add it to docs as well.