### PR TITLE
chore(deps): Updated babel-plugin-annotate-pure-calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "babel-jest": "^16.0.0",
     "babel-loader": "^6.2.7",
     "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-plugin-annotate-pure-calls": "^0.2.0",
+    "babel-plugin-annotate-pure-calls": "^0.2.1",
     "babel-plugin-external-helpers": "^6.18.0",
     "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
     "babel-plugin-transform-flow-strip-types": "^6.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -523,9 +523,9 @@ babel-plugin-add-module-exports@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-0.2.1.tgz#9ae9a1f4a8dc67f0cdec4f4aeda1e43a5ff65e25"
 
-babel-plugin-annotate-pure-calls@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-annotate-pure-calls/-/babel-plugin-annotate-pure-calls-0.2.0.tgz#4224fbaa1f5ff689dac3956846a1db562e506db8"
+babel-plugin-annotate-pure-calls@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-annotate-pure-calls/-/babel-plugin-annotate-pure-calls-0.2.1.tgz#ef92cd9f5dc3a8cc566909cfb44b226d0fdaa09f"
   dependencies:
     babel-plugin-syntax-dynamic-import "^6.18.0"
 


### PR DESCRIPTION
I've checked and it doesn't introduce any change to your output, but the important issue got fixed in the plugin. Anyway it's always better to upgrade ;)