### PR TITLE
docs(style)Improve color contrast for sidebar text

### DIFF
--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -169,7 +169,7 @@ h4 {
 }
 
 a {
-  color: #9a255d;
+  color: #0D3523;
   text-decoration: none;
 }
 


### PR DESCRIPTION
Proposing this color change to improve accessibility, by using a color that has higher contrast ratio against the background. 

Before: 
![original](https://user-images.githubusercontent.com/22401912/32481955-7864ea5a-c34a-11e7-81f1-9ecb6fa6897d.png)
After: 
![proposed](https://user-images.githubusercontent.com/22401912/32481956-787e8d7a-c34a-11e7-94f3-c3ece08b7040.png)

