### PR TITLE
docs(style)Improve color contrast for sidebar text

### DIFF
--- a/docs-theme/assets/style.css
+++ b/docs-theme/assets/style.css
@@ -169,7 +169,7 @@ h4 {
 }
 
 a {
-  color: #9a255d;
+  color: #0D3523;
   text-decoration: none;
 }
 


### PR DESCRIPTION
Proposing this color change to improve accessibility, by using a color that has higher contrast ratio against the background.

Before: 
![original](https://user-images.githubusercontent.com/22401912/32686197-c6a64fd4-c655-11e7-89c6-f157dac2caec.png)
After:
![proposed](https://user-images.githubusercontent.com/22401912/32686198-c88f339c-c655-11e7-9216-539c04223bee.png)

