### PR TITLE
build: lock rollup-plugin-commonjs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "ramda": "^0.23.0",
     "rollup": "^0.50.0",
     "rollup-plugin-babel": "^3.0.2",
-    "rollup-plugin-commonjs": "^8.2.1",
+    "rollup-plugin-commonjs": "8.2.1",
     "rollup-plugin-flow": "^1.1.1",
     "rollup-plugin-inject": "^2.0.0",
     "rollup-plugin-json": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5278,7 +5278,7 @@ rollup-plugin-babel@^3.0.2:
   dependencies:
     rollup-pluginutils "^1.5.0"
 
-rollup-plugin-commonjs@^8.2.1:
+rollup-plugin-commonjs@8.2.1:
   version "8.2.1"
   resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.2.1.tgz#5e40c78375eb163c14c76bce69da1750e5905a2e"
   dependencies:


### PR DESCRIPTION
Lock rollup-plugin-commonjs version to prevent the build from throwing when running `npm install` instead of `yarn install` untill https://github.com/rollup/rollup-plugin-commonjs/issues/275 is resolved.

fixes #279