### PR TITLE
feat(border): Border shorthand

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -53,6 +53,7 @@ import transparentize from './color/transparentize'
 import animation from './shorthands/animation'
 import backgroundImages from './shorthands/backgroundImages'
 import backgrounds from './shorthands/backgrounds'
+import border from './shorthands/border'
 import borderColor from './shorthands/borderColor'
 import borderRadius from './shorthands/borderRadius'
 import borderStyle from './shorthands/borderStyle'
@@ -70,6 +71,7 @@ export {
   animation,
   backgroundImages,
   backgrounds,
+  border,
   borderColor,
   borderRadius,
   borderStyle,

--- a/src/shorthands/border.js
+++ b/src/shorthands/border.js
@@ -1,0 +1,69 @@
+// @flow
+import capitalizeString from '../internalHelpers/_capitalizeString'
+
+import type { SideKeyword } from '../types/sideKeyword'
+
+const sideMap = ['top', 'right', 'bottom', 'left']
+
+/**
+ * Shorthand for the border property that splits out individual properties for use with tools like Fela and Styletron. A side keyword can optionally be passed to target only one side's border properties.
+ *
+ * @example
+ * // Styles as object usage
+ * const styles = {
+ *   ...border('1px', 'solid', 'red')
+ * }
+ *
+ * // styled-components usage
+ * const div = styled.div`
+ *   ${border('1px', 'solid', 'red')}
+ * `
+ *
+ * // CSS as JS Output
+ *
+ * div {
+ *   'borderColor': 'red',
+ *   'borderStyle': 'solid',
+ *   'borderWidth': `1px`,
+ * }
+ *
+ * // Styles as object usage
+ * const styles = {
+ *   ...border('top', '1px', 'solid', 'red')
+ * }
+ *
+ * // styled-components usage
+ * const div = styled.div`
+ *   ${border('top', '1px', 'solid', 'red')}
+ * `
+ *
+ * // CSS as JS Output
+ *
+ * div {
+ *   'borderTopColor': 'red',
+ *   'borderTopStyle': 'solid',
+ *   'borderTopWidth': `1px`,
+ * }
+ */
+
+function border(
+  sideKeyword: SideKeyword | string | number,
+  ...values: Array<string | number>
+): Object {
+  if (typeof sideKeyword === 'string' && sideMap.indexOf(sideKeyword) >= 0) {
+    return {
+      [`border${capitalizeString(sideKeyword)}Width`]: values[0],
+      [`border${capitalizeString(sideKeyword)}Style`]: values[1],
+      [`border${capitalizeString(sideKeyword)}Color`]: values[2],
+    }
+  } else {
+    values.unshift(sideKeyword)
+    return {
+      borderWidth: values[0],
+      borderStyle: values[1],
+      borderColor: values[2],
+    }
+  }
+}
+
+export default border

--- a/src/shorthands/test/__snapshots__/border.test.js.snap
+++ b/src/shorthands/test/__snapshots__/border.test.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`border properly returns separated border styles 1`] = `
+Object {
+  "borderColor": "red",
+  "borderStyle": "solid",
+  "borderWidth": "1px",
+}
+`;
+
+exports[`border properly returns separated border styles for a specific side 1`] = `
+Object {
+  "borderTopColor": "red",
+  "borderTopStyle": "solid",
+  "borderTopWidth": "1px",
+}
+`;
+
+exports[`border properly returns separated border styles for a specific side when passed a number for borderWidth 1`] = `
+Object {
+  "borderTopColor": "red",
+  "borderTopStyle": "solid",
+  "borderTopWidth": 1,
+}
+`;
+
+exports[`border properly returns separated border styles when passed a number for borderWidth 1`] = `
+Object {
+  "borderColor": "red",
+  "borderStyle": "solid",
+  "borderWidth": 1,
+}
+`;

--- a/src/shorthands/test/border.test.js
+++ b/src/shorthands/test/border.test.js
@@ -1,0 +1,17 @@
+// @flow
+import border from '../border'
+
+describe('border', () => {
+  it('properly returns separated border styles', () => {
+    expect(border('1px', 'solid', 'red')).toMatchSnapshot()
+  })
+  it('properly returns separated border styles for a specific side', () => {
+    expect(border('top', '1px', 'solid', 'red')).toMatchSnapshot()
+  })
+  it('properly returns separated border styles when passed a number for borderWidth', () => {
+    expect(border(1, 'solid', 'red')).toMatchSnapshot()
+  })
+  it('properly returns separated border styles for a specific side when passed a number for borderWidth', () => {
+    expect(border('top', 1, 'solid', 'red')).toMatchSnapshot()
+  })
+})

--- a/src/types/sideKeyword.js
+++ b/src/types/sideKeyword.js
@@ -1,0 +1,9 @@
+// @flow
+
+// Note: we define properties with JSdoc since documentation.js doesn't recognize
+// exported types yet. See https://github.com/documentationjs/documentation/issues/680
+
+/**
+ * @property {top, right, bottom, left} SideKeyword
+ */
+export type SideKeyword = 'top' | 'right' | 'bottom' | 'left'


### PR DESCRIPTION
Border shorthand for splitting out individual border properties. Especially useful for atmoic css
libraries like Fela and Styletron.

Addresses #264