### PR TITLE
fix(ellipsis): Harden ellipsis mixin.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,7 @@
     "class-methods-use-this": 0,
     "import/no-extraneous-dependencies": 0,
     "no-confusing-arrow": 0,
+    "no-dupe-keys": 0,
     "no-duplicate-imports": 0,
     "no-else-return": 0,
     "no-mixed-operators": 0,

--- a/src/mixins/ellipsis.js
+++ b/src/mixins/ellipsis.js
@@ -18,6 +18,7 @@
  *
  * div: {
  *   'display': 'inline-block',
+ *   'display': 'inline-flex',
  *   'maxWidth': '250px',
  *   'overflow': 'hidden',
  *   'textOverflow': 'ellipsis',
@@ -26,15 +27,20 @@
  * }
  */
 
-function ellipsis(width?: string | number = '100%'): Object {
-  return {
-    display: 'inline-block',
-    maxWidth: width,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-    wordWrap: 'normal',
-  }
+function ellipsis(width?: string | number = '100%') {
+  return [
+    {
+      display: 'inline-block',
+      maxWidth: width,
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+      wordWrap: 'normal',
+    },
+    {
+      display: 'inline-flex',
+    },
+  ]
 }
 
 export default ellipsis

--- a/src/mixins/test/__snapshots__/ellipsis.test.js.snap
+++ b/src/mixins/test/__snapshots__/ellipsis.test.js.snap
@@ -1,34 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ellipsis should default max-width to 100% 1`] = `
-Object {
-  "display": "inline-block",
-  "maxWidth": "100%",
-  "overflow": "hidden",
-  "textOverflow": "ellipsis",
-  "whiteSpace": "nowrap",
-  "wordWrap": "normal",
-}
+Array [
+  Object {
+    "display": "inline-block",
+    "maxWidth": "100%",
+    "overflow": "hidden",
+    "textOverflow": "ellipsis",
+    "whiteSpace": "nowrap",
+    "wordWrap": "normal",
+  },
+  Object {
+    "display": "inline-flex",
+  },
+]
 `;
 
 exports[`ellipsis should pass parameter of type integer to the value of max-width 1`] = `
-Object {
-  "display": "inline-block",
-  "maxWidth": 300,
-  "overflow": "hidden",
-  "textOverflow": "ellipsis",
-  "whiteSpace": "nowrap",
-  "wordWrap": "normal",
-}
+Array [
+  Object {
+    "display": "inline-block",
+    "maxWidth": 300,
+    "overflow": "hidden",
+    "textOverflow": "ellipsis",
+    "whiteSpace": "nowrap",
+    "wordWrap": "normal",
+  },
+  Object {
+    "display": "inline-flex",
+  },
+]
 `;
 
 exports[`ellipsis should pass parameter to the value of max-width 1`] = `
-Object {
-  "display": "inline-block",
-  "maxWidth": "300px",
-  "overflow": "hidden",
-  "textOverflow": "ellipsis",
-  "whiteSpace": "nowrap",
-  "wordWrap": "normal",
-}
+Array [
+  Object {
+    "display": "inline-block",
+    "maxWidth": "300px",
+    "overflow": "hidden",
+    "textOverflow": "ellipsis",
+    "whiteSpace": "nowrap",
+    "wordWrap": "normal",
+  },
+  Object {
+    "display": "inline-flex",
+  },
+]
 `;

--- a/src/mixins/test/ellipsis.test.js
+++ b/src/mixins/test/ellipsis.test.js
@@ -3,14 +3,14 @@ import ellipsis from '../ellipsis'
 
 describe('ellipsis', () => {
   it('should pass parameter to the value of max-width', () => {
-    expect({ ...ellipsis('300px') }).toMatchSnapshot()
+    expect(ellipsis('300px')).toMatchSnapshot()
   })
 
   it('should pass parameter of type integer to the value of max-width', () => {
-    expect({ ...ellipsis(300) }).toMatchSnapshot()
+    expect(ellipsis(300)).toMatchSnapshot()
   })
 
   it('should default max-width to 100%', () => {
-    expect({ ...ellipsis() }).toMatchSnapshot()
+    expect(ellipsis()).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
Add `display: inline-flex` for browsers that support it better handle white-space issues with
`display: inline-block`

Addresses #256