### PR TITLE
fix(color): Color modules now support string amounts

### DIFF
--- a/src/color/adjustHue.js
+++ b/src/color/adjustHue.js
@@ -13,13 +13,13 @@ import curry from '../internalHelpers/_curry'
  * // Styles as object usage
  * const styles = {
  *   background: adjustHue(180, '#448'),
- *   background: adjustHue(180, 'rgba(101,100,205,0.7)'),
+ *   background: adjustHue('180', 'rgba(101,100,205,0.7)'),
  * }
  *
  * // styled-components usage
  * const div = styled.div`
  *   background: ${adjustHue(180, '#448')};
- *   background: ${adjustHue(180, 'rgba(101,100,205,0.7)')};
+ *   background: ${adjustHue('180', 'rgba(101,100,205,0.7)')};
  * `
  *
  * // CSS in JS Output
@@ -28,11 +28,11 @@ import curry from '../internalHelpers/_curry'
  *   background: "rgba(136,136,68,0.7)";
  * }
  */
-function adjustHue(degree: number, color: string): string {
+function adjustHue(degree: number | string, color: string): string {
   const hslColor = parseToHsl(color)
   return toColorString({
     ...hslColor,
-    hue: (hslColor.hue + degree) % 360,
+    hue: (hslColor.hue + parseFloat(degree)) % 360,
   })
 }
 

--- a/src/color/darken.js
+++ b/src/color/darken.js
@@ -12,13 +12,13 @@ import curry from '../internalHelpers/_curry'
  * // Styles as object usage
  * const styles = {
  *   background: darken(0.2, '#FFCD64'),
- *   background: darken(0.2, 'rgba(255,205,100,0.7)'),
+ *   background: darken('0.2', 'rgba(255,205,100,0.7)'),
  * }
  *
  * // styled-components usage
  * const div = styled.div`
  *   background: ${darken(0.2, '#FFCD64')};
- *   background: ${darken(0.2, 'rgba(255,205,100,0.7)')};
+ *   background: ${darken('0.2', 'rgba(255,205,100,0.7)')};
  * `
  *
  * // CSS in JS Output
@@ -28,11 +28,11 @@ import curry from '../internalHelpers/_curry'
  *   background: "rgba(255,189,49,0.7)";
  * }
  */
-function darken(amount: number, color: string): string {
+function darken(amount: number | string, color: string): string {
   const hslColor = parseToHsl(color)
   return toColorString({
     ...hslColor,
-    lightness: guard(0, 1, hslColor.lightness - amount),
+    lightness: guard(0, 1, hslColor.lightness - parseFloat(amount)),
   })
 }
 

--- a/src/color/desaturate.js
+++ b/src/color/desaturate.js
@@ -14,13 +14,13 @@ import curry from '../internalHelpers/_curry'
  * // Styles as object usage
  * const styles = {
  *   background: desaturate(0.2, '#CCCD64'),
- *   background: desaturate(0.2, 'rgba(204,205,100,0.7)'),
+ *   background: desaturate('0.2', 'rgba(204,205,100,0.7)'),
  * }
  *
  * // styled-components usage
  * const div = styled.div`
  *   background: ${desaturate(0.2, '#CCCD64')};
- *   background: ${desaturate(0.2, 'rgba(204,205,100,0.7)')};
+ *   background: ${desaturate('0.2', 'rgba(204,205,100,0.7)')};
  * `
  *
  * // CSS in JS Output
@@ -29,11 +29,11 @@ import curry from '../internalHelpers/_curry'
  *   background: "rgba(184,185,121,0.7)";
  * }
  */
-function desaturate(amount: number, color: string): string {
+function desaturate(amount: number | string, color: string): string {
   const hslColor = parseToHsl(color)
   return toColorString({
     ...hslColor,
-    saturation: guard(0, 1, hslColor.saturation - amount),
+    saturation: guard(0, 1, hslColor.saturation - parseFloat(amount)),
   })
 }
 

--- a/src/color/lighten.js
+++ b/src/color/lighten.js
@@ -12,13 +12,13 @@ import curry from '../internalHelpers/_curry'
  * // Styles as object usage
  * const styles = {
  *   background: lighten(0.2, '#CCCD64'),
- *   background: lighten(0.2, 'rgba(204,205,100,0.7)'),
+ *   background: lighten('0.2', 'rgba(204,205,100,0.7)'),
  * }
  *
  * // styled-components usage
  * const div = styled.div`
  *   background: ${lighten(0.2, '#FFCD64')};
- *   background: ${lighten(0.2, 'rgba(204,205,100,0.7)')};
+ *   background: ${lighten('0.2', 'rgba(204,205,100,0.7)')};
  * `
  *
  * // CSS in JS Output
@@ -28,11 +28,11 @@ import curry from '../internalHelpers/_curry'
  *   background: "rgba(229,230,177,0.7)";
  * }
  */
-function lighten(amount: number, color: string): string {
+function lighten(amount: number | string, color: string): string {
   const hslColor = parseToHsl(color)
   return toColorString({
     ...hslColor,
-    lightness: guard(0, 1, hslColor.lightness + amount),
+    lightness: guard(0, 1, hslColor.lightness + parseFloat(amount)),
   })
 }
 

--- a/src/color/mix.js
+++ b/src/color/mix.js
@@ -17,14 +17,14 @@ import curry from '../internalHelpers/_curry'
  * const styles = {
  *   background: mix(0.5, '#f00', '#00f')
  *   background: mix(0.25, '#f00', '#00f')
- *   background: mix(0.5, 'rgba(255, 0, 0, 0.5)', '#00f')
+ *   background: mix('0.5', 'rgba(255, 0, 0, 0.5)', '#00f')
  * }
  *
  * // styled-components usage
  * const div = styled.div`
  *   background: ${mix(0.5, '#f00', '#00f')};
  *   background: ${mix(0.25, '#f00', '#00f')};
- *   background: ${mix(0.5, 'rgba(255, 0, 0, 0.5)', '#00f')};
+ *   background: ${mix('0.5', 'rgba(255, 0, 0, 0.5)', '#00f')};
  * `
  *
  * // CSS in JS Output
@@ -51,7 +51,7 @@ function mix(weight?: number = 0.5, color: string, otherColor: string): string {
   // The formular is copied from the original Sass implementation:
   // http://sass-lang.com/documentation/Sass/Script/Functions.html#mix-instance_method
   const alphaDelta = color1.alpha - color2.alpha
-  const x = weight * 2 - 1
+  const x = parseFloat(weight) * 2 - 1
   const y = x * alphaDelta === -1 ? x : x + alphaDelta
   const z = 1 + x * alphaDelta
   const weight1 = (y / z + 1) / 2.0

--- a/src/color/opacify.js
+++ b/src/color/opacify.js
@@ -13,14 +13,14 @@ import curry from '../internalHelpers/_curry'
  * const styles = {
  *   background: opacify(0.1, 'rgba(255, 255, 255, 0.9)');
  *   background: opacify(0.2, 'hsla(0, 0%, 100%, 0.5)'),
- *   background: opacify(0.5, 'rgba(255, 0, 0, 0.2)'),
+ *   background: opacify('0.5', 'rgba(255, 0, 0, 0.2)'),
  * }
  *
  * // styled-components usage
  * const div = styled.div`
  *   background: ${opacify(0.1, 'rgba(255, 255, 255, 0.9)')};
  *   background: ${opacify(0.2, 'hsla(0, 0%, 100%, 0.5)')},
- *   background: ${opacify(0.5, 'rgba(255, 0, 0, 0.2)')},
+ *   background: ${opacify('0.5', 'rgba(255, 0, 0, 0.2)')},
  * `
  *
  * // CSS in JS Output
@@ -31,13 +31,13 @@ import curry from '../internalHelpers/_curry'
  *   background: "rgba(255,0,0,0.7)";
  * }
  */
-function opacify(amount: number, color: string): string {
+function opacify(amount: number | string, color: string): string {
   const parsedColor = parseToRgb(color)
   const alpha: number =
     typeof parsedColor.alpha === 'number' ? parsedColor.alpha : 1
   const colorWithAlpha = {
     ...parsedColor,
-    alpha: guard(0, 1, (alpha * 100 + amount * 100) / 100),
+    alpha: guard(0, 1, (alpha * 100 + parseFloat(amount) * 100) / 100),
   }
   return rgba(colorWithAlpha)
 }

--- a/src/color/saturate.js
+++ b/src/color/saturate.js
@@ -14,13 +14,13 @@ import curry from '../internalHelpers/_curry'
  * // Styles as object usage
  * const styles = {
  *   background: saturate(0.2, '#CCCD64'),
- *   background: saturate(0.2, 'rgba(204,205,100,0.7)'),
+ *   background: saturate('0.2', 'rgba(204,205,100,0.7)'),
  * }
  *
  * // styled-components usage
  * const div = styled.div`
  *   background: ${saturate(0.2, '#FFCD64')};
- *   background: ${saturate(0.2, 'rgba(204,205,100,0.7)')};
+ *   background: ${saturate('0.2', 'rgba(204,205,100,0.7)')};
  * `
  *
  * // CSS in JS Output
@@ -30,11 +30,11 @@ import curry from '../internalHelpers/_curry'
  *   background: "rgba(224,226,80,0.7)";
  * }
  */
-function saturate(amount: number, color: string): string {
+function saturate(amount: number | string, color: string): string {
   const hslColor = parseToHsl(color)
   return toColorString({
     ...hslColor,
-    saturation: guard(0, 1, hslColor.saturation + amount),
+    saturation: guard(0, 1, hslColor.saturation + parseFloat(amount)),
   })
 }
 

--- a/src/color/setHue.js
+++ b/src/color/setHue.js
@@ -12,13 +12,13 @@ import curry from '../internalHelpers/_curry'
  * // Styles as object usage
  * const styles = {
  *   background: setHue(42, '#CCCD64'),
- *   background: setHue(244, 'rgba(204,205,100,0.7)'),
+ *   background: setHue('244', 'rgba(204,205,100,0.7)'),
  * }
  *
  * // styled-components usage
  * const div = styled.div`
  *   background: ${setHue(42, '#CCCD64')};
- *   background: ${setHue(244, 'rgba(204,205,100,0.7)')};
+ *   background: ${setHue('244', 'rgba(204,205,100,0.7)')};
  * `
  *
  * // CSS in JS Output
@@ -27,10 +27,10 @@ import curry from '../internalHelpers/_curry'
  *   background: "rgba(107,100,205,0.7)";
  * }
  */
-function setHue(hue: number, color: string): string {
+function setHue(hue: number | string, color: string): string {
   return toColorString({
     ...parseToHsl(color),
-    hue,
+    hue: parseFloat(hue),
   })
 }
 

--- a/src/color/setLightness.js
+++ b/src/color/setLightness.js
@@ -12,13 +12,13 @@ import curry from '../internalHelpers/_curry'
  * // Styles as object usage
  * const styles = {
  *   background: setLightness(0.2, '#CCCD64'),
- *   background: setLightness(0.75, 'rgba(204,205,100,0.7)'),
+ *   background: setLightness('0.75', 'rgba(204,205,100,0.7)'),
  * }
  *
  * // styled-components usage
  * const div = styled.div`
  *   background: ${setLightness(0.2, '#CCCD64')};
- *   background: ${setLightness(0.75, 'rgba(204,205,100,0.7)')};
+ *   background: ${setLightness('0.75', 'rgba(204,205,100,0.7)')};
  * `
  *
  * // CSS in JS Output
@@ -27,10 +27,10 @@ import curry from '../internalHelpers/_curry'
  *   background: "rgba(223,224,159,0.7)";
  * }
  */
-function setLightness(lightness: number, color: string): string {
+function setLightness(lightness: number | string, color: string): string {
   return toColorString({
     ...parseToHsl(color),
-    lightness,
+    lightness: parseFloat(lightness),
   })
 }
 

--- a/src/color/setSaturation.js
+++ b/src/color/setSaturation.js
@@ -12,13 +12,13 @@ import curry from '../internalHelpers/_curry'
  * // Styles as object usage
  * const styles = {
  *   background: setSaturation(0.2, '#CCCD64'),
- *   background: setSaturation(0.75, 'rgba(204,205,100,0.7)'),
+ *   background: setSaturation('0.75', 'rgba(204,205,100,0.7)'),
  * }
  *
  * // styled-components usage
  * const div = styled.div`
  *   background: ${setSaturation(0.2, '#CCCD64')};
- *   background: ${setSaturation(0.75, 'rgba(204,205,100,0.7)')};
+ *   background: ${setSaturation('0.75', 'rgba(204,205,100,0.7)')};
  * `
  *
  * // CSS in JS Output
@@ -27,10 +27,10 @@ import curry from '../internalHelpers/_curry'
  *   background: "rgba(228,229,76,0.7)";
  * }
  */
-function setSaturation(saturation: number, color: string): string {
+function setSaturation(saturation: number | string, color: string): string {
   return toColorString({
     ...parseToHsl(color),
-    saturation,
+    saturation: parseFloat(saturation),
   })
 }
 

--- a/src/color/shade.js
+++ b/src/color/shade.js
@@ -26,14 +26,8 @@ import curry from '../internalHelpers/_curry'
  * }
  */
 
-function shade(percentage: number, color: string): string {
-  if (typeof percentage !== 'number' || percentage > 1 || percentage < -1) {
-    throw new Error('Passed an incorrect argument to shade, please pass a percentage less than or equal to 1 and larger than or equal to -1.')
-  }
-  if (typeof color !== 'string') {
-    throw new Error('Passed an incorrect argument to a color function, please pass a string representation of a color.')
-  }
-  return mix(percentage, color, 'rgb(0, 0, 0)')
+function shade(percentage: number | string, color: string): string {
+  return mix(parseFloat(percentage), color, 'rgb(0, 0, 0)')
 }
 
 const curriedShade = curry(shade)

--- a/src/color/test/__snapshots__/adjustHue.test.js.snap
+++ b/src/color/test/__snapshots__/adjustHue.test.js.snap
@@ -7,3 +7,5 @@ exports[`adjustHue should adjustHue of a color with opacity 1`] = `"rgba(136,100
 exports[`adjustHue should adjustHue of a hex color 1`] = `"#a9cd64"`;
 
 exports[`adjustHue should adjustHue of a reduced hex color 1`] = `"#5b4488"`;
+
+exports[`adjustHue should adjustHue when passed a string for adjustment 1`] = `"#5b4488"`;

--- a/src/color/test/__snapshots__/darken.test.js.snap
+++ b/src/color/test/__snapshots__/darken.test.js.snap
@@ -4,6 +4,8 @@ exports[`darken should darken a color but not go below 0 1`] = `"rgba(0,0,0,0.7)
 
 exports[`darken should darken a color by 20% 1`] = `"#111"`;
 
+exports[`darken should darken a color by when passed a string for amount 1`] = `"#111"`;
+
 exports[`darken should darken a color with a value of 255 and opacity by 10% 1`] = `"rgba(255,89,89,0.7)"`;
 
 exports[`darken should darken a color with opacity by 10% 1`] = `"rgba(208,101,101,0.7)"`;

--- a/src/color/test/__snapshots__/lighten.test.js.snap
+++ b/src/color/test/__snapshots__/lighten.test.js.snap
@@ -4,6 +4,8 @@ exports[`lighten should lighten a color but not go beyond 255 1`] = `"rgba(255,2
 
 exports[`lighten should lighten a color by 10% 1`] = `"#5e5e5e"`;
 
+exports[`lighten should lighten a color when passed a string for amount 1`] = `"#5e5e5e"`;
+
 exports[`lighten should lighten a color with opacity by 20% 1`] = `"rgba(229,230,177,0.7)"`;
 
 exports[`lighten should lighten a hex color by 20% 1`] = `"#e5e6b1"`;

--- a/src/color/test/__snapshots__/opacify.test.js.snap
+++ b/src/color/test/__snapshots__/opacify.test.js.snap
@@ -10,6 +10,8 @@ exports[`opacify should increase the opacity of rgba(255, 0, 0, .5) by 0.5 1`] =
 
 exports[`opacify should increase the opacity of rgba(255, 0, 0, 0.5) by 0.2 1`] = `"rgba(255,0,0,0.7)"`;
 
+exports[`opacify should increase the opacity when passed a string for amount 1`] = `"#fff"`;
+
 exports[`opacify should not decrease the opacity below 0 1`] = `"rgba(255,0,0,0)"`;
 
 exports[`opacify should not increase the opacity beyond 1 1`] = `"#f00"`;

--- a/src/color/test/__snapshots__/saturate.test.js.snap
+++ b/src/color/test/__snapshots__/saturate.test.js.snap
@@ -4,6 +4,8 @@ exports[`saturate should saturate a color but not go beyond 255 1`] = `"rgba(255
 
 exports[`saturate should saturate a color by 10% 1`] = `"#4b3d3d"`;
 
+exports[`saturate should saturate a color when passed a string for amount 1`] = `"#4b3d3d"`;
+
 exports[`saturate should saturate a color with opacity by 20% 1`] = `"rgba(224,226,80,0.7)"`;
 
 exports[`saturate should saturate a hex color by 20% 1`] = `"#e0e250"`;

--- a/src/color/test/__snapshots__/setHue.test.js.snap
+++ b/src/color/test/__snapshots__/setHue.test.js.snap
@@ -3,3 +3,5 @@
 exports[`setHue should update the hue and return a color with opacity 1`] = `"rgba(107,100,205,0.7)"`;
 
 exports[`setHue should update the hue and return a hex color 1`] = `"#cdae64"`;
+
+exports[`setHue should update the hue when passed a string for hue 1`] = `"#cdae64"`;

--- a/src/color/test/__snapshots__/setLightness.test.js.snap
+++ b/src/color/test/__snapshots__/setLightness.test.js.snap
@@ -3,3 +3,5 @@
 exports[`setLightness should update the lightness and return a color with opacity 1`] = `"rgba(223,224,159,0.7)"`;
 
 exports[`setLightness should update the lightness and return a hex color 1`] = `"#4d4d19"`;
+
+exports[`setLightness should update the lightness when passed a string 1`] = `"#4d4d19"`;

--- a/src/color/test/__snapshots__/setSaturation.test.js.snap
+++ b/src/color/test/__snapshots__/setSaturation.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`setSaturation should update the lightness and return a color with opacity 1`] = `"rgba(228,229,76,0.7)"`;
+exports[`setSaturation should update the saturation and return a color with opacity 1`] = `"rgba(228,229,76,0.7)"`;
 
-exports[`setSaturation should update the lightness and return a hex color 1`] = `"#adad84"`;
+exports[`setSaturation should update the saturation and return a hex color 1`] = `"#adad84"`;
+
+exports[`setSaturation should update the saturation when passed a string 1`] = `"rgba(228,229,76,0.7)"`;

--- a/src/color/test/__snapshots__/shade.test.js.snap
+++ b/src/color/test/__snapshots__/shade.test.js.snap
@@ -1,3 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`shade should shade the provided color when passed a string for amount 1`] = `"#00003f"`;
+
 exports[`shade should shade the provided color with white by the given percentage 1`] = `"#00003f"`;

--- a/src/color/test/__snapshots__/tint.test.js.snap
+++ b/src/color/test/__snapshots__/tint.test.js.snap
@@ -1,3 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`test should tint the provided color when passed a string for amount 1`] = `"#bfbfff"`;
+
 exports[`test should tint the provided color with white by the given percentage 1`] = `"#bfbfff"`;

--- a/src/color/test/__snapshots__/transparentize.test.js.snap
+++ b/src/color/test/__snapshots__/transparentize.test.js.snap
@@ -17,3 +17,5 @@ exports[`transparentize should reduce the opacity of rgba(255, 0, 0, .5) by 0.3 
 exports[`transparentize should reduce the opacity of rgba(255, 0, 0, .5) by 0.5 1`] = `"rgba(255,0,0,0)"`;
 
 exports[`transparentize should reduce the opacity of rgba(255, 0, 0, 1) by 0.1 1`] = `"rgba(255,0,0,0.9)"`;
+
+exports[`transparentize should reduce the opacity when passed a string for amount 1`] = `"rgba(255,255,255,0.9)"`;

--- a/src/color/test/adjustHue.test.js
+++ b/src/color/test/adjustHue.test.js
@@ -17,4 +17,8 @@ describe('adjustHue', () => {
   it('should adjustHue of a color and not go beyond 360', () => {
     expect(adjustHue(350, '#448')).toMatchSnapshot()
   })
+
+  it('should adjustHue when passed a string for adjustment', () => {
+    expect(adjustHue('20', '#448')).toMatchSnapshot()
+  })
 })

--- a/src/color/test/darken.test.js
+++ b/src/color/test/darken.test.js
@@ -17,4 +17,8 @@ describe('darken', () => {
   it('should darken a color but not go below 0', () => {
     expect(darken(0.8, 'rgba(40,20,10,0.7)')).toMatchSnapshot()
   })
+
+  it('should darken a color by when passed a string for amount', () => {
+    expect(darken('0.2', '#444')).toMatchSnapshot()
+  })
 })

--- a/src/color/test/lighten.test.js
+++ b/src/color/test/lighten.test.js
@@ -17,4 +17,8 @@ describe('lighten', () => {
   it('should lighten a color but not go beyond 255', () => {
     expect(lighten(0.8, 'rgba(255,200,200,0.7)')).toMatchSnapshot()
   })
+
+  it('should lighten a color when passed a string for amount', () => {
+    expect(lighten('0.1', '#444')).toMatchSnapshot()
+  })
 })

--- a/src/color/test/opacify.test.js
+++ b/src/color/test/opacify.test.js
@@ -30,6 +30,10 @@ describe('opacify', () => {
     expect(opacify(0.5, 'rgba(255, 0, 0, .8)')).toMatchSnapshot()
   })
 
+  it('should increase the opacity when passed a string for amount', () => {
+    expect(opacify('0.1', '#fff')).toMatchSnapshot()
+  })
+
   it('should throw an error when enter an invalid color', () => {
     expect(() => {
       opacify(0.5, 'not a color')

--- a/src/color/test/saturate.test.js
+++ b/src/color/test/saturate.test.js
@@ -17,4 +17,8 @@ describe('saturate', () => {
   it('should saturate a color but not go beyond 255', () => {
     expect(saturate(0.8, 'rgba(255,200,200,0.7)')).toMatchSnapshot()
   })
+
+  it('should saturate a color when passed a string for amount', () => {
+    expect(saturate('0.1', '#444')).toMatchSnapshot()
+  })
 })

--- a/src/color/test/setHue.test.js
+++ b/src/color/test/setHue.test.js
@@ -9,4 +9,8 @@ describe('setHue', () => {
   it('should update the hue and return a color with opacity', () => {
     expect(setHue(244, 'rgba(204,205,100,0.7)')).toMatchSnapshot()
   })
+
+  it('should update the hue when passed a string for hue', () => {
+    expect(setHue('42', '#CCCD64')).toMatchSnapshot()
+  })
 })

--- a/src/color/test/setLightness.test.js
+++ b/src/color/test/setLightness.test.js
@@ -9,4 +9,8 @@ describe('setLightness', () => {
   it('should update the lightness and return a color with opacity', () => {
     expect(setLightness(0.75, 'rgba(204,205,100,0.7)')).toMatchSnapshot()
   })
+
+  it('should update the lightness when passed a string', () => {
+    expect(setLightness('0.2', '#CCCD64')).toMatchSnapshot()
+  })
 })

--- a/src/color/test/setSaturation.test.js
+++ b/src/color/test/setSaturation.test.js
@@ -2,11 +2,15 @@
 import setSaturation from '../setSaturation'
 
 describe('setSaturation', () => {
-  it('should update the lightness and return a hex color', () => {
+  it('should update the saturation and return a hex color', () => {
     expect(setSaturation(0.2, '#CCCD64')).toMatchSnapshot()
   })
 
-  it('should update the lightness and return a color with opacity', () => {
+  it('should update the saturation and return a color with opacity', () => {
     expect(setSaturation(0.75, 'rgba(204,205,100,0.7)')).toMatchSnapshot()
+  })
+
+  it('should update the saturation when passed a string', () => {
+    expect(setSaturation('0.75', 'rgba(204,205,100,0.7)')).toMatchSnapshot()
   })
 })

--- a/src/color/test/shade.test.js
+++ b/src/color/test/shade.test.js
@@ -6,26 +6,7 @@ describe('shade', () => {
     expect(shade(0.25, '#00f')).toMatchSnapshot()
   })
 
-  it('should throw an error if a percentage greater than 1 is passed', () => {
-    const error = new Error('Passed an incorrect argument to shade, please pass a percentage less than or equal to 1 and larger than or equal to -1.')
-    expect(() => {
-      shade(1.1, '#00f')
-    }).toThrow(error)
-  })
-
-  it('should throw an error if the arguments are passed in the wrong order', () => {
-    const error = new Error('Passed an incorrect argument to shade, please pass a percentage less than or equal to 1 and larger than or equal to -1.')
-    expect(() => {
-      // $FlowFixMe
-      shade('#00f', 0.2)
-    }).toThrow(error)
-  })
-
-  it('should throw an error if a valid string is not passed as a color', () => {
-    const error = new Error('Passed an incorrect argument to a color function, please pass a string representation of a color.')
-    expect(() => {
-      // $FlowFixMe
-      shade(1, 2.0)
-    }).toThrow(error)
+  it('should shade the provided color when passed a string for amount', () => {
+    expect(shade('0.25', '#00f')).toMatchSnapshot()
   })
 })

--- a/src/color/test/tint.test.js
+++ b/src/color/test/tint.test.js
@@ -5,27 +5,7 @@ describe('test', () => {
   it('should tint the provided color with white by the given percentage', () => {
     expect(tint(0.25, '#00f')).toMatchSnapshot()
   })
-
-  it('should throw an error if a percentage greater than 1 is passed', () => {
-    const error = new Error('Passed an incorrect argument to tint, please pass a percentage less than or equal to 1 and larger than or equal to -1.')
-    expect(() => {
-      tint(1.1, '#00f')
-    }).toThrow(error)
-  })
-
-  it('should throw an error if the arguments are passed in the wrong order', () => {
-    const error = new Error('Passed an incorrect argument to tint, please pass a percentage less than or equal to 1 and larger than or equal to -1.')
-    expect(() => {
-      // $FlowFixMe
-      tint('#00f', 0.2)
-    }).toThrow(error)
-  })
-
-  it('should throw an error if a valid string is not passed as a color', () => {
-    const error = new Error('Passed an incorrect argument to a color function, please pass a string representation of a color.')
-    expect(() => {
-      // $FlowFixMe
-      tint(1, 2.0)
-    }).toThrow(error)
+  it('should tint the provided color when passed a string for amount', () => {
+    expect(tint('0.25', '#00f')).toMatchSnapshot()
   })
 })

--- a/src/color/test/transparentize.test.js
+++ b/src/color/test/transparentize.test.js
@@ -38,6 +38,10 @@ describe('transparentize', () => {
     expect(transparentize(-0.5, 'rgba(255, 0, 0, .8)')).toMatchSnapshot()
   })
 
+  it('should reduce the opacity when passed a string for amount', () => {
+    expect(transparentize('0.1', '#fff')).toMatchSnapshot()
+  })
+
   it('should throw an error when enter an invalid color', () => {
     expect(() => {
       transparentize(0.5, 'not a color')

--- a/src/color/tint.js
+++ b/src/color/tint.js
@@ -26,14 +26,8 @@ import curry from '../internalHelpers/_curry'
  * }
  */
 
-function tint(percentage: number, color: string): string {
-  if (typeof percentage !== 'number' || percentage > 1 || percentage < -1) {
-    throw new Error('Passed an incorrect argument to tint, please pass a percentage less than or equal to 1 and larger than or equal to -1.')
-  }
-  if (typeof color !== 'string') {
-    throw new Error('Passed an incorrect argument to a color function, please pass a string representation of a color.')
-  }
-  return mix(percentage, color, 'rgb(255, 255, 255)')
+function tint(percentage: number | string, color: string): string {
+  return mix(parseFloat(percentage), color, 'rgb(255, 255, 255)')
 }
 
 const curriedTint = curry(tint)

--- a/src/color/transparentize.js
+++ b/src/color/transparentize.js
@@ -13,14 +13,14 @@ import curry from '../internalHelpers/_curry'
  * const styles = {
  *   background: transparentize(0.1, '#fff');
  *   background: transparentize(0.2, 'hsl(0, 0%, 100%)'),
- *   background: transparentize(0.5, 'rgba(255, 0, 0, 0.8)'),
+ *   background: transparentize('0.5', 'rgba(255, 0, 0, 0.8)'),
  * }
  *
  * // styled-components usage
  * const div = styled.div`
  *   background: ${transparentize(0.1, '#fff')};
  *   background: ${transparentize(0.2, 'hsl(0, 0%, 100%)')},
- *   background: ${transparentize(0.5, 'rgba(255, 0, 0, 0.8)')},
+ *   background: ${transparentize('0.5', 'rgba(255, 0, 0, 0.8)')},
  * `
  *
  * // CSS in JS Output
@@ -31,13 +31,13 @@ import curry from '../internalHelpers/_curry'
  *   background: "rgba(255,0,0,0.3)";
  * }
  */
-function transparentize(amount: number, color: string): string {
+function transparentize(amount: number | string, color: string): string {
   const parsedColor = parseToRgb(color)
   const alpha: number =
     typeof parsedColor.alpha === 'number' ? parsedColor.alpha : 1
   const colorWithAlpha = {
     ...parsedColor,
-    alpha: guard(0, 1, (alpha * 100 - amount * 100) / 100),
+    alpha: guard(0, 1, (alpha * 100 - parseFloat(amount) * 100) / 100),
   }
   return rgba(colorWithAlpha)
 }


### PR DESCRIPTION
All color modules now support string inputs for their amounts(percentage, amount, etc..) and
automatically convert them to ints/floats

Fix #243