### PR TITLE
feat(color): Add support for 8 CSS hexcolor values (#RRGGBBAA)

### DIFF
--- a/docs/assets/polished.js
+++ b/docs/assets/polished.js
@@ -11,8 +11,6 @@ function capitalizeString(string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
-module.exports = exports["default"];
-
 //      
 var positionMap = ['Top', 'Right', 'Bottom', 'Left'];
 
@@ -80,14 +78,11 @@ function directionalProperty(property) {
   return generateStyles(property, valuesWithDefaults);
 }
 
-module.exports = exports['default'];
-
 //      
 
 function endsWith (string, suffix) {
   return string.substr(-suffix.length) === suffix;
 }
-module.exports = exports["default"];
 
 //      
 
@@ -117,8 +112,6 @@ function stripUnit(value) {
   if (isNaN(unitlessValue)) return value;
   return unitlessValue;
 }
-
-module.exports = exports["default"];
 
 //      
 
@@ -158,8 +151,6 @@ var pxtoFactory = function pxtoFactory(to) {
   };
 };
 
-module.exports = exports['default'];
-
 //      
 /**
  * Convert pixel value to ems. The default base value is 16px, but can be changed by passing a
@@ -186,7 +177,6 @@ module.exports = exports['default'];
  */
 
 var em = /*#__PURE__*/pxtoFactory('em');
-module.exports = exports['default'];
 
 //      
 
@@ -280,7 +270,6 @@ var ratioNames = {
  */
 
 var rem = /*#__PURE__*/pxtoFactory('rem');
-module.exports = exports['default'];
 
 //      
 
@@ -319,8 +308,6 @@ function clearFix() {
     display: 'table'
   }, _ref;
 }
-
-module.exports = exports['default'];
 
 //      
 
@@ -362,8 +349,6 @@ function ellipsis() {
     wordWrap: 'normal'
   };
 }
-
-module.exports = exports['default'];
 
 //      
 
@@ -459,8 +444,6 @@ function fontFace(_ref) {
   };return JSON.parse(JSON.stringify(fontFaceDeclaration));
 }
 
-module.exports = exports['default'];
-
 //      
 
 /**
@@ -496,8 +479,6 @@ function hideText() {
     whiteSpace: 'nowrap'
   };
 }
-
-module.exports = exports['default'];
 
 //      
 
@@ -547,8 +528,6 @@ function hideVisually() {
   };
 }
 
-module.exports = exports['default'];
-
 //      
 
 /**
@@ -586,9 +565,50 @@ function hiDPI() {
   return "\n    @media only screen and (-webkit-min-device-pixel-ratio: " + ratio + "),\n    only screen and (min--moz-device-pixel-ratio: " + ratio + "),\n    only screen and (-o-min-device-pixel-ratio: " + ratio + "/1),\n    only screen and (min-resolution: " + Math.round(ratio * 96) + "dpi),\n    only screen and (min-resolution: " + ratio + "dppx)\n  ";
 }
 
-module.exports = exports["default"];
+var _extends = Object.assign || function (target) {
+  for (var i = 1; i < arguments.length; i++) {
+    var source = arguments[i];
 
-var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+    for (var key in source) {
+      if (Object.prototype.hasOwnProperty.call(source, key)) {
+        target[key] = source[key];
+      }
+    }
+  }
+
+  return target;
+};
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+var taggedTemplateLiteralLoose = function (strings, raw) {
+  strings.raw = raw;
+  return strings;
+};
 
 var _opinionatedRules;
 var _abbrTitle;
@@ -761,10 +781,6 @@ function normalize(excludeOpinionated) {
   return mergeRules(unopinionatedRules, opinionatedRules);
 }
 
-module.exports = exports['default'];
-
-var _extends$1 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
-
 //      
 
 /**
@@ -804,14 +820,10 @@ function placeholder(styles) {
 
   var parent = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '&';
 
-  return _ref = {}, _ref[parent + '::-webkit-input-placeholder'] = _extends$1({}, styles), _ref[parent + ':-moz-placeholder'] = _extends$1({}, styles), _ref[parent + '::-moz-placeholder'] = _extends$1({}, styles), _ref[parent + ':-ms-input-placeholder'] = _extends$1({}, styles), _ref;
+  return _ref = {}, _ref[parent + '::-webkit-input-placeholder'] = _extends({}, styles), _ref[parent + ':-moz-placeholder'] = _extends({}, styles), _ref[parent + '::-moz-placeholder'] = _extends({}, styles), _ref[parent + ':-ms-input-placeholder'] = _extends({}, styles), _ref;
 }
 
-module.exports = exports['default'];
-
-var _templateObject = /*#__PURE__*/ _taggedTemplateLiteralLoose(['radial-gradient(', '', '', '', ')'], ['radial-gradient(', '', '', '', ')']);
-
-function _taggedTemplateLiteralLoose(strings, raw) { strings.raw = raw; return strings; }
+var _templateObject = /*#__PURE__*/ taggedTemplateLiteralLoose(['radial-gradient(', '', '', '', ')'], ['radial-gradient(', '', '', '', ')']);
 
 //      
 
@@ -888,8 +900,6 @@ function radialGradient(_ref) {
   };
 }
 
-module.exports = exports['default'];
-
 //      
 
 /**
@@ -943,10 +953,6 @@ function retinaImage(filename, backgroundSize) {
   }, _ref;
 }
 
-module.exports = exports['default'];
-
-var _extends$2 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
-
 //      
 
 /**
@@ -982,10 +988,8 @@ function selection(styles) {
 
   var parent = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '';
 
-  return _ref = {}, _ref[parent + '::-moz-selection'] = _extends$2({}, styles), _ref[parent + '::selection'] = _extends$2({}, styles), _ref;
+  return _ref = {}, _ref[parent + '::-moz-selection'] = _extends({}, styles), _ref[parent + '::selection'] = _extends({}, styles), _ref;
 }
-
-module.exports = exports['default'];
 
 //      
 
@@ -1045,8 +1049,6 @@ var functionsMap = {
 };function timingFunctions(timingFunction) {
   return functionsMap[timingFunction];
 }
-
-module.exports = exports['default'];
 
 //      
 
@@ -1128,8 +1130,6 @@ var reverseDirection = {
   }, _ref2['border' + reverseDirection[pointingDirection] + 'Color'] = foregroundColor + ' !important', _ref2;
 }
 
-module.exports = exports['default'];
-
 //      
 
 /**
@@ -1165,8 +1165,6 @@ function wordWrap() {
     wordBreak: wordBreak
   };
 }
-
-module.exports = exports['default'];
 
 //      
 
@@ -1222,8 +1220,6 @@ function hslToRgb(hue, saturation, lightness) {
   var finalBlue = blue + lightnessModification;
   return convert(finalRed, finalGreen, finalBlue);
 }
-
-module.exports = exports["default"];
 
 //      
 var namedColorMap = {
@@ -1386,8 +1382,6 @@ var namedColorMap = {
   return namedColorMap[normalizedColorName] ? '#' + namedColorMap[normalizedColorName] : color;
 }
 
-module.exports = exports['default'];
-
 //      
 var hexRegex = /^#[a-fA-F0-9]{6}$/;
 var reducedHexRegex = /^#[a-fA-F0-9]{3}$/;
@@ -1473,8 +1467,6 @@ function parseToRgb(color) {
   throw new Error("Couldn't parse the color string. Please provide the color as a string in hex, rgb, rgba, hsl or hsla notation.");
 }
 
-module.exports = exports['default'];
-
 //      
 
 
@@ -1530,8 +1522,6 @@ function rgbToHsl(color) {
   return { hue: hue, saturation: saturation, lightness: lightness };
 }
 
-module.exports = exports["default"];
-
 //      
 
 /**
@@ -1551,8 +1541,6 @@ function parseToHsl(color) {
   return rgbToHsl(parseToRgb(color));
 }
 
-module.exports = exports['default'];
-
 //      
 
 /**
@@ -1566,17 +1554,11 @@ var reduceHexValue = function reduceHexValue(value) {
   return value;
 };
 
-module.exports = exports["default"];
-
 //      
 function numberToHex(value) {
   var hex = value.toString(16);
   return hex.length === 1 ? "0" + hex : hex;
 }
-
-module.exports = exports["default"];
-
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 //      
 
@@ -1606,16 +1588,12 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 function rgb(value, green, blue) {
   if (typeof value === 'number' && typeof green === 'number' && typeof blue === 'number') {
     return reduceHexValue('#' + numberToHex(value) + numberToHex(green) + numberToHex(blue));
-  } else if ((typeof value === 'undefined' ? 'undefined' : _typeof(value)) === 'object' && green === undefined && blue === undefined) {
+  } else if (typeof value === 'object' && green === undefined && blue === undefined) {
     return reduceHexValue('#' + numberToHex(value.red) + numberToHex(value.green) + numberToHex(value.blue));
   }
 
   throw new Error('Passed invalid arguments to rgb, please pass multiple numbers e.g. rgb(255, 205, 100) or an object e.g. rgb({ red: 255, green: 205, blue: 100 }).');
 }
-
-module.exports = exports['default'];
-
-var _typeof$1 = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 //      
 
@@ -1659,14 +1637,12 @@ function rgba(firstValue, secondValue, thirdValue, fourthValue) {
     return 'rgba(' + rgbValue.red + ',' + rgbValue.green + ',' + rgbValue.blue + ',' + secondValue + ')';
   } else if (typeof firstValue === 'number' && typeof secondValue === 'number' && typeof thirdValue === 'number' && typeof fourthValue === 'number') {
     return fourthValue >= 1 ? rgb(firstValue, secondValue, thirdValue) : 'rgba(' + firstValue + ',' + secondValue + ',' + thirdValue + ',' + fourthValue + ')';
-  } else if ((typeof firstValue === 'undefined' ? 'undefined' : _typeof$1(firstValue)) === 'object' && secondValue === undefined && thirdValue === undefined && fourthValue === undefined) {
+  } else if (typeof firstValue === 'object' && secondValue === undefined && thirdValue === undefined && fourthValue === undefined) {
     return firstValue.alpha >= 1 ? rgb(firstValue.red, firstValue.green, firstValue.blue) : 'rgba(' + firstValue.red + ',' + firstValue.green + ',' + firstValue.blue + ',' + firstValue.alpha + ')';
   }
 
   throw new Error('Passed invalid arguments to rgba, please pass multiple numbers e.g. rgb(255, 205, 100, 0.75) or an object e.g. rgb({ red: 255, green: 205, blue: 100, alpha: 0.75 }).');
 }
-
-module.exports = exports['default'];
 
 //      
 function colorToHex(color) {
@@ -1680,10 +1656,6 @@ function convertToHex(red, green, blue) {
 function hslToHex(hue, saturation, lightness) {
   return hslToRgb(hue, saturation, lightness, convertToHex);
 }
-
-module.exports = exports['default'];
-
-var _typeof$2 = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 //      
 
@@ -1713,16 +1685,12 @@ var _typeof$2 = typeof Symbol === "function" && typeof Symbol.iterator === "symb
 function hsl(value, saturation, lightness) {
   if (typeof value === 'number' && typeof saturation === 'number' && typeof lightness === 'number') {
     return hslToHex(value, saturation, lightness);
-  } else if ((typeof value === 'undefined' ? 'undefined' : _typeof$2(value)) === 'object' && saturation === undefined && lightness === undefined) {
+  } else if (typeof value === 'object' && saturation === undefined && lightness === undefined) {
     return hslToHex(value.hue, value.saturation, value.lightness);
   }
 
   throw new Error('Passed invalid arguments to hsl, please pass multiple numbers e.g. hsl(360, 0.75, 0.4) or an object e.g. rgb({ hue: 255, saturation: 0.4, lightness: 0.75 }).');
 }
-
-module.exports = exports['default'];
-
-var _typeof$3 = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 //      
 
@@ -1755,16 +1723,12 @@ var _typeof$3 = typeof Symbol === "function" && typeof Symbol.iterator === "symb
 function hsla(value, saturation, lightness, alpha) {
   if (typeof value === 'number' && typeof saturation === 'number' && typeof lightness === 'number' && typeof alpha === 'number') {
     return alpha >= 1 ? hslToHex(value, saturation, lightness) : 'rgba(' + hslToRgb(value, saturation, lightness) + ',' + alpha + ')';
-  } else if ((typeof value === 'undefined' ? 'undefined' : _typeof$3(value)) === 'object' && saturation === undefined && lightness === undefined && alpha === undefined) {
+  } else if (typeof value === 'object' && saturation === undefined && lightness === undefined && alpha === undefined) {
     return value.alpha >= 1 ? hslToHex(value.hue, value.saturation, value.lightness) : 'rgba(' + hslToRgb(value.hue, value.saturation, value.lightness) + ',' + value.alpha + ')';
   }
 
   throw new Error('Passed invalid arguments to hsla, please pass multiple numbers e.g. hsl(360, 0.75, 0.4, 0.7) or an object e.g. rgb({ hue: 255, saturation: 0.4, lightness: 0.75, alpha: 0.7 }).');
 }
-
-module.exports = exports['default'];
-
-var _typeof$4 = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 //      
 var isRgb = function isRgb(color) {
@@ -1817,7 +1781,7 @@ var errMsg = 'Passed invalid argument to toColorString, please pass a RgbColor, 
  */
 
 function toColorString(color) {
-  if ((typeof color === 'undefined' ? 'undefined' : _typeof$4(color)) !== 'object') throw new Error(errMsg);
+  if (typeof color !== 'object') throw new Error(errMsg);
   if (isRgba(color)) return rgba(color);
   if (isRgb(color)) return rgb(color);
   if (isHsla(color)) return hsla(color);
@@ -1825,8 +1789,6 @@ function toColorString(color) {
 
   throw new Error(errMsg);
 }
-
-module.exports = exports['default'];
 
 //      
 
@@ -1854,9 +1816,6 @@ function curry(f) {
   // eslint-disable-line no-redeclare
   return curried(f, f.length, []);
 }
-module.exports = exports["default"];
-
-var _extends$3 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 //      
 
@@ -1886,15 +1845,12 @@ var _extends$3 = Object.assign || function (target) { for (var i = 1; i < argume
  */
 function adjustHue(degree, color) {
   var hslColor = parseToHsl(color);
-  return toColorString(_extends$3({}, hslColor, {
+  return toColorString(_extends({}, hslColor, {
     hue: (hslColor.hue + degree) % 360
   }));
 }
 
 var curriedAdjustHue = /*#__PURE__*/curry(adjustHue);
-module.exports = exports['default'];
-
-var _extends$4 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 //      
 
@@ -1922,22 +1878,16 @@ var _extends$4 = Object.assign || function (target) { for (var i = 1; i < argume
  */
 function complement(color) {
   var hslColor = parseToHsl(color);
-  return toColorString(_extends$4({}, hslColor, {
+  return toColorString(_extends({}, hslColor, {
     hue: (hslColor.hue + 180) % 360
   }));
 }
-
-module.exports = exports['default'];
 
 //      
 
 function guard(lowerBoundary, upperBoundary, value) {
   return Math.max(lowerBoundary, Math.min(upperBoundary, value));
 }
-
-module.exports = exports["default"];
-
-var _extends$5 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 //      
 
@@ -1966,15 +1916,12 @@ var _extends$5 = Object.assign || function (target) { for (var i = 1; i < argume
  */
 function darken(amount, color) {
   var hslColor = parseToHsl(color);
-  return toColorString(_extends$5({}, hslColor, {
+  return toColorString(_extends({}, hslColor, {
     lightness: guard(0, 1, hslColor.lightness - amount)
   }));
 }
 
 var curriedDarken = /*#__PURE__*/curry(darken);
-module.exports = exports['default'];
-
-var _extends$6 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 //      
 
@@ -2004,13 +1951,12 @@ var _extends$6 = Object.assign || function (target) { for (var i = 1; i < argume
  */
 function desaturate(amount, color) {
   var hslColor = parseToHsl(color);
-  return toColorString(_extends$6({}, hslColor, {
+  return toColorString(_extends({}, hslColor, {
     saturation: guard(0, 1, hslColor.saturation - amount)
   }));
 }
 
 var curriedDesaturate = /*#__PURE__*/curry(desaturate);
-module.exports = exports['default'];
 
 //      
 /**
@@ -2053,10 +1999,6 @@ function getLuminance(color) {
   return 0.2126 * r + 0.7152 * g + 0.0722 * b;
 }
 
-module.exports = exports['default'];
-
-var _extends$7 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
-
 //      
 
 /**
@@ -2082,14 +2024,10 @@ var _extends$7 = Object.assign || function (target) { for (var i = 1; i < argume
  * }
  */
 function grayscale(color) {
-  return toColorString(_extends$7({}, parseToHsl(color), {
+  return toColorString(_extends({}, parseToHsl(color), {
     saturation: 0
   }));
 }
-
-module.exports = exports['default'];
-
-var _extends$8 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 //      
 
@@ -2119,16 +2057,12 @@ var _extends$8 = Object.assign || function (target) { for (var i = 1; i < argume
 function invert(color) {
   // parse color string to rgb
   var value = parseToRgb(color);
-  return toColorString(_extends$8({}, value, {
+  return toColorString(_extends({}, value, {
     red: 255 - value.red,
     green: 255 - value.green,
     blue: 255 - value.blue
   }));
 }
-
-module.exports = exports['default'];
-
-var _extends$9 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 //      
 
@@ -2157,15 +2091,12 @@ var _extends$9 = Object.assign || function (target) { for (var i = 1; i < argume
  */
 function lighten(amount, color) {
   var hslColor = parseToHsl(color);
-  return toColorString(_extends$9({}, hslColor, {
+  return toColorString(_extends({}, hslColor, {
     lightness: guard(0, 1, hslColor.lightness + amount)
   }));
 }
 
 var curriedLighten = /*#__PURE__*/curry(lighten);
-module.exports = exports['default'];
-
-var _extends$10 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 //      
 
@@ -2206,12 +2137,12 @@ function mix() {
   var otherColor = arguments[2];
 
   var parsedColor1 = parseToRgb(color);
-  var color1 = _extends$10({}, parsedColor1, {
+  var color1 = _extends({}, parsedColor1, {
     alpha: typeof parsedColor1.alpha === 'number' ? parsedColor1.alpha : 1
   });
 
   var parsedColor2 = parseToRgb(otherColor);
-  var color2 = _extends$10({}, parsedColor2, {
+  var color2 = _extends({}, parsedColor2, {
     alpha: typeof parsedColor2.alpha === 'number' ? parsedColor2.alpha : 1
 
     // The formular is copied from the original Sass implementation:
@@ -2234,9 +2165,6 @@ function mix() {
 }
 
 var curriedMix = /*#__PURE__*/curry(mix);
-module.exports = exports['default'];
-
-var _extends$11 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 //      
 /**
@@ -2269,14 +2197,13 @@ var _extends$11 = Object.assign || function (target) { for (var i = 1; i < argum
 function opacify(amount, color) {
   var parsedColor = parseToRgb(color);
   var alpha = typeof parsedColor.alpha === 'number' ? parsedColor.alpha : 1;
-  var colorWithAlpha = _extends$11({}, parsedColor, {
+  var colorWithAlpha = _extends({}, parsedColor, {
     alpha: guard(0, 1, (alpha * 100 + amount * 100) / 100)
   });
   return rgba(colorWithAlpha);
 }
 
 var curriedOpacify = /*#__PURE__*/curry(opacify);
-module.exports = exports['default'];
 
 //      
 /**
@@ -2312,9 +2239,6 @@ function readableColor(color) {
 }
 
 var curriedReadableColor = /*#__PURE__*/curry(readableColor);
-module.exports = exports['default'];
-
-var _extends$12 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 //      
 
@@ -2345,15 +2269,12 @@ var _extends$12 = Object.assign || function (target) { for (var i = 1; i < argum
  */
 function saturate(amount, color) {
   var hslColor = parseToHsl(color);
-  return toColorString(_extends$12({}, hslColor, {
+  return toColorString(_extends({}, hslColor, {
     saturation: guard(0, 1, hslColor.saturation + amount)
   }));
 }
 
 var curriedSaturate = /*#__PURE__*/curry(saturate);
-module.exports = exports['default'];
-
-var _extends$13 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 //      
 
@@ -2381,15 +2302,12 @@ var _extends$13 = Object.assign || function (target) { for (var i = 1; i < argum
  * }
  */
 function setHue(hue, color) {
-  return toColorString(_extends$13({}, parseToHsl(color), {
+  return toColorString(_extends({}, parseToHsl(color), {
     hue: hue
   }));
 }
 
 var curriedSetHue = /*#__PURE__*/curry(setHue);
-module.exports = exports['default'];
-
-var _extends$14 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 //      
 
@@ -2417,15 +2335,12 @@ var _extends$14 = Object.assign || function (target) { for (var i = 1; i < argum
  * }
  */
 function setLightness(lightness, color) {
-  return toColorString(_extends$14({}, parseToHsl(color), {
+  return toColorString(_extends({}, parseToHsl(color), {
     lightness: lightness
   }));
 }
 
 var curriedSetLightness = /*#__PURE__*/curry(setLightness);
-module.exports = exports['default'];
-
-var _extends$15 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 //      
 
@@ -2453,13 +2368,12 @@ var _extends$15 = Object.assign || function (target) { for (var i = 1; i < argum
  * }
  */
 function setSaturation(saturation, color) {
-  return toColorString(_extends$15({}, parseToHsl(color), {
+  return toColorString(_extends({}, parseToHsl(color), {
     saturation: saturation
   }));
 }
 
 var curriedSetSaturation = /*#__PURE__*/curry(setSaturation);
-module.exports = exports['default'];
 
 //      
 
@@ -2497,7 +2411,6 @@ function shade(percentage, color) {
 }
 
 var curriedShade = /*#__PURE__*/curry(shade);
-module.exports = exports['default'];
 
 //      
 
@@ -2535,9 +2448,6 @@ function tint(percentage, color) {
 }
 
 var curriedTint = /*#__PURE__*/curry(tint);
-module.exports = exports['default'];
-
-var _extends$16 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 //      
 /**
@@ -2570,14 +2480,13 @@ var _extends$16 = Object.assign || function (target) { for (var i = 1; i < argum
 function transparentize(amount, color) {
   var parsedColor = parseToRgb(color);
   var alpha = typeof parsedColor.alpha === 'number' ? parsedColor.alpha : 1;
-  var colorWithAlpha = _extends$16({}, parsedColor, {
+  var colorWithAlpha = _extends({}, parsedColor, {
     alpha: guard(0, 1, (alpha * 100 - amount * 100) / 100)
   });
   return rgba(colorWithAlpha);
 }
 
 var curriedTransparentize = /*#__PURE__*/curry(transparentize);
-module.exports = exports['default'];
 
 //      
 
@@ -2645,8 +2554,6 @@ function animation() {
   };
 }
 
-module.exports = exports['default'];
-
 //      
 
 /**
@@ -2679,8 +2586,6 @@ function backgroundImages() {
   };
 }
 
-module.exports = exports['default'];
-
 //      
 
 /**
@@ -2711,8 +2616,6 @@ function backgrounds() {
     background: properties.join(', ')
   };
 }
-
-module.exports = exports['default'];
 
 //      
 /**
@@ -2745,8 +2648,6 @@ function borderColor() {
 
   return directionalProperty.apply(undefined, ['borderColor'].concat(values));
 }
-
-module.exports = exports['default'];
 
 //      
 /**
@@ -2790,8 +2691,6 @@ function borderRadius(side, radius) {
   throw new Error('borderRadius expects one of "top", "bottom", "left" or "right" as the first argument.');
 }
 
-module.exports = exports['default'];
-
 //      
 /**
  * Shorthand that accepts up to four values, including null to skip a value, and maps them to their respective directions.
@@ -2824,8 +2723,6 @@ function borderStyle() {
   return directionalProperty.apply(undefined, ['borderStyle'].concat(values));
 }
 
-module.exports = exports['default'];
-
 //      
 /**
  * Shorthand that accepts up to four values, including null to skip a value, and maps them to their respective directions.
@@ -2857,8 +2754,6 @@ function borderWidth() {
   return directionalProperty.apply(undefined, ['borderWidth'].concat(values));
 }
 
-module.exports = exports['default'];
-
 //      
 
 
@@ -2884,8 +2779,6 @@ function statefulSelectors(states, template, stateMap) {
   selectors = selectors.join(',');
   return selectors;
 }
-
-module.exports = exports['default'];
 
 //      
 var stateMap = [undefined, null, 'active', 'focus', 'hover'];
@@ -2929,8 +2822,6 @@ function buttons() {
   return statefulSelectors(states, template, stateMap);
 }
 
-module.exports = exports['default'];
-
 //      
 /**
  * Shorthand that accepts up to four values, including null to skip a value, and maps them to their respective directions.
@@ -2963,8 +2854,6 @@ function margin() {
   return directionalProperty.apply(undefined, ['margin'].concat(values));
 }
 
-module.exports = exports['default'];
-
 //      
 /**
  * Shorthand that accepts up to four values, including null to skip a value, and maps them to their respective directions.
@@ -2996,10 +2885,6 @@ function padding() {
 
   return directionalProperty.apply(undefined, ['padding'].concat(values));
 }
-
-module.exports = exports['default'];
-
-var _extends$17 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 //      
 var positionMap$1 = ['absolute', 'fixed', 'relative', 'static', 'sticky'];
@@ -3053,7 +2938,7 @@ function position(positionKeyword) {
   }
 
   if (positionMap$1.indexOf(positionKeyword) >= 0) {
-    return _extends$17({
+    return _extends({
       position: positionKeyword
     }, directionalProperty.apply(undefined, [''].concat(values)));
   } else {
@@ -3061,8 +2946,6 @@ function position(positionKeyword) {
     return directionalProperty.apply(undefined, ['', firstValue].concat(values));
   }
 }
-
-module.exports = exports['default'];
 
 //      
 
@@ -3095,8 +2978,6 @@ function size(height) {
     width: width
   };
 }
-
-module.exports = exports["default"];
 
 //      
 var stateMap$1 = [undefined, null, 'active', 'focus', 'hover'];
@@ -3152,8 +3033,6 @@ function textInputs() {
   return statefulSelectors(states, template$1, stateMap$1);
 }
 
-module.exports = exports['default'];
-
 //      
 
 /**
@@ -3185,8 +3064,6 @@ function transitions() {
     transition: properties.join(', ')
   };
 }
-
-module.exports = exports['default'];
 
 //      
 // Helpers

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -875,7 +875,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/clearFix.js#L26-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/mixins/clearFix.js#L26-L35'>
       <span>src/mixins/clearFix.js</span>
       </a>
     
@@ -966,7 +966,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/ellipsis.js#L29-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/mixins/ellipsis.js#L29-L38'>
       <span>src/mixins/ellipsis.js</span>
       </a>
     
@@ -1060,7 +1060,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/fontFace.js#L70-L107'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/mixins/fontFace.js#L70-L107'>
       <span>src/mixins/fontFace.js</span>
       </a>
     
@@ -1227,7 +1227,7 @@ injectGlobal`${
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/hiDPI.js#L32-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/mixins/hiDPI.js#L32-L40'>
       <span>src/mixins/hiDPI.js</span>
       </a>
     
@@ -1324,7 +1324,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/hideText.js#L29-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/mixins/hideText.js#L29-L35'>
       <span>src/mixins/hideText.js</span>
       </a>
     
@@ -1404,7 +1404,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/hideVisually.js#L34-L47'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/mixins/hideVisually.js#L34-L47'>
       <span>src/mixins/hideVisually.js</span>
       </a>
     
@@ -1489,7 +1489,7 @@ from <a href="https://github.com/h5bp/html5-boilerplate/blob/9a176f57af1cfe8ec70
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/normalize.js#L288-L291'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/mixins/normalize.js#L288-L291'>
       <span>src/mixins/normalize.js</span>
       </a>
     
@@ -1577,7 +1577,7 @@ html {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/placeholder.js#L35-L50'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/mixins/placeholder.js#L35-L50'>
       <span>src/mixins/placeholder.js</span>
       </a>
     
@@ -1685,7 +1685,7 @@ const div = styled.input`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/radialGradient.js#L78-L92'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/mixins/radialGradient.js#L78-L92'>
       <span>src/mixins/radialGradient.js</span>
       </a>
     
@@ -1830,7 +1830,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/retinaImage.js#L33-L56'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/mixins/retinaImage.js#L33-L56'>
       <span>src/mixins/retinaImage.js</span>
       </a>
     
@@ -1960,7 +1960,7 @@ a _2x.png filename suffix by default.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/selection.js#L31-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/mixins/selection.js#L31-L40'>
       <span>src/mixins/selection.js</span>
       </a>
     
@@ -2064,7 +2064,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/timingFunctions.js#L82-L84'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/mixins/timingFunctions.js#L82-L84'>
       <span>src/mixins/timingFunctions.js</span>
       </a>
     
@@ -2152,7 +2152,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/wordWrap.js#L26-L33'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/mixins/wordWrap.js#L26-L33'>
       <span>src/mixins/wordWrap.js</span>
       </a>
     
@@ -2255,7 +2255,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/adjustHue.js#L31-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/color/adjustHue.js#L31-L37'>
       <span>src/color/adjustHue.js</span>
       </a>
     
@@ -2355,7 +2355,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/complement.js#L28-L34'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/color/complement.js#L28-L34'>
       <span>src/color/complement.js</span>
       </a>
     
@@ -2445,7 +2445,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/darken.js#L31-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/color/darken.js#L31-L37'>
       <span>src/color/darken.js</span>
       </a>
     
@@ -2544,7 +2544,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/desaturate.js#L32-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/color/desaturate.js#L32-L38'>
       <span>src/color/desaturate.js</span>
       </a>
     
@@ -2644,7 +2644,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/getLuminance.js#L30-L39'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/color/getLuminance.js#L30-L39'>
       <span>src/color/getLuminance.js</span>
       </a>
     
@@ -2738,7 +2738,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/grayscale.js#L28-L33'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/color/grayscale.js#L28-L33'>
       <span>src/color/grayscale.js</span>
       </a>
     
@@ -2828,7 +2828,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/hsl.js#L29-L49'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/color/hsl.js#L29-L49'>
       <span>src/color/hsl.js</span>
       </a>
     
@@ -2935,7 +2935,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/hsla.js#L33-L62'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/color/hsla.js#L33-L62'>
       <span>src/color/hsla.js</span>
       </a>
     
@@ -3053,7 +3053,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/invert.js#L29-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/color/invert.js#L29-L38'>
       <span>src/color/invert.js</span>
       </a>
     
@@ -3144,7 +3144,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/lighten.js#L31-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/color/lighten.js#L31-L37'>
       <span>src/color/lighten.js</span>
       </a>
     
@@ -3243,7 +3243,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/mix.js#L38-L68'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/color/mix.js#L38-L68'>
       <span>src/color/mix.js</span>
       </a>
     
@@ -3358,7 +3358,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/opacify.js#L34-L43'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/color/opacify.js#L34-L43'>
       <span>src/color/opacify.js</span>
       </a>
     
@@ -3460,7 +3460,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/parseToHsl.js#L18-L22'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/color/parseToHsl.js#L18-L22'>
       <span>src/color/parseToHsl.js</span>
       </a>
     
@@ -3539,7 +3539,7 @@ const color2 = 'hsla(<span class="hljs-number">210</span>, <span class="hljs-num
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/parseToRgb.js#L24-L88'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/color/parseToRgb.js#L24-L88'>
       <span>src/color/parseToRgb.js</span>
       </a>
     
@@ -3618,7 +3618,7 @@ const color2 = 'hsla(<span class="hljs-number">210</span>, <span class="hljs-num
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/readableColor.js#L33-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/color/readableColor.js#L33-L35'>
       <span>src/color/readableColor.js</span>
       </a>
     
@@ -3713,7 +3713,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/rgb.js#L30-L46'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/color/rgb.js#L30-L46'>
       <span>src/color/rgb.js</span>
       </a>
     
@@ -3820,7 +3820,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/rgba.js#L41-L75'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/color/rgba.js#L41-L75'>
       <span>src/color/rgba.js</span>
       </a>
     
@@ -3945,7 +3945,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/saturate.js#L33-L39'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/color/saturate.js#L33-L39'>
       <span>src/color/saturate.js</span>
       </a>
     
@@ -4046,7 +4046,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/setHue.js#L30-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/color/setHue.js#L30-L35'>
       <span>src/color/setHue.js</span>
       </a>
     
@@ -4145,7 +4145,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/setLightness.js#L30-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/color/setLightness.js#L30-L35'>
       <span>src/color/setLightness.js</span>
       </a>
     
@@ -4244,7 +4244,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/setSaturation.js#L30-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/color/setSaturation.js#L30-L35'>
       <span>src/color/setSaturation.js</span>
       </a>
     
@@ -4343,7 +4343,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/shade.js#L29-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/color/shade.js#L29-L37'>
       <span>src/color/shade.js</span>
       </a>
     
@@ -4441,7 +4441,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/tint.js#L29-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/color/tint.js#L29-L37'>
       <span>src/color/tint.js</span>
       </a>
     
@@ -4539,7 +4539,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/transparentize.js#L34-L43'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/color/transparentize.js#L34-L43'>
       <span>src/color/transparentize.js</span>
       </a>
     
@@ -4653,7 +4653,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/animation.js#L42-L67'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/shorthands/animation.js#L42-L67'>
       <span>src/shorthands/animation.js</span>
       </a>
     
@@ -4759,7 +4759,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/backgroundImages.js#L23-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/shorthands/backgroundImages.js#L23-L27'>
       <span>src/shorthands/backgroundImages.js</span>
       </a>
     
@@ -4847,7 +4847,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/backgrounds.js#L22-L26'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/shorthands/backgrounds.js#L22-L26'>
       <span>src/shorthands/backgrounds.js</span>
       </a>
     
@@ -4935,7 +4935,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/borderColor.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/shorthands/borderColor.js#L27-L29'>
       <span>src/shorthands/borderColor.js</span>
       </a>
     
@@ -5026,7 +5026,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/borderRadius.js#L25-L45'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/shorthands/borderRadius.js#L25-L45'>
       <span>src/shorthands/borderRadius.js</span>
       </a>
     
@@ -5123,7 +5123,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/borderStyle.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/shorthands/borderStyle.js#L27-L29'>
       <span>src/shorthands/borderStyle.js</span>
       </a>
     
@@ -5214,7 +5214,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/borderWidth.js#L26-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/shorthands/borderWidth.js#L26-L28'>
       <span>src/shorthands/borderWidth.js</span>
       </a>
     
@@ -5305,7 +5305,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/buttons.js#L42-L44'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/shorthands/buttons.js#L42-L44'>
       <span>src/shorthands/buttons.js</span>
       </a>
     
@@ -5400,7 +5400,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/margin.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/shorthands/margin.js#L27-L29'>
       <span>src/shorthands/margin.js</span>
       </a>
     
@@ -5491,7 +5491,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/padding.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/shorthands/padding.js#L27-L29'>
       <span>src/shorthands/padding.js</span>
       </a>
     
@@ -5582,7 +5582,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/position.js#L49-L62'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/shorthands/position.js#L49-L62'>
       <span>src/shorthands/position.js</span>
       </a>
     
@@ -5701,7 +5701,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/size.js#L24-L32'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/shorthands/size.js#L24-L32'>
       <span>src/shorthands/size.js</span>
       </a>
     
@@ -5799,7 +5799,7 @@ const <span class="hljs-keyword">div</span> = styled.<span class="hljs-keyword">
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/textInputs.js#L66-L68'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/shorthands/textInputs.js#L66-L68'>
       <span>src/shorthands/textInputs.js</span>
       </a>
     
@@ -5906,7 +5906,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/transitions.js#L23-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/shorthands/transitions.js#L23-L27'>
       <span>src/shorthands/transitions.js</span>
       </a>
     
@@ -6006,7 +6006,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/helpers/directionalProperty.js#L53-L61'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/helpers/directionalProperty.js#L53-L61'>
       <span>src/helpers/directionalProperty.js</span>
       </a>
     
@@ -6105,7 +6105,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/helpers/em.js#L28-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/helpers/em.js#L28-L28'>
       <span>src/helpers/em.js</span>
       </a>
     
@@ -6203,7 +6203,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/helpers/modularScale.js#L67-L87'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/helpers/modularScale.js#L67-L87'>
       <span>src/helpers/modularScale.js</span>
       </a>
     
@@ -6311,7 +6311,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/helpers/rem.js#L29-L32'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/helpers/rem.js#L29-L32'>
       <span>src/helpers/rem.js</span>
       </a>
     
@@ -6409,7 +6409,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/helpers/stripUnit.js#L24-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/helpers/stripUnit.js#L24-L28'>
       <span>src/helpers/stripUnit.js</span>
       </a>
     
@@ -6509,7 +6509,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/animation.js#L4-L4'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/shorthands/animation.js#L4-L4'>
       <span>src/shorthands/animation.js</span>
       </a>
     
@@ -6563,7 +6563,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/fontFace.js#L4-L14'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/mixins/fontFace.js#L4-L14'>
       <span>src/mixins/fontFace.js</span>
       </a>
     
@@ -6676,7 +6676,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/types/color.js#L11-L15'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/types/color.js#L11-L15'>
       <span>src/types/color.js</span>
       </a>
     
@@ -6753,7 +6753,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/types/color.js#L23-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/types/color.js#L23-L28'>
       <span>src/types/color.js</span>
       </a>
     
@@ -6836,7 +6836,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/types/interactionState.js#L9-L14'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/types/interactionState.js#L9-L14'>
       <span>src/types/interactionState.js</span>
       </a>
     
@@ -6890,7 +6890,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/triangle.js#L4-L4'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/mixins/triangle.js#L4-L4'>
       <span>src/mixins/triangle.js</span>
       </a>
     
@@ -6944,7 +6944,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/radialGradient.js#L4-L10'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/mixins/radialGradient.js#L4-L10'>
       <span>src/mixins/radialGradient.js</span>
       </a>
     
@@ -7033,7 +7033,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/types/color.js#L47-L52'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/types/color.js#L47-L52'>
       <span>src/types/color.js</span>
       </a>
     
@@ -7116,7 +7116,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/types/color.js#L35-L39'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/types/color.js#L35-L39'>
       <span>src/types/color.js</span>
       </a>
     
@@ -7193,7 +7193,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/toColorString.js#L65-L73'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/color/toColorString.js#L65-L73'>
       <span>src/color/toColorString.js</span>
       </a>
     
@@ -7291,7 +7291,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/helpers/modularScale.js#L5-L23'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/helpers/modularScale.js#L5-L23'>
       <span>src/helpers/modularScale.js</span>
       </a>
     
@@ -7340,7 +7340,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/timingFunctions.js#L4-L31'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/mixins/timingFunctions.js#L4-L31'>
       <span>src/mixins/timingFunctions.js</span>
       </a>
     
@@ -7389,7 +7389,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/triangle.js#L35-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/mixins/triangle.js#L35-L40'>
       <span>src/mixins/triangle.js</span>
       </a>
     
@@ -7466,7 +7466,7 @@ div:</span> {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/types/modularScaleRatio.js#L9-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ce1af2e395ce1ed9f4a11035cbd61e312770a762/src/types/modularScaleRatio.js#L9-L27'>
       <span>src/types/modularScaleRatio.js</span>
       </a>
     

--- a/src/color/parseToRgb.js
+++ b/src/color/parseToRgb.js
@@ -4,6 +4,7 @@ import nameToHex from '../internalHelpers/_nameToHex'
 import type { RgbColor, RgbaColor } from '../types/color'
 
 const hexRegex = /^#[a-fA-F0-9]{6}$/
+const hexRgbaRegex = /^#[a-fA-F0-9]{8}$/
 const reducedHexRegex = /^#[a-fA-F0-9]{3}$/
 const rgbRegex = /^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/
 const rgbaRegex = /^rgba\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*([-+]?[0-9]*[.]?[0-9]+)\s*\)$/
@@ -31,6 +32,16 @@ function parseToRgb(color: string): RgbColor | RgbaColor {
       red: parseInt(`${normalizedColor[1]}${normalizedColor[2]}`, 16),
       green: parseInt(`${normalizedColor[3]}${normalizedColor[4]}`, 16),
       blue: parseInt(`${normalizedColor[5]}${normalizedColor[6]}`, 16),
+    }
+  }
+  if (normalizedColor.match(hexRgbaRegex)) {
+    const alpha =
+      parseInt(`${normalizedColor[7]}${normalizedColor[8]}`, 16) / 255
+    return {
+      red: parseInt(`${normalizedColor[1]}${normalizedColor[2]}`, 16),
+      green: parseInt(`${normalizedColor[3]}${normalizedColor[4]}`, 16),
+      blue: parseInt(`${normalizedColor[5]}${normalizedColor[6]}`, 16),
+      alpha,
     }
   }
   if (normalizedColor.match(reducedHexRegex)) {

--- a/src/color/test/__snapshots__/adjustHue.test.js.snap
+++ b/src/color/test/__snapshots__/adjustHue.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`adjustHue should adjustHue of a 8-digit hex color 1`] = `"rgba(169,205,100,0.4980392156862745)"`;
+
 exports[`adjustHue should adjustHue of a color and not go beyond 360 1`] = `"#444f88"`;
 
 exports[`adjustHue should adjustHue of a color with opacity 1`] = `"rgba(136,100,205,0.7)"`;

--- a/src/color/test/__snapshots__/complement.test.js.snap
+++ b/src/color/test/__snapshots__/complement.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`complement should return the complement of a 8-digit hex color 1`] = `"rgba(101,100,205,0.4980392156862745)"`;
+
 exports[`complement should return the complement of a color with opacity 1`] = `"rgba(204,205,100,0.7)"`;
 
 exports[`complement should return the complement of a hex color 1`] = `"#6564cd"`;

--- a/src/color/test/__snapshots__/desaturate.test.js.snap
+++ b/src/color/test/__snapshots__/desaturate.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`desaturate should desaturate a 8-digit hex color by 20% 1`] = `"rgba(184,185,121,0.4980392156862745)"`;
+
 exports[`desaturate should desaturate a color but not go below 0 1`] = `"rgba(25,25,25,0.7)"`;
 
 exports[`desaturate should desaturate a color with opacity by 20% 1`] = `"rgba(184,185,121,0.7)"`;

--- a/src/color/test/__snapshots__/grayscale.test.js.snap
+++ b/src/color/test/__snapshots__/grayscale.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`grayscale should grayscale a 8-digit hex color 1`] = `"rgba(153,153,153,0.4980392156862745)"`;
+
 exports[`grayscale should grayscale a color with opacity 1`] = `"rgba(153,153,153,0.7)"`;
 
 exports[`grayscale should grayscale a hex color 1`] = `"#999"`;

--- a/src/color/test/__snapshots__/invert.test.js.snap
+++ b/src/color/test/__snapshots__/invert.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`invert should invert a 8-digit hex color 1`] = `"rgba(51,50,155,0.6549019607843137)"`;
+
 exports[`invert should invert a color with opacity 1`] = `"rgba(154,155,50,0.7)"`;
 
 exports[`invert should invert a hex color 1`] = `"#33329b"`;

--- a/src/color/test/__snapshots__/lighten.test.js.snap
+++ b/src/color/test/__snapshots__/lighten.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`lighten should lighten a 8-digit hex color by 20% 1`] = `"rgba(229,230,177,0.6549019607843137)"`;
+
 exports[`lighten should lighten a color but not go beyond 255 1`] = `"rgba(255,255,255,0.7)"`;
 
 exports[`lighten should lighten a color by 10% 1`] = `"#5e5e5e"`;

--- a/src/color/test/__snapshots__/mix.test.js.snap
+++ b/src/color/test/__snapshots__/mix.test.js.snap
@@ -2,6 +2,8 @@
 
 exports[`mix should mix two colors 1`] = `"#7f007f"`;
 
+exports[`mix should mix two colors with 8-digit hex color 1`] = `"rgba(63,0,191,0.7490196078431373)"`;
+
 exports[`mix should mix two colors with by a weight of 25% 1`] = `"#3f00bf"`;
 
 exports[`mix should mix two colors with opacity lower than 1 1`] = `"rgba(63,0,191,0.75)"`;

--- a/src/color/test/__snapshots__/parseToHsl.test.js.snap
+++ b/src/color/test/__snapshots__/parseToHsl.test.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`parseToHsl should parse a 8-digit hex color representation 1`] = `
+Object {
+  "alpha": 0.6549019607843137,
+  "hue": 325.8510638297872,
+  "lightness": 0.6313725490196078,
+  "saturation": 1,
+}
+`;
+
 exports[`parseToHsl should parse a hex color representation 1`] = `
 Object {
   "hue": 325.8510638297872,

--- a/src/color/test/__snapshots__/parseToRgb.test.js.snap
+++ b/src/color/test/__snapshots__/parseToRgb.test.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`parseToRgb should parse a 8-digit hex color representation 1`] = `
+Object {
+  "alpha": 1,
+  "blue": 174,
+  "green": 67,
+  "red": 255,
+}
+`;
+
 exports[`parseToRgb should parse a hex color representation 1`] = `
 Object {
   "blue": 174,

--- a/src/color/test/__snapshots__/readableColor.test.js.snap
+++ b/src/color/test/__snapshots__/readableColor.test.js.snap
@@ -24,6 +24,10 @@ exports[`readableColor should return white given black, "black" 1`] = `"#fff"`;
 
 exports[`readableColor should return white given black, #000 1`] = `"#fff"`;
 
+exports[`readableColor should return white given black, #0000001A 1`] = `"#fff"`;
+
+exports[`readableColor should return white given black, #000000BF 1`] = `"#fff"`;
+
 exports[`readableColor should return white given black, rgb(0,0,0) 1`] = `"#fff"`;
 
 exports[`readableColor should return white given black, rgba(0,0,0,0.1) 1`] = `"#fff"`;

--- a/src/color/test/__snapshots__/saturate.test.js.snap
+++ b/src/color/test/__snapshots__/saturate.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`saturate should saturate a 8-digit hex color by 20% 1`] = `"rgba(224,226,80,0.4980392156862745)"`;
+
 exports[`saturate should saturate a color but not go beyond 255 1`] = `"rgba(255,200,200,0.7)"`;
 
 exports[`saturate should saturate a color by 10% 1`] = `"#4b3d3d"`;

--- a/src/color/test/adjustHue.test.js
+++ b/src/color/test/adjustHue.test.js
@@ -10,6 +10,10 @@ describe('adjustHue', () => {
     expect(adjustHue(20, '#CCCD64')).toMatchSnapshot()
   })
 
+  it('should adjustHue of a 8-digit hex color', () => {
+    expect(adjustHue(20, '#CCCD647F')).toMatchSnapshot()
+  })
+
   it('should adjustHue of a color with opacity', () => {
     expect(adjustHue(20, 'rgba(101,100,205,0.7)')).toMatchSnapshot()
   })

--- a/src/color/test/complement.test.js
+++ b/src/color/test/complement.test.js
@@ -10,6 +10,10 @@ describe('complement', () => {
     expect(complement('#CCCD64')).toMatchSnapshot()
   })
 
+  it('should return the complement of a 8-digit hex color', () => {
+    expect(complement('#CCCD647F')).toMatchSnapshot()
+  })
+
   it('should return the complement of a color with opacity', () => {
     expect(complement('rgba(101,100,205,0.7)')).toMatchSnapshot()
   })

--- a/src/color/test/desaturate.test.js
+++ b/src/color/test/desaturate.test.js
@@ -10,6 +10,10 @@ describe('desaturate', () => {
     expect(desaturate(0.2, '#CCCD64')).toMatchSnapshot()
   })
 
+  it('should desaturate a 8-digit hex color by 20%', () => {
+    expect(desaturate(0.2, '#CCCD647F')).toMatchSnapshot()
+  })
+
   it('should desaturate a color with opacity by 20%', () => {
     expect(desaturate(0.2, 'rgba(204,205,100,0.7)')).toMatchSnapshot()
   })

--- a/src/color/test/grayscale.test.js
+++ b/src/color/test/grayscale.test.js
@@ -10,6 +10,10 @@ describe('grayscale', () => {
     expect(grayscale('#CCCD64')).toMatchSnapshot()
   })
 
+  it('should grayscale a 8-digit hex color', () => {
+    expect(grayscale('#CCCD647F')).toMatchSnapshot()
+  })
+
   it('should grayscale a color with opacity', () => {
     expect(grayscale('rgba(204,205,100,0.7)')).toMatchSnapshot()
   })

--- a/src/color/test/invert.test.js
+++ b/src/color/test/invert.test.js
@@ -10,6 +10,10 @@ describe('invert', () => {
     expect(invert('#CCCD64')).toMatchSnapshot()
   })
 
+  it('should invert a 8-digit hex color', () => {
+    expect(invert('#CCCD64A7')).toMatchSnapshot()
+  })
+
   it('should invert a color with opacity', () => {
     expect(invert('rgba(101,100,205,0.7)')).toMatchSnapshot()
   })

--- a/src/color/test/lighten.test.js
+++ b/src/color/test/lighten.test.js
@@ -10,6 +10,10 @@ describe('lighten', () => {
     expect(lighten(0.2, '#CCCD64')).toMatchSnapshot()
   })
 
+  it('should lighten a 8-digit hex color by 20%', () => {
+    expect(lighten(0.2, '#CCCD64A7')).toMatchSnapshot()
+  })
+
   it('should lighten a color with opacity by 20%', () => {
     expect(lighten(0.2, 'rgba(204,205,100,0.7)')).toMatchSnapshot()
   })

--- a/src/color/test/mix.test.js
+++ b/src/color/test/mix.test.js
@@ -10,6 +10,10 @@ describe('mix', () => {
     expect(mix(0.25, '#f00', '#00f')).toMatchSnapshot()
   })
 
+  it('should mix two colors with 8-digit hex color', () => {
+    expect(mix(0.5, '#FF00007F', '#00f')).toMatchSnapshot()
+  })
+
   it('should mix two colors with opacity lower than 1', () => {
     expect(mix(0.5, 'rgba(255, 0, 0, 0.5)', '#00f')).toMatchSnapshot()
   })

--- a/src/color/test/parseToHsl.test.js
+++ b/src/color/test/parseToHsl.test.js
@@ -5,6 +5,10 @@ describe('parseToHsl', () => {
     expect(parseToHsl('#Ff43AE')).toMatchSnapshot()
   })
 
+  it('should parse a 8-digit hex color representation', () => {
+    expect(parseToHsl('#Ff43AEA7')).toMatchSnapshot()
+  })
+
   it('should parse a reduced hex color representation', () => {
     expect(parseToHsl('#45a')).toMatchSnapshot()
   })

--- a/src/color/test/parseToRgb.test.js
+++ b/src/color/test/parseToRgb.test.js
@@ -5,6 +5,10 @@ describe('parseToRgb', () => {
     expect(parseToRgb('#Ff43AE')).toMatchSnapshot()
   })
 
+  it('should parse a 8-digit hex color representation', () => {
+    expect(parseToRgb('#Ff43AEFF')).toMatchSnapshot()
+  })
+
   it('should parse a reduced hex color representation', () => {
     expect(parseToRgb('#45a')).toMatchSnapshot()
   })

--- a/src/color/test/readableColor.test.js
+++ b/src/color/test/readableColor.test.js
@@ -22,6 +22,12 @@ describe('readableColor', () => {
   it('should return white given gray, #757575', () => {
     expect(readableColor('#757575')).toMatchSnapshot()
   })
+  it('should return white given black, #0000001A', () => {
+    expect(readableColor('#0000001A')).toMatchSnapshot()
+  })
+  it('should return white given black, #000000BF', () => {
+    expect(readableColor('#000000BF')).toMatchSnapshot()
+  })
   it('should return black given white, rgb(255,255,255)', () => {
     expect(readableColor('rgb(255,255,255)')).toMatchSnapshot()
   })

--- a/src/color/test/saturate.test.js
+++ b/src/color/test/saturate.test.js
@@ -10,6 +10,10 @@ describe('saturate', () => {
     expect(saturate(0.2, '#CCCD64')).toMatchSnapshot()
   })
 
+  it('should saturate a 8-digit hex color by 20%', () => {
+    expect(saturate(0.2, '#CCCD647F')).toMatchSnapshot()
+  })
+
   it('should saturate a color with opacity by 20%', () => {
     expect(saturate(0.2, 'rgba(204,205,100,0.7)')).toMatchSnapshot()
   })


### PR DESCRIPTION
#RRGGBBAA hexadecimal color notation supported by [Chrome](https://www.chromestatus.com/feature/5685348285808640), [Firefox](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#Syntax)

#306