### PR TITLE
feat(tracking) : Add helper for converting Illustrator, Photoshop, Indesign tracking values to em

### DIFF
--- a/.documentation.json
+++ b/.documentation.json
@@ -83,6 +83,7 @@
     "modularScale",
     "rem",
     "stripUnit",
+    "tracking",
     {
       "name": "Types"
     },

--- a/docs/assets/polished.js
+++ b/docs/assets/polished.js
@@ -11,8 +11,6 @@ function capitalizeString(string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
-module.exports = exports["default"];
-
 //      
 var positionMap = ['Top', 'Right', 'Bottom', 'Left'];
 
@@ -80,14 +78,11 @@ function directionalProperty(property) {
   return generateStyles(property, valuesWithDefaults);
 }
 
-module.exports = exports['default'];
-
 //      
 
 function endsWith (string, suffix) {
   return string.substr(-suffix.length) === suffix;
 }
-module.exports = exports["default"];
 
 //      
 
@@ -117,8 +112,6 @@ function stripUnit(value) {
   if (isNaN(unitlessValue)) return value;
   return unitlessValue;
 }
-
-module.exports = exports["default"];
 
 //      
 
@@ -158,8 +151,6 @@ var pxtoFactory = function pxtoFactory(to) {
   };
 };
 
-module.exports = exports['default'];
-
 //      
 /**
  * Convert pixel value to ems. The default base value is 16px, but can be changed by passing a
@@ -186,7 +177,6 @@ module.exports = exports['default'];
  */
 
 var em = /*#__PURE__*/pxtoFactory('em');
-module.exports = exports['default'];
 
 //      
 
@@ -280,7 +270,39 @@ var ratioNames = {
  */
 
 var rem = /*#__PURE__*/pxtoFactory('rem');
-module.exports = exports['default'];
+
+//      
+
+/**
+ * Convert tracking to letter-space friendly ems. Useful for converting
+ * Adobe Illustrator, Indesign and Photoshop tracking values, in which
+ * tracking is measured in 1/1000 em.
+ * @name tracking
+ * @function
+ * @param {number} target
+ * @example
+ * // Styles as object usage
+ * const styles = {
+ *   'letterSpacing': tracking(50)
+ * }
+ *
+ * // styled-components usage
+ * const div = styled.div`
+ *   letterSpacing: ${tracking(50)}
+ * `
+ *
+ * // CSS in JS Output
+ *
+ * element {
+ *   'letterSpacing': '0.05em'
+ * }
+ */
+
+var TRACKING_DIVISOR = 1000;
+
+var tracking = function tracking(target) {
+  return target / TRACKING_DIVISOR + "em";
+};
 
 //      
 
@@ -319,8 +341,6 @@ function clearFix() {
     display: 'table'
   }, _ref;
 }
-
-module.exports = exports['default'];
 
 //      
 
@@ -362,8 +382,6 @@ function ellipsis() {
     wordWrap: 'normal'
   };
 }
-
-module.exports = exports['default'];
 
 //      
 
@@ -459,8 +477,6 @@ function fontFace(_ref) {
   };return JSON.parse(JSON.stringify(fontFaceDeclaration));
 }
 
-module.exports = exports['default'];
-
 //      
 
 /**
@@ -496,8 +512,6 @@ function hideText() {
     whiteSpace: 'nowrap'
   };
 }
-
-module.exports = exports['default'];
 
 //      
 
@@ -547,8 +561,6 @@ function hideVisually() {
   };
 }
 
-module.exports = exports['default'];
-
 //      
 
 /**
@@ -586,9 +598,50 @@ function hiDPI() {
   return "\n    @media only screen and (-webkit-min-device-pixel-ratio: " + ratio + "),\n    only screen and (min--moz-device-pixel-ratio: " + ratio + "),\n    only screen and (-o-min-device-pixel-ratio: " + ratio + "/1),\n    only screen and (min-resolution: " + Math.round(ratio * 96) + "dpi),\n    only screen and (min-resolution: " + ratio + "dppx)\n  ";
 }
 
-module.exports = exports["default"];
+var _extends = Object.assign || function (target) {
+  for (var i = 1; i < arguments.length; i++) {
+    var source = arguments[i];
 
-var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+    for (var key in source) {
+      if (Object.prototype.hasOwnProperty.call(source, key)) {
+        target[key] = source[key];
+      }
+    }
+  }
+
+  return target;
+};
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+var taggedTemplateLiteralLoose = function (strings, raw) {
+  strings.raw = raw;
+  return strings;
+};
 
 var _opinionatedRules;
 var _abbrTitle;
@@ -761,10 +814,6 @@ function normalize(excludeOpinionated) {
   return mergeRules(unopinionatedRules, opinionatedRules);
 }
 
-module.exports = exports['default'];
-
-var _extends$1 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
-
 //      
 
 /**
@@ -804,14 +853,10 @@ function placeholder(styles) {
 
   var parent = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '&';
 
-  return _ref = {}, _ref[parent + '::-webkit-input-placeholder'] = _extends$1({}, styles), _ref[parent + ':-moz-placeholder'] = _extends$1({}, styles), _ref[parent + '::-moz-placeholder'] = _extends$1({}, styles), _ref[parent + ':-ms-input-placeholder'] = _extends$1({}, styles), _ref;
+  return _ref = {}, _ref[parent + '::-webkit-input-placeholder'] = _extends({}, styles), _ref[parent + ':-moz-placeholder'] = _extends({}, styles), _ref[parent + '::-moz-placeholder'] = _extends({}, styles), _ref[parent + ':-ms-input-placeholder'] = _extends({}, styles), _ref;
 }
 
-module.exports = exports['default'];
-
-var _templateObject = /*#__PURE__*/ _taggedTemplateLiteralLoose(['radial-gradient(', '', '', '', ')'], ['radial-gradient(', '', '', '', ')']);
-
-function _taggedTemplateLiteralLoose(strings, raw) { strings.raw = raw; return strings; }
+var _templateObject = /*#__PURE__*/ taggedTemplateLiteralLoose(['radial-gradient(', '', '', '', ')'], ['radial-gradient(', '', '', '', ')']);
 
 //      
 
@@ -888,8 +933,6 @@ function radialGradient(_ref) {
   };
 }
 
-module.exports = exports['default'];
-
 //      
 
 /**
@@ -943,10 +986,6 @@ function retinaImage(filename, backgroundSize) {
   }, _ref;
 }
 
-module.exports = exports['default'];
-
-var _extends$2 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
-
 //      
 
 /**
@@ -982,10 +1021,8 @@ function selection(styles) {
 
   var parent = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '';
 
-  return _ref = {}, _ref[parent + '::-moz-selection'] = _extends$2({}, styles), _ref[parent + '::selection'] = _extends$2({}, styles), _ref;
+  return _ref = {}, _ref[parent + '::-moz-selection'] = _extends({}, styles), _ref[parent + '::selection'] = _extends({}, styles), _ref;
 }
-
-module.exports = exports['default'];
 
 //      
 
@@ -1045,8 +1082,6 @@ var functionsMap = {
 };function timingFunctions(timingFunction) {
   return functionsMap[timingFunction];
 }
-
-module.exports = exports['default'];
 
 //      
 
@@ -1128,8 +1163,6 @@ var reverseDirection = {
   }, _ref2['border' + reverseDirection[pointingDirection] + 'Color'] = foregroundColor + ' !important', _ref2;
 }
 
-module.exports = exports['default'];
-
 //      
 
 /**
@@ -1165,8 +1198,6 @@ function wordWrap() {
     wordBreak: wordBreak
   };
 }
-
-module.exports = exports['default'];
 
 //      
 
@@ -1222,8 +1253,6 @@ function hslToRgb(hue, saturation, lightness) {
   var finalBlue = blue + lightnessModification;
   return convert(finalRed, finalGreen, finalBlue);
 }
-
-module.exports = exports["default"];
 
 //      
 var namedColorMap = {
@@ -1386,8 +1415,6 @@ var namedColorMap = {
   return namedColorMap[normalizedColorName] ? '#' + namedColorMap[normalizedColorName] : color;
 }
 
-module.exports = exports['default'];
-
 //      
 var hexRegex = /^#[a-fA-F0-9]{6}$/;
 var reducedHexRegex = /^#[a-fA-F0-9]{3}$/;
@@ -1473,8 +1500,6 @@ function parseToRgb(color) {
   throw new Error("Couldn't parse the color string. Please provide the color as a string in hex, rgb, rgba, hsl or hsla notation.");
 }
 
-module.exports = exports['default'];
-
 //      
 
 
@@ -1530,8 +1555,6 @@ function rgbToHsl(color) {
   return { hue: hue, saturation: saturation, lightness: lightness };
 }
 
-module.exports = exports["default"];
-
 //      
 
 /**
@@ -1551,8 +1574,6 @@ function parseToHsl(color) {
   return rgbToHsl(parseToRgb(color));
 }
 
-module.exports = exports['default'];
-
 //      
 
 /**
@@ -1566,17 +1587,11 @@ var reduceHexValue = function reduceHexValue(value) {
   return value;
 };
 
-module.exports = exports["default"];
-
 //      
 function numberToHex(value) {
   var hex = value.toString(16);
   return hex.length === 1 ? "0" + hex : hex;
 }
-
-module.exports = exports["default"];
-
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 //      
 
@@ -1606,16 +1621,12 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 function rgb(value, green, blue) {
   if (typeof value === 'number' && typeof green === 'number' && typeof blue === 'number') {
     return reduceHexValue('#' + numberToHex(value) + numberToHex(green) + numberToHex(blue));
-  } else if ((typeof value === 'undefined' ? 'undefined' : _typeof(value)) === 'object' && green === undefined && blue === undefined) {
+  } else if (typeof value === 'object' && green === undefined && blue === undefined) {
     return reduceHexValue('#' + numberToHex(value.red) + numberToHex(value.green) + numberToHex(value.blue));
   }
 
   throw new Error('Passed invalid arguments to rgb, please pass multiple numbers e.g. rgb(255, 205, 100) or an object e.g. rgb({ red: 255, green: 205, blue: 100 }).');
 }
-
-module.exports = exports['default'];
-
-var _typeof$1 = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 //      
 
@@ -1659,14 +1670,12 @@ function rgba(firstValue, secondValue, thirdValue, fourthValue) {
     return 'rgba(' + rgbValue.red + ',' + rgbValue.green + ',' + rgbValue.blue + ',' + secondValue + ')';
   } else if (typeof firstValue === 'number' && typeof secondValue === 'number' && typeof thirdValue === 'number' && typeof fourthValue === 'number') {
     return fourthValue >= 1 ? rgb(firstValue, secondValue, thirdValue) : 'rgba(' + firstValue + ',' + secondValue + ',' + thirdValue + ',' + fourthValue + ')';
-  } else if ((typeof firstValue === 'undefined' ? 'undefined' : _typeof$1(firstValue)) === 'object' && secondValue === undefined && thirdValue === undefined && fourthValue === undefined) {
+  } else if (typeof firstValue === 'object' && secondValue === undefined && thirdValue === undefined && fourthValue === undefined) {
     return firstValue.alpha >= 1 ? rgb(firstValue.red, firstValue.green, firstValue.blue) : 'rgba(' + firstValue.red + ',' + firstValue.green + ',' + firstValue.blue + ',' + firstValue.alpha + ')';
   }
 
   throw new Error('Passed invalid arguments to rgba, please pass multiple numbers e.g. rgb(255, 205, 100, 0.75) or an object e.g. rgb({ red: 255, green: 205, blue: 100, alpha: 0.75 }).');
 }
-
-module.exports = exports['default'];
 
 //      
 function colorToHex(color) {
@@ -1680,10 +1689,6 @@ function convertToHex(red, green, blue) {
 function hslToHex(hue, saturation, lightness) {
   return hslToRgb(hue, saturation, lightness, convertToHex);
 }
-
-module.exports = exports['default'];
-
-var _typeof$2 = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 //      
 
@@ -1713,16 +1718,12 @@ var _typeof$2 = typeof Symbol === "function" && typeof Symbol.iterator === "symb
 function hsl(value, saturation, lightness) {
   if (typeof value === 'number' && typeof saturation === 'number' && typeof lightness === 'number') {
     return hslToHex(value, saturation, lightness);
-  } else if ((typeof value === 'undefined' ? 'undefined' : _typeof$2(value)) === 'object' && saturation === undefined && lightness === undefined) {
+  } else if (typeof value === 'object' && saturation === undefined && lightness === undefined) {
     return hslToHex(value.hue, value.saturation, value.lightness);
   }
 
   throw new Error('Passed invalid arguments to hsl, please pass multiple numbers e.g. hsl(360, 0.75, 0.4) or an object e.g. rgb({ hue: 255, saturation: 0.4, lightness: 0.75 }).');
 }
-
-module.exports = exports['default'];
-
-var _typeof$3 = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 //      
 
@@ -1755,16 +1756,12 @@ var _typeof$3 = typeof Symbol === "function" && typeof Symbol.iterator === "symb
 function hsla(value, saturation, lightness, alpha) {
   if (typeof value === 'number' && typeof saturation === 'number' && typeof lightness === 'number' && typeof alpha === 'number') {
     return alpha >= 1 ? hslToHex(value, saturation, lightness) : 'rgba(' + hslToRgb(value, saturation, lightness) + ',' + alpha + ')';
-  } else if ((typeof value === 'undefined' ? 'undefined' : _typeof$3(value)) === 'object' && saturation === undefined && lightness === undefined && alpha === undefined) {
+  } else if (typeof value === 'object' && saturation === undefined && lightness === undefined && alpha === undefined) {
     return value.alpha >= 1 ? hslToHex(value.hue, value.saturation, value.lightness) : 'rgba(' + hslToRgb(value.hue, value.saturation, value.lightness) + ',' + value.alpha + ')';
   }
 
   throw new Error('Passed invalid arguments to hsla, please pass multiple numbers e.g. hsl(360, 0.75, 0.4, 0.7) or an object e.g. rgb({ hue: 255, saturation: 0.4, lightness: 0.75, alpha: 0.7 }).');
 }
-
-module.exports = exports['default'];
-
-var _typeof$4 = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 //      
 var isRgb = function isRgb(color) {
@@ -1817,7 +1814,7 @@ var errMsg = 'Passed invalid argument to toColorString, please pass a RgbColor, 
  */
 
 function toColorString(color) {
-  if ((typeof color === 'undefined' ? 'undefined' : _typeof$4(color)) !== 'object') throw new Error(errMsg);
+  if (typeof color !== 'object') throw new Error(errMsg);
   if (isRgba(color)) return rgba(color);
   if (isRgb(color)) return rgb(color);
   if (isHsla(color)) return hsla(color);
@@ -1825,8 +1822,6 @@ function toColorString(color) {
 
   throw new Error(errMsg);
 }
-
-module.exports = exports['default'];
 
 //      
 
@@ -1854,9 +1849,6 @@ function curry(f) {
   // eslint-disable-line no-redeclare
   return curried(f, f.length, []);
 }
-module.exports = exports["default"];
-
-var _extends$3 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 //      
 
@@ -1886,15 +1878,12 @@ var _extends$3 = Object.assign || function (target) { for (var i = 1; i < argume
  */
 function adjustHue(degree, color) {
   var hslColor = parseToHsl(color);
-  return toColorString(_extends$3({}, hslColor, {
+  return toColorString(_extends({}, hslColor, {
     hue: (hslColor.hue + degree) % 360
   }));
 }
 
 var curriedAdjustHue = /*#__PURE__*/curry(adjustHue);
-module.exports = exports['default'];
-
-var _extends$4 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 //      
 
@@ -1922,22 +1911,16 @@ var _extends$4 = Object.assign || function (target) { for (var i = 1; i < argume
  */
 function complement(color) {
   var hslColor = parseToHsl(color);
-  return toColorString(_extends$4({}, hslColor, {
+  return toColorString(_extends({}, hslColor, {
     hue: (hslColor.hue + 180) % 360
   }));
 }
-
-module.exports = exports['default'];
 
 //      
 
 function guard(lowerBoundary, upperBoundary, value) {
   return Math.max(lowerBoundary, Math.min(upperBoundary, value));
 }
-
-module.exports = exports["default"];
-
-var _extends$5 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 //      
 
@@ -1966,15 +1949,12 @@ var _extends$5 = Object.assign || function (target) { for (var i = 1; i < argume
  */
 function darken(amount, color) {
   var hslColor = parseToHsl(color);
-  return toColorString(_extends$5({}, hslColor, {
+  return toColorString(_extends({}, hslColor, {
     lightness: guard(0, 1, hslColor.lightness - amount)
   }));
 }
 
 var curriedDarken = /*#__PURE__*/curry(darken);
-module.exports = exports['default'];
-
-var _extends$6 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 //      
 
@@ -2004,13 +1984,12 @@ var _extends$6 = Object.assign || function (target) { for (var i = 1; i < argume
  */
 function desaturate(amount, color) {
   var hslColor = parseToHsl(color);
-  return toColorString(_extends$6({}, hslColor, {
+  return toColorString(_extends({}, hslColor, {
     saturation: guard(0, 1, hslColor.saturation - amount)
   }));
 }
 
 var curriedDesaturate = /*#__PURE__*/curry(desaturate);
-module.exports = exports['default'];
 
 //      
 /**
@@ -2053,10 +2032,6 @@ function getLuminance(color) {
   return 0.2126 * r + 0.7152 * g + 0.0722 * b;
 }
 
-module.exports = exports['default'];
-
-var _extends$7 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
-
 //      
 
 /**
@@ -2082,14 +2057,10 @@ var _extends$7 = Object.assign || function (target) { for (var i = 1; i < argume
  * }
  */
 function grayscale(color) {
-  return toColorString(_extends$7({}, parseToHsl(color), {
+  return toColorString(_extends({}, parseToHsl(color), {
     saturation: 0
   }));
 }
-
-module.exports = exports['default'];
-
-var _extends$8 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 //      
 
@@ -2119,16 +2090,12 @@ var _extends$8 = Object.assign || function (target) { for (var i = 1; i < argume
 function invert(color) {
   // parse color string to rgb
   var value = parseToRgb(color);
-  return toColorString(_extends$8({}, value, {
+  return toColorString(_extends({}, value, {
     red: 255 - value.red,
     green: 255 - value.green,
     blue: 255 - value.blue
   }));
 }
-
-module.exports = exports['default'];
-
-var _extends$9 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 //      
 
@@ -2157,15 +2124,12 @@ var _extends$9 = Object.assign || function (target) { for (var i = 1; i < argume
  */
 function lighten(amount, color) {
   var hslColor = parseToHsl(color);
-  return toColorString(_extends$9({}, hslColor, {
+  return toColorString(_extends({}, hslColor, {
     lightness: guard(0, 1, hslColor.lightness + amount)
   }));
 }
 
 var curriedLighten = /*#__PURE__*/curry(lighten);
-module.exports = exports['default'];
-
-var _extends$10 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 //      
 
@@ -2206,12 +2170,12 @@ function mix() {
   var otherColor = arguments[2];
 
   var parsedColor1 = parseToRgb(color);
-  var color1 = _extends$10({}, parsedColor1, {
+  var color1 = _extends({}, parsedColor1, {
     alpha: typeof parsedColor1.alpha === 'number' ? parsedColor1.alpha : 1
   });
 
   var parsedColor2 = parseToRgb(otherColor);
-  var color2 = _extends$10({}, parsedColor2, {
+  var color2 = _extends({}, parsedColor2, {
     alpha: typeof parsedColor2.alpha === 'number' ? parsedColor2.alpha : 1
 
     // The formular is copied from the original Sass implementation:
@@ -2234,9 +2198,6 @@ function mix() {
 }
 
 var curriedMix = /*#__PURE__*/curry(mix);
-module.exports = exports['default'];
-
-var _extends$11 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 //      
 /**
@@ -2269,14 +2230,13 @@ var _extends$11 = Object.assign || function (target) { for (var i = 1; i < argum
 function opacify(amount, color) {
   var parsedColor = parseToRgb(color);
   var alpha = typeof parsedColor.alpha === 'number' ? parsedColor.alpha : 1;
-  var colorWithAlpha = _extends$11({}, parsedColor, {
+  var colorWithAlpha = _extends({}, parsedColor, {
     alpha: guard(0, 1, (alpha * 100 + amount * 100) / 100)
   });
   return rgba(colorWithAlpha);
 }
 
 var curriedOpacify = /*#__PURE__*/curry(opacify);
-module.exports = exports['default'];
 
 //      
 /**
@@ -2312,9 +2272,6 @@ function readableColor(color) {
 }
 
 var curriedReadableColor = /*#__PURE__*/curry(readableColor);
-module.exports = exports['default'];
-
-var _extends$12 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 //      
 
@@ -2345,15 +2302,12 @@ var _extends$12 = Object.assign || function (target) { for (var i = 1; i < argum
  */
 function saturate(amount, color) {
   var hslColor = parseToHsl(color);
-  return toColorString(_extends$12({}, hslColor, {
+  return toColorString(_extends({}, hslColor, {
     saturation: guard(0, 1, hslColor.saturation + amount)
   }));
 }
 
 var curriedSaturate = /*#__PURE__*/curry(saturate);
-module.exports = exports['default'];
-
-var _extends$13 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 //      
 
@@ -2381,15 +2335,12 @@ var _extends$13 = Object.assign || function (target) { for (var i = 1; i < argum
  * }
  */
 function setHue(hue, color) {
-  return toColorString(_extends$13({}, parseToHsl(color), {
+  return toColorString(_extends({}, parseToHsl(color), {
     hue: hue
   }));
 }
 
 var curriedSetHue = /*#__PURE__*/curry(setHue);
-module.exports = exports['default'];
-
-var _extends$14 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 //      
 
@@ -2417,15 +2368,12 @@ var _extends$14 = Object.assign || function (target) { for (var i = 1; i < argum
  * }
  */
 function setLightness(lightness, color) {
-  return toColorString(_extends$14({}, parseToHsl(color), {
+  return toColorString(_extends({}, parseToHsl(color), {
     lightness: lightness
   }));
 }
 
 var curriedSetLightness = /*#__PURE__*/curry(setLightness);
-module.exports = exports['default'];
-
-var _extends$15 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 //      
 
@@ -2453,13 +2401,12 @@ var _extends$15 = Object.assign || function (target) { for (var i = 1; i < argum
  * }
  */
 function setSaturation(saturation, color) {
-  return toColorString(_extends$15({}, parseToHsl(color), {
+  return toColorString(_extends({}, parseToHsl(color), {
     saturation: saturation
   }));
 }
 
 var curriedSetSaturation = /*#__PURE__*/curry(setSaturation);
-module.exports = exports['default'];
 
 //      
 
@@ -2497,7 +2444,6 @@ function shade(percentage, color) {
 }
 
 var curriedShade = /*#__PURE__*/curry(shade);
-module.exports = exports['default'];
 
 //      
 
@@ -2535,9 +2481,6 @@ function tint(percentage, color) {
 }
 
 var curriedTint = /*#__PURE__*/curry(tint);
-module.exports = exports['default'];
-
-var _extends$16 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 //      
 /**
@@ -2570,14 +2513,13 @@ var _extends$16 = Object.assign || function (target) { for (var i = 1; i < argum
 function transparentize(amount, color) {
   var parsedColor = parseToRgb(color);
   var alpha = typeof parsedColor.alpha === 'number' ? parsedColor.alpha : 1;
-  var colorWithAlpha = _extends$16({}, parsedColor, {
+  var colorWithAlpha = _extends({}, parsedColor, {
     alpha: guard(0, 1, (alpha * 100 - amount * 100) / 100)
   });
   return rgba(colorWithAlpha);
 }
 
 var curriedTransparentize = /*#__PURE__*/curry(transparentize);
-module.exports = exports['default'];
 
 //      
 
@@ -2645,8 +2587,6 @@ function animation() {
   };
 }
 
-module.exports = exports['default'];
-
 //      
 
 /**
@@ -2679,8 +2619,6 @@ function backgroundImages() {
   };
 }
 
-module.exports = exports['default'];
-
 //      
 
 /**
@@ -2711,8 +2649,6 @@ function backgrounds() {
     background: properties.join(', ')
   };
 }
-
-module.exports = exports['default'];
 
 //      
 /**
@@ -2745,8 +2681,6 @@ function borderColor() {
 
   return directionalProperty.apply(undefined, ['borderColor'].concat(values));
 }
-
-module.exports = exports['default'];
 
 //      
 /**
@@ -2790,8 +2724,6 @@ function borderRadius(side, radius) {
   throw new Error('borderRadius expects one of "top", "bottom", "left" or "right" as the first argument.');
 }
 
-module.exports = exports['default'];
-
 //      
 /**
  * Shorthand that accepts up to four values, including null to skip a value, and maps them to their respective directions.
@@ -2824,8 +2756,6 @@ function borderStyle() {
   return directionalProperty.apply(undefined, ['borderStyle'].concat(values));
 }
 
-module.exports = exports['default'];
-
 //      
 /**
  * Shorthand that accepts up to four values, including null to skip a value, and maps them to their respective directions.
@@ -2857,8 +2787,6 @@ function borderWidth() {
   return directionalProperty.apply(undefined, ['borderWidth'].concat(values));
 }
 
-module.exports = exports['default'];
-
 //      
 
 
@@ -2884,8 +2812,6 @@ function statefulSelectors(states, template, stateMap) {
   selectors = selectors.join(',');
   return selectors;
 }
-
-module.exports = exports['default'];
 
 //      
 var stateMap = [undefined, null, 'active', 'focus', 'hover'];
@@ -2929,8 +2855,6 @@ function buttons() {
   return statefulSelectors(states, template, stateMap);
 }
 
-module.exports = exports['default'];
-
 //      
 /**
  * Shorthand that accepts up to four values, including null to skip a value, and maps them to their respective directions.
@@ -2963,8 +2887,6 @@ function margin() {
   return directionalProperty.apply(undefined, ['margin'].concat(values));
 }
 
-module.exports = exports['default'];
-
 //      
 /**
  * Shorthand that accepts up to four values, including null to skip a value, and maps them to their respective directions.
@@ -2996,10 +2918,6 @@ function padding() {
 
   return directionalProperty.apply(undefined, ['padding'].concat(values));
 }
-
-module.exports = exports['default'];
-
-var _extends$17 = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 //      
 var positionMap$1 = ['absolute', 'fixed', 'relative', 'static', 'sticky'];
@@ -3053,7 +2971,7 @@ function position(positionKeyword) {
   }
 
   if (positionMap$1.indexOf(positionKeyword) >= 0) {
-    return _extends$17({
+    return _extends({
       position: positionKeyword
     }, directionalProperty.apply(undefined, [''].concat(values)));
   } else {
@@ -3061,8 +2979,6 @@ function position(positionKeyword) {
     return directionalProperty.apply(undefined, ['', firstValue].concat(values));
   }
 }
-
-module.exports = exports['default'];
 
 //      
 
@@ -3095,8 +3011,6 @@ function size(height) {
     width: width
   };
 }
-
-module.exports = exports["default"];
 
 //      
 var stateMap$1 = [undefined, null, 'active', 'focus', 'hover'];
@@ -3152,8 +3066,6 @@ function textInputs() {
   return statefulSelectors(states, template$1, stateMap$1);
 }
 
-module.exports = exports['default'];
-
 //      
 
 /**
@@ -3185,8 +3097,6 @@ function transitions() {
     transition: properties.join(', ')
   };
 }
-
-module.exports = exports['default'];
 
 //      
 // Helpers
@@ -3248,6 +3158,7 @@ exports.textInputs = textInputs;
 exports.timingFunctions = timingFunctions;
 exports.tint = curriedTint;
 exports.toColorString = toColorString;
+exports.tracking = tracking;
 exports.transitions = transitions;
 exports.transparentize = curriedTransparentize;
 exports.triangle = triangle;

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -665,6 +665,16 @@
             
               
               <li><a
+                href='#tracking'
+                class="">
+                tracking
+                
+              </a>
+              
+              </li>
+            
+              
+              <li><a
                 href='#types'
                 class="h5 bold black caps">
                 Types
@@ -875,7 +885,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/clearFix.js#L26-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/mixins/clearFix.js#L26-L35'>
       <span>src/mixins/clearFix.js</span>
       </a>
     
@@ -966,7 +976,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/ellipsis.js#L29-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/mixins/ellipsis.js#L29-L38'>
       <span>src/mixins/ellipsis.js</span>
       </a>
     
@@ -1060,7 +1070,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/fontFace.js#L70-L107'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/mixins/fontFace.js#L70-L107'>
       <span>src/mixins/fontFace.js</span>
       </a>
     
@@ -1227,7 +1237,7 @@ injectGlobal`${
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/hiDPI.js#L32-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/mixins/hiDPI.js#L32-L40'>
       <span>src/mixins/hiDPI.js</span>
       </a>
     
@@ -1324,7 +1334,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/hideText.js#L29-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/mixins/hideText.js#L29-L35'>
       <span>src/mixins/hideText.js</span>
       </a>
     
@@ -1404,7 +1414,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/hideVisually.js#L34-L47'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/mixins/hideVisually.js#L34-L47'>
       <span>src/mixins/hideVisually.js</span>
       </a>
     
@@ -1489,7 +1499,7 @@ from <a href="https://github.com/h5bp/html5-boilerplate/blob/9a176f57af1cfe8ec70
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/normalize.js#L288-L291'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/mixins/normalize.js#L288-L291'>
       <span>src/mixins/normalize.js</span>
       </a>
     
@@ -1577,7 +1587,7 @@ html {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/placeholder.js#L35-L50'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/mixins/placeholder.js#L35-L50'>
       <span>src/mixins/placeholder.js</span>
       </a>
     
@@ -1685,7 +1695,7 @@ const div = styled.input`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/radialGradient.js#L78-L92'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/mixins/radialGradient.js#L78-L92'>
       <span>src/mixins/radialGradient.js</span>
       </a>
     
@@ -1830,7 +1840,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/retinaImage.js#L33-L56'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/mixins/retinaImage.js#L33-L56'>
       <span>src/mixins/retinaImage.js</span>
       </a>
     
@@ -1960,7 +1970,7 @@ a _2x.png filename suffix by default.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/selection.js#L31-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/mixins/selection.js#L31-L40'>
       <span>src/mixins/selection.js</span>
       </a>
     
@@ -2064,7 +2074,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/timingFunctions.js#L82-L84'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/mixins/timingFunctions.js#L82-L84'>
       <span>src/mixins/timingFunctions.js</span>
       </a>
     
@@ -2152,7 +2162,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/wordWrap.js#L26-L33'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/mixins/wordWrap.js#L26-L33'>
       <span>src/mixins/wordWrap.js</span>
       </a>
     
@@ -2255,7 +2265,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/adjustHue.js#L31-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/color/adjustHue.js#L31-L37'>
       <span>src/color/adjustHue.js</span>
       </a>
     
@@ -2355,7 +2365,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/complement.js#L28-L34'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/color/complement.js#L28-L34'>
       <span>src/color/complement.js</span>
       </a>
     
@@ -2445,7 +2455,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/darken.js#L31-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/color/darken.js#L31-L37'>
       <span>src/color/darken.js</span>
       </a>
     
@@ -2544,7 +2554,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/desaturate.js#L32-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/color/desaturate.js#L32-L38'>
       <span>src/color/desaturate.js</span>
       </a>
     
@@ -2644,7 +2654,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/getLuminance.js#L30-L39'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/color/getLuminance.js#L30-L39'>
       <span>src/color/getLuminance.js</span>
       </a>
     
@@ -2738,7 +2748,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/grayscale.js#L28-L33'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/color/grayscale.js#L28-L33'>
       <span>src/color/grayscale.js</span>
       </a>
     
@@ -2828,7 +2838,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/hsl.js#L29-L49'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/color/hsl.js#L29-L49'>
       <span>src/color/hsl.js</span>
       </a>
     
@@ -2935,7 +2945,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/hsla.js#L33-L62'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/color/hsla.js#L33-L62'>
       <span>src/color/hsla.js</span>
       </a>
     
@@ -3053,7 +3063,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/invert.js#L29-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/color/invert.js#L29-L38'>
       <span>src/color/invert.js</span>
       </a>
     
@@ -3144,7 +3154,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/lighten.js#L31-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/color/lighten.js#L31-L37'>
       <span>src/color/lighten.js</span>
       </a>
     
@@ -3243,7 +3253,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/mix.js#L38-L68'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/color/mix.js#L38-L68'>
       <span>src/color/mix.js</span>
       </a>
     
@@ -3358,7 +3368,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/opacify.js#L34-L43'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/color/opacify.js#L34-L43'>
       <span>src/color/opacify.js</span>
       </a>
     
@@ -3460,7 +3470,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/parseToHsl.js#L18-L22'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/color/parseToHsl.js#L18-L22'>
       <span>src/color/parseToHsl.js</span>
       </a>
     
@@ -3539,7 +3549,7 @@ const color2 = 'hsla(<span class="hljs-number">210</span>, <span class="hljs-num
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/parseToRgb.js#L24-L88'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/color/parseToRgb.js#L24-L88'>
       <span>src/color/parseToRgb.js</span>
       </a>
     
@@ -3618,7 +3628,7 @@ const color2 = 'hsla(<span class="hljs-number">210</span>, <span class="hljs-num
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/readableColor.js#L33-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/color/readableColor.js#L33-L35'>
       <span>src/color/readableColor.js</span>
       </a>
     
@@ -3713,7 +3723,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/rgb.js#L30-L46'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/color/rgb.js#L30-L46'>
       <span>src/color/rgb.js</span>
       </a>
     
@@ -3820,7 +3830,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/rgba.js#L41-L75'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/color/rgba.js#L41-L75'>
       <span>src/color/rgba.js</span>
       </a>
     
@@ -3945,7 +3955,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/saturate.js#L33-L39'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/color/saturate.js#L33-L39'>
       <span>src/color/saturate.js</span>
       </a>
     
@@ -4046,7 +4056,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/setHue.js#L30-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/color/setHue.js#L30-L35'>
       <span>src/color/setHue.js</span>
       </a>
     
@@ -4145,7 +4155,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/setLightness.js#L30-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/color/setLightness.js#L30-L35'>
       <span>src/color/setLightness.js</span>
       </a>
     
@@ -4244,7 +4254,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/setSaturation.js#L30-L35'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/color/setSaturation.js#L30-L35'>
       <span>src/color/setSaturation.js</span>
       </a>
     
@@ -4343,7 +4353,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/shade.js#L29-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/color/shade.js#L29-L37'>
       <span>src/color/shade.js</span>
       </a>
     
@@ -4441,7 +4451,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/tint.js#L29-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/color/tint.js#L29-L37'>
       <span>src/color/tint.js</span>
       </a>
     
@@ -4539,7 +4549,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/transparentize.js#L34-L43'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/color/transparentize.js#L34-L43'>
       <span>src/color/transparentize.js</span>
       </a>
     
@@ -4653,7 +4663,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/animation.js#L42-L67'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/shorthands/animation.js#L42-L67'>
       <span>src/shorthands/animation.js</span>
       </a>
     
@@ -4759,7 +4769,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/backgroundImages.js#L23-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/shorthands/backgroundImages.js#L23-L27'>
       <span>src/shorthands/backgroundImages.js</span>
       </a>
     
@@ -4847,7 +4857,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/backgrounds.js#L22-L26'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/shorthands/backgrounds.js#L22-L26'>
       <span>src/shorthands/backgrounds.js</span>
       </a>
     
@@ -4935,7 +4945,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/borderColor.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/shorthands/borderColor.js#L27-L29'>
       <span>src/shorthands/borderColor.js</span>
       </a>
     
@@ -5026,7 +5036,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/borderRadius.js#L25-L45'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/shorthands/borderRadius.js#L25-L45'>
       <span>src/shorthands/borderRadius.js</span>
       </a>
     
@@ -5123,7 +5133,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/borderStyle.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/shorthands/borderStyle.js#L27-L29'>
       <span>src/shorthands/borderStyle.js</span>
       </a>
     
@@ -5214,7 +5224,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/borderWidth.js#L26-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/shorthands/borderWidth.js#L26-L28'>
       <span>src/shorthands/borderWidth.js</span>
       </a>
     
@@ -5305,7 +5315,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/buttons.js#L42-L44'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/shorthands/buttons.js#L42-L44'>
       <span>src/shorthands/buttons.js</span>
       </a>
     
@@ -5400,7 +5410,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/margin.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/shorthands/margin.js#L27-L29'>
       <span>src/shorthands/margin.js</span>
       </a>
     
@@ -5491,7 +5501,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/padding.js#L27-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/shorthands/padding.js#L27-L29'>
       <span>src/shorthands/padding.js</span>
       </a>
     
@@ -5582,7 +5592,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/position.js#L49-L62'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/shorthands/position.js#L49-L62'>
       <span>src/shorthands/position.js</span>
       </a>
     
@@ -5701,7 +5711,7 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/size.js#L24-L32'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/shorthands/size.js#L24-L32'>
       <span>src/shorthands/size.js</span>
       </a>
     
@@ -5799,7 +5809,7 @@ const <span class="hljs-keyword">div</span> = styled.<span class="hljs-keyword">
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/textInputs.js#L66-L68'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/shorthands/textInputs.js#L66-L68'>
       <span>src/shorthands/textInputs.js</span>
       </a>
     
@@ -5906,7 +5916,7 @@ const div = styled.div`
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/transitions.js#L23-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/shorthands/transitions.js#L23-L27'>
       <span>src/shorthands/transitions.js</span>
       </a>
     
@@ -6006,7 +6016,7 @@ div {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/helpers/directionalProperty.js#L53-L61'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/helpers/directionalProperty.js#L53-L61'>
       <span>src/helpers/directionalProperty.js</span>
       </a>
     
@@ -6105,7 +6115,7 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/helpers/em.js#L28-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/helpers/em.js#L28-L28'>
       <span>src/helpers/em.js</span>
       </a>
     
@@ -6203,7 +6213,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/helpers/modularScale.js#L67-L87'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/helpers/modularScale.js#L67-L87'>
       <span>src/helpers/modularScale.js</span>
       </a>
     
@@ -6311,7 +6321,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/helpers/rem.js#L29-L32'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/helpers/rem.js#L29-L32'>
       <span>src/helpers/rem.js</span>
       </a>
     
@@ -6409,7 +6419,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/helpers/stripUnit.js#L24-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/helpers/stripUnit.js#L24-L28'>
       <span>src/helpers/stripUnit.js</span>
       </a>
     
@@ -6487,6 +6497,91 @@ element {
         
       
         
+          <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='tracking'>
+      tracking
+    </h3>
+    
+    
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/helpers/tracking.js#L28-L28'>
+      <span>src/helpers/tracking.js</span>
+      </a>
+    
+  </div>
+  
+
+  <p>Convert tracking to letter-space friendly ems. Useful for converting
+Adobe Illustrator, Indesign and Photoshop tracking values, in which
+tracking is measured in 1/1000 em.</p>
+
+
+  <div class='pre p1 fill-light mt0'>tracking(target: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</div>
+  
+  
+
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>target</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
+	    
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
+<span class="hljs-keyword">const</span> styles = {
+  <span class="hljs-string">'letterSpacing'</span>: tracking(<span class="hljs-number">50</span>)
+}
+
+<span class="hljs-comment">// styled-components usage</span>
+<span class="hljs-keyword">const</span> div = styled.div<span class="hljs-string">`
+  letterSpacing: <span class="hljs-subst">${tracking(<span class="hljs-number">50</span>)}</span>
+`</span>
+
+<span class="hljs-comment">// CSS in JS Output</span>
+
+element {
+  <span class="hljs-string">'letterSpacing'</span>: <span class="hljs-string">'0.05em'</span>
+}</pre>
+    
+  
+
+  
+
+  
+
+  
+</section>
+
+        
+      
+        
           <div class='keyline-top-not py2'><section class='section py2 clearfix'>
 
   <h2 class="section__heading" id='types' class='mt0'>
@@ -6509,7 +6604,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/shorthands/animation.js#L4-L4'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/shorthands/animation.js#L4-L4'>
       <span>src/shorthands/animation.js</span>
       </a>
     
@@ -6563,7 +6658,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/fontFace.js#L4-L14'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/mixins/fontFace.js#L4-L14'>
       <span>src/mixins/fontFace.js</span>
       </a>
     
@@ -6676,7 +6771,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/types/color.js#L11-L15'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/types/color.js#L11-L15'>
       <span>src/types/color.js</span>
       </a>
     
@@ -6753,7 +6848,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/types/color.js#L23-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/types/color.js#L23-L28'>
       <span>src/types/color.js</span>
       </a>
     
@@ -6836,7 +6931,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/types/interactionState.js#L9-L14'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/types/interactionState.js#L9-L14'>
       <span>src/types/interactionState.js</span>
       </a>
     
@@ -6890,7 +6985,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/triangle.js#L4-L4'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/mixins/triangle.js#L4-L4'>
       <span>src/mixins/triangle.js</span>
       </a>
     
@@ -6944,7 +7039,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/radialGradient.js#L4-L10'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/mixins/radialGradient.js#L4-L10'>
       <span>src/mixins/radialGradient.js</span>
       </a>
     
@@ -7033,7 +7128,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/types/color.js#L47-L52'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/types/color.js#L47-L52'>
       <span>src/types/color.js</span>
       </a>
     
@@ -7116,7 +7211,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/types/color.js#L35-L39'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/types/color.js#L35-L39'>
       <span>src/types/color.js</span>
       </a>
     
@@ -7193,7 +7288,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/color/toColorString.js#L65-L73'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/color/toColorString.js#L65-L73'>
       <span>src/color/toColorString.js</span>
       </a>
     
@@ -7291,7 +7386,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/helpers/modularScale.js#L5-L23'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/helpers/modularScale.js#L5-L23'>
       <span>src/helpers/modularScale.js</span>
       </a>
     
@@ -7340,7 +7435,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/timingFunctions.js#L4-L31'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/mixins/timingFunctions.js#L4-L31'>
       <span>src/mixins/timingFunctions.js</span>
       </a>
     
@@ -7389,7 +7484,7 @@ element {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/mixins/triangle.js#L35-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/mixins/triangle.js#L35-L40'>
       <span>src/mixins/triangle.js</span>
       </a>
     
@@ -7466,7 +7561,7 @@ div:</span> {
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/e5057200814b3e2c569871d6f39db6be3537dd50/src/types/modularScaleRatio.js#L9-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/styled-components/polished/blob/ee912ff48c87af34af51409ba19d0f15c1ced0e6/src/types/modularScaleRatio.js#L9-L27'>
       <span>src/types/modularScaleRatio.js</span>
       </a>
     

--- a/src/helpers/test/__snapshots__/tracking.test.js.snap
+++ b/src/helpers/test/__snapshots__/tracking.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`tracking should convert a tracking target to em 1`] = `
+Object {
+  "letterSpacing": "0.05em",
+}
+`;

--- a/src/helpers/test/tracking.test.js
+++ b/src/helpers/test/tracking.test.js
@@ -1,0 +1,8 @@
+// @flow
+import tracking from '../tracking'
+
+describe('tracking', () => {
+  it('should convert a tracking target to em', () => {
+    expect({ letterSpacing: tracking(50) }).toMatchSnapshot()
+  })
+})

--- a/src/helpers/tracking.js
+++ b/src/helpers/tracking.js
@@ -1,0 +1,33 @@
+// @flow
+
+/**
+ * Convert tracking to letter-space friendly ems. Useful for converting
+ * Adobe Illustrator, Indesign and Photoshop tracking values, in which
+ * tracking is measured in 1/1000 em.
+ * @name tracking
+ * @function
+ * @param {number} target
+ * @example
+ * // Styles as object usage
+ * const styles = {
+ *   'letterSpacing': tracking(50)
+ * }
+ *
+ * // styled-components usage
+ * const div = styled.div`
+ *   letterSpacing: ${tracking(50)}
+ * `
+ *
+ * // CSS in JS Output
+ *
+ * element {
+ *   'letterSpacing': '0.05em'
+ * }
+ */
+
+const TRACKING_DIVISOR = 1000
+
+const tracking: (target: number) => string = target =>
+  `${target / TRACKING_DIVISOR}em`
+
+export default tracking

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import em from './helpers/em'
 import modularScale from './helpers/modularScale'
 import rem from './helpers/rem'
 import stripUnit from './helpers/stripUnit'
+import tracking from './helpers/tracking'
 
 // Mixins
 import clearFix from './mixins/clearFix'
@@ -120,6 +121,7 @@ export {
   timingFunctions,
   tint,
   toColorString,
+  tracking,
   transitions,
   transparentize,
   triangle,

--- a/typescript-test.ts
+++ b/typescript-test.ts
@@ -149,3 +149,4 @@ modularScale = polished.modularScale(2, 2, 5);
 modularScale = polished.modularScale(2, 2, "minorSecond");
 
 const stripUnit: number | string = polished.stripUnit("100px");
+const tracking: string = polished.tracking(50);


### PR DESCRIPTION
👋 In the event this is helpful!

Helper to convert tracking to letter-space friendly ems. 

Useful for converting Adobe Illustrator, Indesign and Photoshop tracking values, in which tracking is measured in 1/1000 em.
