### PR TITLE
 feat(color): Add support for 8 CSS hexcolor values (#RRGGBBAA)

### DIFF
--- a/src/color/parseToRgb.js
+++ b/src/color/parseToRgb.js
@@ -35,8 +35,9 @@ function parseToRgb(color: string): RgbColor | RgbaColor {
     }
   }
   if (normalizedColor.match(hexRgbaRegex)) {
-    const alpha =
+    const alpha = parseFloat((
       parseInt(`${normalizedColor[7]}${normalizedColor[8]}`, 16) / 255
+    ).toFixed(2))
     return {
       red: parseInt(`${normalizedColor[1]}${normalizedColor[2]}`, 16),
       green: parseInt(`${normalizedColor[3]}${normalizedColor[4]}`, 16),

--- a/src/color/test/__snapshots__/adjustHue.test.js.snap
+++ b/src/color/test/__snapshots__/adjustHue.test.js.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`adjustHue should adjustHue of a 8-digit hex color 1`] = `"rgba(169,205,100,0.4980392156862745)"`;
-
 exports[`adjustHue should adjustHue of a color and not go beyond 360 1`] = `"#444f88"`;
 
 exports[`adjustHue should adjustHue of a color with opacity 1`] = `"rgba(136,100,205,0.7)"`;
@@ -9,5 +7,7 @@ exports[`adjustHue should adjustHue of a color with opacity 1`] = `"rgba(136,100
 exports[`adjustHue should adjustHue of a hex color 1`] = `"#a9cd64"`;
 
 exports[`adjustHue should adjustHue of a reduced hex color 1`] = `"#5b4488"`;
+
+exports[`adjustHue should adjustHue of an 8-digit hex color 1`] = `"rgba(169,205,100,0.4980392156862745)"`;
 
 exports[`adjustHue should adjustHue when passed a string for adjustment 1`] = `"#5b4488"`;

--- a/src/color/test/__snapshots__/adjustHue.test.js.snap
+++ b/src/color/test/__snapshots__/adjustHue.test.js.snap
@@ -8,6 +8,6 @@ exports[`adjustHue should adjustHue of a hex color 1`] = `"#a9cd64"`;
 
 exports[`adjustHue should adjustHue of a reduced hex color 1`] = `"#5b4488"`;
 
-exports[`adjustHue should adjustHue of an 8-digit hex color 1`] = `"rgba(169,205,100,0.5)"`;
+exports[`adjustHue should adjustHue of an 8-digit hex color 1`] = `"rgba(136,100,205,0.7)"`;
 
 exports[`adjustHue should adjustHue when passed a string for adjustment 1`] = `"#5b4488"`;

--- a/src/color/test/__snapshots__/adjustHue.test.js.snap
+++ b/src/color/test/__snapshots__/adjustHue.test.js.snap
@@ -8,6 +8,6 @@ exports[`adjustHue should adjustHue of a hex color 1`] = `"#a9cd64"`;
 
 exports[`adjustHue should adjustHue of a reduced hex color 1`] = `"#5b4488"`;
 
-exports[`adjustHue should adjustHue of an 8-digit hex color 1`] = `"rgba(169,205,100,0.4980392156862745)"`;
+exports[`adjustHue should adjustHue of an 8-digit hex color 1`] = `"rgba(169,205,100,0.5)"`;
 
 exports[`adjustHue should adjustHue when passed a string for adjustment 1`] = `"#5b4488"`;

--- a/src/color/test/__snapshots__/complement.test.js.snap
+++ b/src/color/test/__snapshots__/complement.test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`complement should return the complement of a 8-digit hex color 1`] = `"rgba(101,100,205,0.4980392156862745)"`;
-
 exports[`complement should return the complement of a color with opacity 1`] = `"rgba(204,205,100,0.7)"`;
 
 exports[`complement should return the complement of a hex color 1`] = `"#6564cd"`;
 
 exports[`complement should return the complement of a reduced hex color 1`] = `"#884"`;
+
+exports[`complement should return the complement of an 8-digit hex color 1`] = `"rgba(101,100,205,0.4980392156862745)"`;

--- a/src/color/test/__snapshots__/complement.test.js.snap
+++ b/src/color/test/__snapshots__/complement.test.js.snap
@@ -6,4 +6,4 @@ exports[`complement should return the complement of a hex color 1`] = `"#6564cd"
 
 exports[`complement should return the complement of a reduced hex color 1`] = `"#884"`;
 
-exports[`complement should return the complement of an 8-digit hex color 1`] = `"rgba(101,100,205,0.5)"`;
+exports[`complement should return the complement of an 8-digit hex color 1`] = `"rgba(204,205,100,0.7)"`;

--- a/src/color/test/__snapshots__/complement.test.js.snap
+++ b/src/color/test/__snapshots__/complement.test.js.snap
@@ -6,4 +6,4 @@ exports[`complement should return the complement of a hex color 1`] = `"#6564cd"
 
 exports[`complement should return the complement of a reduced hex color 1`] = `"#884"`;
 
-exports[`complement should return the complement of an 8-digit hex color 1`] = `"rgba(101,100,205,0.4980392156862745)"`;
+exports[`complement should return the complement of an 8-digit hex color 1`] = `"rgba(101,100,205,0.5)"`;

--- a/src/color/test/__snapshots__/darken.test.js.snap
+++ b/src/color/test/__snapshots__/darken.test.js.snap
@@ -9,3 +9,5 @@ exports[`darken should darken a color by when passed a string for amount 1`] = `
 exports[`darken should darken a color with a value of 255 and opacity by 10% 1`] = `"rgba(255,89,89,0.7)"`;
 
 exports[`darken should darken a color with opacity by 10% 1`] = `"rgba(208,101,101,0.7)"`;
+
+exports[`darken should darken an 8-digit hex color by 20% 1`] = `"rgba(17,17,17,0.8)"`;

--- a/src/color/test/__snapshots__/darken.test.js.snap
+++ b/src/color/test/__snapshots__/darken.test.js.snap
@@ -8,6 +8,6 @@ exports[`darken should darken a color by when passed a string for amount 1`] = `
 
 exports[`darken should darken a color with a value of 255 and opacity by 10% 1`] = `"rgba(255,89,89,0.7)"`;
 
-exports[`darken should darken a color with opacity by 10% 1`] = `"rgba(208,101,101,0.7)"`;
+exports[`darken should darken a color with opacity by 20% 1`] = `"rgba(51,50,153,0.7)"`;
 
-exports[`darken should darken an 8-digit hex color by 20% 1`] = `"rgba(17,17,17,0.8)"`;
+exports[`darken should darken an 8-digit hex color by 20% 1`] = `"rgba(51,50,153,0.7)"`;

--- a/src/color/test/__snapshots__/desaturate.test.js.snap
+++ b/src/color/test/__snapshots__/desaturate.test.js.snap
@@ -2,10 +2,10 @@
 
 exports[`desaturate should desaturate a color but not go below 0 1`] = `"rgba(25,25,25,0.7)"`;
 
-exports[`desaturate should desaturate a color with opacity by 20% 1`] = `"rgba(184,185,121,0.7)"`;
+exports[`desaturate should desaturate a color with opacity by 20% 1`] = `"rgba(121,121,185,0.7)"`;
 
 exports[`desaturate should desaturate a hex color by 20% 1`] = `"#b8b979"`;
 
 exports[`desaturate should desaturate a reduced hex color by 10% 1`] = `"#444"`;
 
-exports[`desaturate should desaturate an 8-digit hex color by 20% 1`] = `"rgba(184,185,121,0.5)"`;
+exports[`desaturate should desaturate an 8-digit hex color by 20% 1`] = `"rgba(121,121,185,0.7)"`;

--- a/src/color/test/__snapshots__/desaturate.test.js.snap
+++ b/src/color/test/__snapshots__/desaturate.test.js.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`desaturate should desaturate a 8-digit hex color by 20% 1`] = `"rgba(184,185,121,0.4980392156862745)"`;
-
 exports[`desaturate should desaturate a color but not go below 0 1`] = `"rgba(25,25,25,0.7)"`;
 
 exports[`desaturate should desaturate a color with opacity by 20% 1`] = `"rgba(184,185,121,0.7)"`;
@@ -9,3 +7,5 @@ exports[`desaturate should desaturate a color with opacity by 20% 1`] = `"rgba(1
 exports[`desaturate should desaturate a hex color by 20% 1`] = `"#b8b979"`;
 
 exports[`desaturate should desaturate a reduced hex color by 10% 1`] = `"#444"`;
+
+exports[`desaturate should desaturate an 8-digit hex color by 20% 1`] = `"rgba(184,185,121,0.4980392156862745)"`;

--- a/src/color/test/__snapshots__/desaturate.test.js.snap
+++ b/src/color/test/__snapshots__/desaturate.test.js.snap
@@ -8,4 +8,4 @@ exports[`desaturate should desaturate a hex color by 20% 1`] = `"#b8b979"`;
 
 exports[`desaturate should desaturate a reduced hex color by 10% 1`] = `"#444"`;
 
-exports[`desaturate should desaturate an 8-digit hex color by 20% 1`] = `"rgba(184,185,121,0.4980392156862745)"`;
+exports[`desaturate should desaturate an 8-digit hex color by 20% 1`] = `"rgba(184,185,121,0.5)"`;

--- a/src/color/test/__snapshots__/getLuminance.test.js.snap
+++ b/src/color/test/__snapshots__/getLuminance.test.js.snap
@@ -4,7 +4,7 @@ exports[`getLuminance should return the luminance of a hex color 1`] = `0.057805
 
 exports[`getLuminance should return the luminance of a named CSS color 1`] = `0.877971001998354`;
 
-exports[`getLuminance should return the luminance of an 8-digit hex color 1`] = `0.05780543019106723`;
+exports[`getLuminance should return the luminance of an 8-digit hex color 1`] = `0.16288822420427432`;
 
 exports[`getLuminance should return the luminance of an hls color 1`] = `0.2126`;
 
@@ -12,4 +12,4 @@ exports[`getLuminance should return the luminance of an hlsa color 1`] = `0.0773
 
 exports[`getLuminance should return the luminance of an rgb color 1`] = `0.5742011250098834`;
 
-exports[`getLuminance should return the luminance of an rgba color 1`] = `0.5742011250098834`;
+exports[`getLuminance should return the luminance of an rgba color 1`] = `0.16288822420427432`;

--- a/src/color/test/__snapshots__/getLuminance.test.js.snap
+++ b/src/color/test/__snapshots__/getLuminance.test.js.snap
@@ -4,6 +4,8 @@ exports[`getLuminance should return the luminance of a hex color 1`] = `0.057805
 
 exports[`getLuminance should return the luminance of a named CSS color 1`] = `0.877971001998354`;
 
+exports[`getLuminance should return the luminance of an 8-digit hex color 1`] = `0.05780543019106723`;
+
 exports[`getLuminance should return the luminance of an hls color 1`] = `0.2126`;
 
 exports[`getLuminance should return the luminance of an hlsa color 1`] = `0.07733591265855211`;

--- a/src/color/test/__snapshots__/grayscale.test.js.snap
+++ b/src/color/test/__snapshots__/grayscale.test.js.snap
@@ -6,4 +6,4 @@ exports[`grayscale should grayscale a hex color 1`] = `"#999"`;
 
 exports[`grayscale should grayscale a reduced hex color 1`] = `"#444"`;
 
-exports[`grayscale should grayscale an 8-digit hex color 1`] = `"rgba(153,153,153,0.4980392156862745)"`;
+exports[`grayscale should grayscale an 8-digit hex color 1`] = `"rgba(153,153,153,0.5)"`;

--- a/src/color/test/__snapshots__/grayscale.test.js.snap
+++ b/src/color/test/__snapshots__/grayscale.test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`grayscale should grayscale a 8-digit hex color 1`] = `"rgba(153,153,153,0.4980392156862745)"`;
-
 exports[`grayscale should grayscale a color with opacity 1`] = `"rgba(153,153,153,0.7)"`;
 
 exports[`grayscale should grayscale a hex color 1`] = `"#999"`;
 
 exports[`grayscale should grayscale a reduced hex color 1`] = `"#444"`;
+
+exports[`grayscale should grayscale an 8-digit hex color 1`] = `"rgba(153,153,153,0.4980392156862745)"`;

--- a/src/color/test/__snapshots__/grayscale.test.js.snap
+++ b/src/color/test/__snapshots__/grayscale.test.js.snap
@@ -6,4 +6,4 @@ exports[`grayscale should grayscale a hex color 1`] = `"#999"`;
 
 exports[`grayscale should grayscale a reduced hex color 1`] = `"#444"`;
 
-exports[`grayscale should grayscale an 8-digit hex color 1`] = `"rgba(153,153,153,0.5)"`;
+exports[`grayscale should grayscale an 8-digit hex color 1`] = `"rgba(153,153,153,0.7)"`;

--- a/src/color/test/__snapshots__/invert.test.js.snap
+++ b/src/color/test/__snapshots__/invert.test.js.snap
@@ -6,4 +6,4 @@ exports[`invert should invert a hex color 1`] = `"#33329b"`;
 
 exports[`invert should invert a reduced hex color 1`] = `"#bb7"`;
 
-exports[`invert should invert an 8-digit hex color 1`] = `"rgba(51,50,155,0.6549019607843137)"`;
+exports[`invert should invert an 8-digit hex color 1`] = `"rgba(51,50,155,0.65)"`;

--- a/src/color/test/__snapshots__/invert.test.js.snap
+++ b/src/color/test/__snapshots__/invert.test.js.snap
@@ -6,4 +6,4 @@ exports[`invert should invert a hex color 1`] = `"#33329b"`;
 
 exports[`invert should invert a reduced hex color 1`] = `"#bb7"`;
 
-exports[`invert should invert an 8-digit hex color 1`] = `"rgba(51,50,155,0.65)"`;
+exports[`invert should invert an 8-digit hex color 1`] = `"rgba(154,155,50,0.7)"`;

--- a/src/color/test/__snapshots__/invert.test.js.snap
+++ b/src/color/test/__snapshots__/invert.test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`invert should invert a 8-digit hex color 1`] = `"rgba(51,50,155,0.6549019607843137)"`;
-
 exports[`invert should invert a color with opacity 1`] = `"rgba(154,155,50,0.7)"`;
 
 exports[`invert should invert a hex color 1`] = `"#33329b"`;
 
 exports[`invert should invert a reduced hex color 1`] = `"#bb7"`;
+
+exports[`invert should invert an 8-digit hex color 1`] = `"rgba(51,50,155,0.6549019607843137)"`;

--- a/src/color/test/__snapshots__/lighten.test.js.snap
+++ b/src/color/test/__snapshots__/lighten.test.js.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lighten should lighten a 8-digit hex color by 20% 1`] = `"rgba(229,230,177,0.6549019607843137)"`;
-
 exports[`lighten should lighten a color but not go beyond 255 1`] = `"rgba(255,255,255,0.7)"`;
 
 exports[`lighten should lighten a color by 10% 1`] = `"#5e5e5e"`;
@@ -11,3 +9,5 @@ exports[`lighten should lighten a color when passed a string for amount 1`] = `"
 exports[`lighten should lighten a color with opacity by 20% 1`] = `"rgba(229,230,177,0.7)"`;
 
 exports[`lighten should lighten a hex color by 20% 1`] = `"#e5e6b1"`;
+
+exports[`lighten should lighten an 8-digit hex color by 20% 1`] = `"rgba(229,230,177,0.6549019607843137)"`;

--- a/src/color/test/__snapshots__/lighten.test.js.snap
+++ b/src/color/test/__snapshots__/lighten.test.js.snap
@@ -6,8 +6,8 @@ exports[`lighten should lighten a color by 10% 1`] = `"#5e5e5e"`;
 
 exports[`lighten should lighten a color when passed a string for amount 1`] = `"#5e5e5e"`;
 
-exports[`lighten should lighten a color with opacity by 20% 1`] = `"rgba(229,230,177,0.7)"`;
+exports[`lighten should lighten a color with opacity by 20% 1`] = `"rgba(178,177,230,0.7)"`;
 
 exports[`lighten should lighten a hex color by 20% 1`] = `"#e5e6b1"`;
 
-exports[`lighten should lighten an 8-digit hex color by 20% 1`] = `"rgba(229,230,177,0.65)"`;
+exports[`lighten should lighten an 8-digit hex color by 20% 1`] = `"rgba(178,177,230,0.7)"`;

--- a/src/color/test/__snapshots__/lighten.test.js.snap
+++ b/src/color/test/__snapshots__/lighten.test.js.snap
@@ -10,4 +10,4 @@ exports[`lighten should lighten a color with opacity by 20% 1`] = `"rgba(229,230
 
 exports[`lighten should lighten a hex color by 20% 1`] = `"#e5e6b1"`;
 
-exports[`lighten should lighten an 8-digit hex color by 20% 1`] = `"rgba(229,230,177,0.6549019607843137)"`;
+exports[`lighten should lighten an 8-digit hex color by 20% 1`] = `"rgba(229,230,177,0.65)"`;

--- a/src/color/test/__snapshots__/mix.test.js.snap
+++ b/src/color/test/__snapshots__/mix.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`mix should mix two colors 1`] = `"#7f007f"`;
 
-exports[`mix should mix two colors with an 8-digit hex color 1`] = `"rgba(63,0,191,0.7490196078431373)"`;
+exports[`mix should mix two colors with an 8-digit hex color 1`] = `"rgba(63,0,191,0.75)"`;
 
 exports[`mix should mix two colors with by a weight of 25% 1`] = `"#3f00bf"`;
 

--- a/src/color/test/__snapshots__/mix.test.js.snap
+++ b/src/color/test/__snapshots__/mix.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`mix should mix two colors 1`] = `"#7f007f"`;
 
-exports[`mix should mix two colors with 8-digit hex color 1`] = `"rgba(63,0,191,0.7490196078431373)"`;
+exports[`mix should mix two colors with an 8-digit hex color 1`] = `"rgba(63,0,191,0.7490196078431373)"`;
 
 exports[`mix should mix two colors with by a weight of 25% 1`] = `"#3f00bf"`;
 

--- a/src/color/test/__snapshots__/opacify.test.js.snap
+++ b/src/color/test/__snapshots__/opacify.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`opacify should increase the opacity of an 8-digit hex color by 0.1 and still be 1 1`] = `"rgba(68,68,68,0.9)"`;
+exports[`opacify should increase the opacity of an 8-digit hex color by 0.1 and still be 1 1`] = `"rgba(101,100,205,0.8)"`;
 
 exports[`opacify should increase the opacity of hex #fff by 0.1 and still be 1 1`] = `"#fff"`;
 
@@ -10,7 +10,7 @@ exports[`opacify should increase the opacity of hsla(0, 0%, 100%, .3) by 0.5 1`]
 
 exports[`opacify should increase the opacity of rgba(255, 0, 0, .5) by 0.5 1`] = `"#f00"`;
 
-exports[`opacify should increase the opacity of rgba(255, 0, 0, 0.5) by 0.2 1`] = `"rgba(255,0,0,0.7)"`;
+exports[`opacify should increase the opacity of rgba(255, 0, 0, 0.5) by 0.1 1`] = `"rgba(101,100,205,0.8)"`;
 
 exports[`opacify should increase the opacity when passed a string for amount 1`] = `"#fff"`;
 

--- a/src/color/test/__snapshots__/opacify.test.js.snap
+++ b/src/color/test/__snapshots__/opacify.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`opacify should increase the opacity of an 8-digit hex color by 0.1 and still be 1 1`] = `"rgba(68,68,68,0.9)"`;
+
 exports[`opacify should increase the opacity of hex #fff by 0.1 and still be 1 1`] = `"#fff"`;
 
 exports[`opacify should increase the opacity of hsl(0, 0%, 100%) by 0.2 and still be 1 1`] = `"#fff"`;

--- a/src/color/test/__snapshots__/parseToHsl.test.js.snap
+++ b/src/color/test/__snapshots__/parseToHsl.test.js.snap
@@ -1,14 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`parseToHsl should parse a 8-digit hex color representation 1`] = `
-Object {
-  "alpha": 0.6549019607843137,
-  "hue": 325.8510638297872,
-  "lightness": 0.6313725490196078,
-  "saturation": 1,
-}
-`;
-
 exports[`parseToHsl should parse a hex color representation 1`] = `
 Object {
   "hue": 325.8510638297872,
@@ -54,6 +45,15 @@ exports[`parseToHsl should parse a rgba color representation 1`] = `
 Object {
   "alpha": 0.6,
   "hue": 274.1489361702128,
+  "lightness": 0.6313725490196078,
+  "saturation": 1,
+}
+`;
+
+exports[`parseToHsl should parse an 8-digit hex color representation 1`] = `
+Object {
+  "alpha": 0.6549019607843137,
+  "hue": 325.8510638297872,
   "lightness": 0.6313725490196078,
   "saturation": 1,
 }

--- a/src/color/test/__snapshots__/parseToHsl.test.js.snap
+++ b/src/color/test/__snapshots__/parseToHsl.test.js.snap
@@ -52,7 +52,7 @@ Object {
 
 exports[`parseToHsl should parse an 8-digit hex color representation 1`] = `
 Object {
-  "alpha": 0.6549019607843137,
+  "alpha": 0.65,
   "hue": 325.8510638297872,
   "lightness": 0.6313725490196078,
   "saturation": 1,

--- a/src/color/test/__snapshots__/parseToRgb.test.js.snap
+++ b/src/color/test/__snapshots__/parseToRgb.test.js.snap
@@ -1,14 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`parseToRgb should parse a 8-digit hex color representation 1`] = `
-Object {
-  "alpha": 1,
-  "blue": 174,
-  "green": 67,
-  "red": 255,
-}
-`;
-
 exports[`parseToRgb should parse a hex color representation 1`] = `
 Object {
   "blue": 174,
@@ -90,5 +81,14 @@ Object {
   "blue": 255,
   "green": 67,
   "red": 174,
+}
+`;
+
+exports[`parseToRgb should parse an 8-digit hex color representation 1`] = `
+Object {
+  "alpha": 1,
+  "blue": 174,
+  "green": 67,
+  "red": 255,
 }
 `;

--- a/src/color/test/__snapshots__/readableColor.test.js.snap
+++ b/src/color/test/__snapshots__/readableColor.test.js.snap
@@ -18,6 +18,8 @@ exports[`readableColor should return black given white hex, #fff 1`] = `"#000"`;
 
 exports[`readableColor should return black given white, "white" 1`] = `"#000"`;
 
+exports[`readableColor should return black given white, #FFFFFFBF 1`] = `"#000"`;
+
 exports[`readableColor should return black given white, rgb(255,255,255) 1`] = `"#000"`;
 
 exports[`readableColor should return white given black, "black" 1`] = `"#fff"`;
@@ -25,8 +27,6 @@ exports[`readableColor should return white given black, "black" 1`] = `"#fff"`;
 exports[`readableColor should return white given black, #000 1`] = `"#fff"`;
 
 exports[`readableColor should return white given black, #0000001A 1`] = `"#fff"`;
-
-exports[`readableColor should return white given black, #000000BF 1`] = `"#fff"`;
 
 exports[`readableColor should return white given black, rgb(0,0,0) 1`] = `"#fff"`;
 

--- a/src/color/test/__snapshots__/saturate.test.js.snap
+++ b/src/color/test/__snapshots__/saturate.test.js.snap
@@ -6,8 +6,8 @@ exports[`saturate should saturate a color by 10% 1`] = `"#4b3d3d"`;
 
 exports[`saturate should saturate a color when passed a string for amount 1`] = `"#4b3d3d"`;
 
-exports[`saturate should saturate a color with opacity by 20% 1`] = `"rgba(224,226,80,0.7)"`;
+exports[`saturate should saturate a color with opacity by 20% 1`] = `"rgba(81,80,226,0.7)"`;
 
 exports[`saturate should saturate a hex color by 20% 1`] = `"#e0e250"`;
 
-exports[`saturate should saturate an 8-digit hex color by 20% 1`] = `"rgba(224,226,80,0.5)"`;
+exports[`saturate should saturate an 8-digit hex color by 20% 1`] = `"rgba(81,80,226,0.7)"`;

--- a/src/color/test/__snapshots__/saturate.test.js.snap
+++ b/src/color/test/__snapshots__/saturate.test.js.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`saturate should saturate a 8-digit hex color by 20% 1`] = `"rgba(224,226,80,0.4980392156862745)"`;
-
 exports[`saturate should saturate a color but not go beyond 255 1`] = `"rgba(255,200,200,0.7)"`;
 
 exports[`saturate should saturate a color by 10% 1`] = `"#4b3d3d"`;
@@ -11,3 +9,5 @@ exports[`saturate should saturate a color when passed a string for amount 1`] = 
 exports[`saturate should saturate a color with opacity by 20% 1`] = `"rgba(224,226,80,0.7)"`;
 
 exports[`saturate should saturate a hex color by 20% 1`] = `"#e0e250"`;
+
+exports[`saturate should saturate an 8-digit hex color by 20% 1`] = `"rgba(224,226,80,0.4980392156862745)"`;

--- a/src/color/test/__snapshots__/saturate.test.js.snap
+++ b/src/color/test/__snapshots__/saturate.test.js.snap
@@ -10,4 +10,4 @@ exports[`saturate should saturate a color with opacity by 20% 1`] = `"rgba(224,2
 
 exports[`saturate should saturate a hex color by 20% 1`] = `"#e0e250"`;
 
-exports[`saturate should saturate an 8-digit hex color by 20% 1`] = `"rgba(224,226,80,0.4980392156862745)"`;
+exports[`saturate should saturate an 8-digit hex color by 20% 1`] = `"rgba(224,226,80,0.5)"`;

--- a/src/color/test/__snapshots__/setHue.test.js.snap
+++ b/src/color/test/__snapshots__/setHue.test.js.snap
@@ -4,6 +4,6 @@ exports[`setHue should update the hue and return a color with opacity 1`] = `"rg
 
 exports[`setHue should update the hue and return a hex color 1`] = `"#cdae64"`;
 
-exports[`setHue should update the hue of an 8-digit hex color and return a hex color 1`] = `"rgba(205,174,100,0.4980392156862745)"`;
+exports[`setHue should update the hue of an 8-digit hex color and return a hex color 1`] = `"rgba(205,174,100,0.5)"`;
 
 exports[`setHue should update the hue when passed a string for hue 1`] = `"#cdae64"`;

--- a/src/color/test/__snapshots__/setHue.test.js.snap
+++ b/src/color/test/__snapshots__/setHue.test.js.snap
@@ -4,6 +4,6 @@ exports[`setHue should update the hue and return a color with opacity 1`] = `"rg
 
 exports[`setHue should update the hue and return a hex color 1`] = `"#cdae64"`;
 
-exports[`setHue should update the hue of an 8-digit hex color and return a hex color 1`] = `"rgba(205,174,100,0.5)"`;
+exports[`setHue should update the hue of an 8-digit hex color and return a hex color 1`] = `"rgba(107,100,205,0.7)"`;
 
 exports[`setHue should update the hue when passed a string for hue 1`] = `"#cdae64"`;

--- a/src/color/test/__snapshots__/setHue.test.js.snap
+++ b/src/color/test/__snapshots__/setHue.test.js.snap
@@ -4,4 +4,6 @@ exports[`setHue should update the hue and return a color with opacity 1`] = `"rg
 
 exports[`setHue should update the hue and return a hex color 1`] = `"#cdae64"`;
 
+exports[`setHue should update the hue of an 8-digit hex color and return a hex color 1`] = `"rgba(205,174,100,0.4980392156862745)"`;
+
 exports[`setHue should update the hue when passed a string for hue 1`] = `"#cdae64"`;

--- a/src/color/test/__snapshots__/setLightness.test.js.snap
+++ b/src/color/test/__snapshots__/setLightness.test.js.snap
@@ -4,6 +4,6 @@ exports[`setLightness should update the lightness and return a color with opacit
 
 exports[`setLightness should update the lightness and return a hex color 1`] = `"#4d4d19"`;
 
-exports[`setLightness should update the lightness of an 8-digit hex color and return a hex color 1`] = `"rgba(77,77,25,0.4980392156862745)"`;
+exports[`setLightness should update the lightness of an 8-digit hex color and return a hex color 1`] = `"rgba(77,77,25,0.5)"`;
 
 exports[`setLightness should update the lightness when passed a string 1`] = `"#4d4d19"`;

--- a/src/color/test/__snapshots__/setLightness.test.js.snap
+++ b/src/color/test/__snapshots__/setLightness.test.js.snap
@@ -4,4 +4,6 @@ exports[`setLightness should update the lightness and return a color with opacit
 
 exports[`setLightness should update the lightness and return a hex color 1`] = `"#4d4d19"`;
 
+exports[`setLightness should update the lightness of an 8-digit hex color and return a hex color 1`] = `"rgba(77,77,25,0.4980392156862745)"`;
+
 exports[`setLightness should update the lightness when passed a string 1`] = `"#4d4d19"`;

--- a/src/color/test/__snapshots__/setLightness.test.js.snap
+++ b/src/color/test/__snapshots__/setLightness.test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`setLightness should update the lightness and return a color with opacity 1`] = `"rgba(223,224,159,0.7)"`;
+exports[`setLightness should update the lightness and return a color with opacity 1`] = `"rgba(25,25,77,0.7)"`;
 
 exports[`setLightness should update the lightness and return a hex color 1`] = `"#4d4d19"`;
 
-exports[`setLightness should update the lightness of an 8-digit hex color and return a hex color 1`] = `"rgba(77,77,25,0.5)"`;
+exports[`setLightness should update the lightness of an 8-digit hex color and return a hex color 1`] = `"rgba(25,25,77,0.7)"`;
 
 exports[`setLightness should update the lightness when passed a string 1`] = `"#4d4d19"`;

--- a/src/color/test/__snapshots__/setSaturation.test.js.snap
+++ b/src/color/test/__snapshots__/setSaturation.test.js.snap
@@ -4,4 +4,6 @@ exports[`setSaturation should update the saturation and return a color with opac
 
 exports[`setSaturation should update the saturation and return a hex color 1`] = `"#adad84"`;
 
+exports[`setSaturation should update the saturation of an 8-digit hex color and return a hex color 1`] = `"rgba(173,173,132,0.4980392156862745)"`;
+
 exports[`setSaturation should update the saturation when passed a string 1`] = `"rgba(228,229,76,0.7)"`;

--- a/src/color/test/__snapshots__/setSaturation.test.js.snap
+++ b/src/color/test/__snapshots__/setSaturation.test.js.snap
@@ -4,6 +4,6 @@ exports[`setSaturation should update the saturation and return a color with opac
 
 exports[`setSaturation should update the saturation and return a hex color 1`] = `"#adad84"`;
 
-exports[`setSaturation should update the saturation of an 8-digit hex color and return a hex color 1`] = `"rgba(173,173,132,0.4980392156862745)"`;
+exports[`setSaturation should update the saturation of an 8-digit hex color and return a hex color 1`] = `"rgba(173,173,132,0.5)"`;
 
 exports[`setSaturation should update the saturation when passed a string 1`] = `"rgba(228,229,76,0.7)"`;

--- a/src/color/test/__snapshots__/setSaturation.test.js.snap
+++ b/src/color/test/__snapshots__/setSaturation.test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`setSaturation should update the saturation and return a color with opacity 1`] = `"rgba(228,229,76,0.7)"`;
+exports[`setSaturation should update the saturation and return a color with opacity 1`] = `"rgba(132,132,173,0.7)"`;
 
 exports[`setSaturation should update the saturation and return a hex color 1`] = `"#adad84"`;
 
-exports[`setSaturation should update the saturation of an 8-digit hex color and return a hex color 1`] = `"rgba(173,173,132,0.5)"`;
+exports[`setSaturation should update the saturation of an 8-digit hex color and return a hex color 1`] = `"rgba(132,132,173,0.7)"`;
 
 exports[`setSaturation should update the saturation when passed a string 1`] = `"rgba(228,229,76,0.7)"`;

--- a/src/color/test/__snapshots__/shade.test.js.snap
+++ b/src/color/test/__snapshots__/shade.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`shade should shade the provided 8-digit hex color with white by the given percentage 1`] = `"rgba(0,2,46,0.8500000000000001)"`;
+
 exports[`shade should shade the provided color when passed a string for amount 1`] = `"#00003f"`;
 
 exports[`shade should shade the provided color with white by the given percentage 1`] = `"#00003f"`;

--- a/src/color/test/__snapshots__/tint.test.js.snap
+++ b/src/color/test/__snapshots__/tint.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`test should tint the provided 8-digit hex color with white by the given percentage 1`] = `"rgba(208,211,255,0.8500000000000001)"`;
+
 exports[`test should tint the provided color when passed a string for amount 1`] = `"#bfbfff"`;
 
 exports[`test should tint the provided color with white by the given percentage 1`] = `"#bfbfff"`;

--- a/src/color/test/__snapshots__/transparentize.test.js.snap
+++ b/src/color/test/__snapshots__/transparentize.test.js.snap
@@ -4,7 +4,7 @@ exports[`transparentize should not increase the opacity beyond 1 1`] = `"#f00"`;
 
 exports[`transparentize should not reduce the opacity below 0 1`] = `"rgba(255,0,0,0)"`;
 
-exports[`transparentize should reduce the opacity of an 8-digit hex color by 0.1 1`] = `"rgba(204,205,100,0.39803921568627454)"`;
+exports[`transparentize should reduce the opacity of an 8-digit hex color by 0.1 1`] = `"rgba(204,205,100,0.4)"`;
 
 exports[`transparentize should reduce the opacity of hex #fff by 0.1 1`] = `"rgba(255,255,255,0.9)"`;
 

--- a/src/color/test/__snapshots__/transparentize.test.js.snap
+++ b/src/color/test/__snapshots__/transparentize.test.js.snap
@@ -4,7 +4,7 @@ exports[`transparentize should not increase the opacity beyond 1 1`] = `"#f00"`;
 
 exports[`transparentize should not reduce the opacity below 0 1`] = `"rgba(255,0,0,0)"`;
 
-exports[`transparentize should reduce the opacity of an 8-digit hex color by 0.1 1`] = `"rgba(204,205,100,0.4)"`;
+exports[`transparentize should reduce the opacity of an 8-digit hex color by 0.1 1`] = `"rgba(101,100,205,0.6)"`;
 
 exports[`transparentize should reduce the opacity of hex #fff by 0.1 1`] = `"rgba(255,255,255,0.9)"`;
 
@@ -18,6 +18,6 @@ exports[`transparentize should reduce the opacity of rgba(255, 0, 0, .5) by 0.3 
 
 exports[`transparentize should reduce the opacity of rgba(255, 0, 0, .5) by 0.5 1`] = `"rgba(255,0,0,0)"`;
 
-exports[`transparentize should reduce the opacity of rgba(255, 0, 0, 1) by 0.1 1`] = `"rgba(255,0,0,0.9)"`;
+exports[`transparentize should reduce the opacity of rgba(255, 0, 0, 1) by 0.1 1`] = `"rgba(101,100,205,0.6)"`;
 
 exports[`transparentize should reduce the opacity when passed a string for amount 1`] = `"rgba(255,255,255,0.9)"`;

--- a/src/color/test/__snapshots__/transparentize.test.js.snap
+++ b/src/color/test/__snapshots__/transparentize.test.js.snap
@@ -4,6 +4,8 @@ exports[`transparentize should not increase the opacity beyond 1 1`] = `"#f00"`;
 
 exports[`transparentize should not reduce the opacity below 0 1`] = `"rgba(255,0,0,0)"`;
 
+exports[`transparentize should reduce the opacity of an 8-digit hex color by 0.1 1`] = `"rgba(204,205,100,0.39803921568627454)"`;
+
 exports[`transparentize should reduce the opacity of hex #fff by 0.1 1`] = `"rgba(255,255,255,0.9)"`;
 
 exports[`transparentize should reduce the opacity of hsl(0, 0%, 100%) by 0.2 1`] = `"rgba(255,255,255,0.8)"`;

--- a/src/color/test/adjustHue.test.js
+++ b/src/color/test/adjustHue.test.js
@@ -10,7 +10,7 @@ describe('adjustHue', () => {
     expect(adjustHue(20, '#CCCD64')).toMatchSnapshot()
   })
 
-  it('should adjustHue of a 8-digit hex color', () => {
+  it('should adjustHue of an 8-digit hex color', () => {
     expect(adjustHue(20, '#CCCD647F')).toMatchSnapshot()
   })
 

--- a/src/color/test/adjustHue.test.js
+++ b/src/color/test/adjustHue.test.js
@@ -11,7 +11,7 @@ describe('adjustHue', () => {
   })
 
   it('should adjustHue of an 8-digit hex color', () => {
-    expect(adjustHue(20, '#CCCD647F')).toMatchSnapshot()
+    expect(adjustHue(20, '#6564CDB3')).toMatchSnapshot()
   })
 
   it('should adjustHue of a color with opacity', () => {

--- a/src/color/test/complement.test.js
+++ b/src/color/test/complement.test.js
@@ -10,7 +10,7 @@ describe('complement', () => {
     expect(complement('#CCCD64')).toMatchSnapshot()
   })
 
-  it('should return the complement of a 8-digit hex color', () => {
+  it('should return the complement of an 8-digit hex color', () => {
     expect(complement('#CCCD647F')).toMatchSnapshot()
   })
 

--- a/src/color/test/complement.test.js
+++ b/src/color/test/complement.test.js
@@ -11,7 +11,7 @@ describe('complement', () => {
   })
 
   it('should return the complement of an 8-digit hex color', () => {
-    expect(complement('#CCCD647F')).toMatchSnapshot()
+    expect(complement('#6564CDB3')).toMatchSnapshot()
   })
 
   it('should return the complement of a color with opacity', () => {

--- a/src/color/test/darken.test.js
+++ b/src/color/test/darken.test.js
@@ -6,6 +6,10 @@ describe('darken', () => {
     expect(darken(0.2, '#444')).toMatchSnapshot()
   })
 
+  it('should darken an 8-digit hex color by 20%', () => {
+    expect(darken(0.2, '#444444CC')).toMatchSnapshot()
+  })
+
   it('should darken a color with opacity by 10%', () => {
     expect(darken(0.1, 'rgba(220,140,140,0.7)')).toMatchSnapshot()
   })

--- a/src/color/test/darken.test.js
+++ b/src/color/test/darken.test.js
@@ -7,11 +7,11 @@ describe('darken', () => {
   })
 
   it('should darken an 8-digit hex color by 20%', () => {
-    expect(darken(0.2, '#444444CC')).toMatchSnapshot()
+    expect(darken(0.2, '#6564CDB3')).toMatchSnapshot()
   })
 
-  it('should darken a color with opacity by 10%', () => {
-    expect(darken(0.1, 'rgba(220,140,140,0.7)')).toMatchSnapshot()
+  it('should darken a color with opacity by 20%', () => {
+    expect(darken(0.2, 'rgba(101,100,205,0.7)')).toMatchSnapshot()
   })
 
   it('should darken a color with a value of 255 and opacity by 10%', () => {

--- a/src/color/test/desaturate.test.js
+++ b/src/color/test/desaturate.test.js
@@ -10,7 +10,7 @@ describe('desaturate', () => {
     expect(desaturate(0.2, '#CCCD64')).toMatchSnapshot()
   })
 
-  it('should desaturate a 8-digit hex color by 20%', () => {
+  it('should desaturate an 8-digit hex color by 20%', () => {
     expect(desaturate(0.2, '#CCCD647F')).toMatchSnapshot()
   })
 

--- a/src/color/test/desaturate.test.js
+++ b/src/color/test/desaturate.test.js
@@ -11,11 +11,11 @@ describe('desaturate', () => {
   })
 
   it('should desaturate an 8-digit hex color by 20%', () => {
-    expect(desaturate(0.2, '#CCCD647F')).toMatchSnapshot()
+    expect(desaturate(0.2, '#6564CDB3')).toMatchSnapshot()
   })
 
   it('should desaturate a color with opacity by 20%', () => {
-    expect(desaturate(0.2, 'rgba(204,205,100,0.7)')).toMatchSnapshot()
+    expect(desaturate(0.2, 'rgba(101,100,205,0.7)')).toMatchSnapshot()
   })
 
   it('should desaturate a color but not go below 0', () => {

--- a/src/color/test/getLuminance.test.js
+++ b/src/color/test/getLuminance.test.js
@@ -6,6 +6,10 @@ describe('getLuminance', () => {
     expect(getLuminance('#444')).toMatchSnapshot()
   })
 
+  it('should return the luminance of an 8-digit hex color', () => {
+    expect(getLuminance('#444444CC')).toMatchSnapshot()
+  })
+
   it('should return the luminance of an rgba color', () => {
     expect(getLuminance('rgba(204,205,100,0.7)')).toMatchSnapshot()
   })

--- a/src/color/test/getLuminance.test.js
+++ b/src/color/test/getLuminance.test.js
@@ -7,11 +7,11 @@ describe('getLuminance', () => {
   })
 
   it('should return the luminance of an 8-digit hex color', () => {
-    expect(getLuminance('#444444CC')).toMatchSnapshot()
+    expect(getLuminance('#6564CDB3')).toMatchSnapshot()
   })
 
   it('should return the luminance of an rgba color', () => {
-    expect(getLuminance('rgba(204,205,100,0.7)')).toMatchSnapshot()
+    expect(getLuminance('rgba(101,100,205,0.7)')).toMatchSnapshot()
   })
 
   it('should return the luminance of an rgb color', () => {

--- a/src/color/test/grayscale.test.js
+++ b/src/color/test/grayscale.test.js
@@ -11,10 +11,10 @@ describe('grayscale', () => {
   })
 
   it('should grayscale an 8-digit hex color', () => {
-    expect(grayscale('#CCCD647F')).toMatchSnapshot()
+    expect(grayscale('#6564CDB3')).toMatchSnapshot()
   })
 
   it('should grayscale a color with opacity', () => {
-    expect(grayscale('rgba(204,205,100,0.7)')).toMatchSnapshot()
+    expect(grayscale('rgba(101,100,205,0.7)')).toMatchSnapshot()
   })
 })

--- a/src/color/test/grayscale.test.js
+++ b/src/color/test/grayscale.test.js
@@ -10,7 +10,7 @@ describe('grayscale', () => {
     expect(grayscale('#CCCD64')).toMatchSnapshot()
   })
 
-  it('should grayscale a 8-digit hex color', () => {
+  it('should grayscale an 8-digit hex color', () => {
     expect(grayscale('#CCCD647F')).toMatchSnapshot()
   })
 

--- a/src/color/test/invert.test.js
+++ b/src/color/test/invert.test.js
@@ -11,7 +11,7 @@ describe('invert', () => {
   })
 
   it('should invert an 8-digit hex color', () => {
-    expect(invert('#CCCD64A7')).toMatchSnapshot()
+    expect(invert('#6564CDB3')).toMatchSnapshot()
   })
 
   it('should invert a color with opacity', () => {

--- a/src/color/test/invert.test.js
+++ b/src/color/test/invert.test.js
@@ -10,7 +10,7 @@ describe('invert', () => {
     expect(invert('#CCCD64')).toMatchSnapshot()
   })
 
-  it('should invert a 8-digit hex color', () => {
+  it('should invert an 8-digit hex color', () => {
     expect(invert('#CCCD64A7')).toMatchSnapshot()
   })
 

--- a/src/color/test/lighten.test.js
+++ b/src/color/test/lighten.test.js
@@ -10,7 +10,7 @@ describe('lighten', () => {
     expect(lighten(0.2, '#CCCD64')).toMatchSnapshot()
   })
 
-  it('should lighten a 8-digit hex color by 20%', () => {
+  it('should lighten an 8-digit hex color by 20%', () => {
     expect(lighten(0.2, '#CCCD64A7')).toMatchSnapshot()
   })
 

--- a/src/color/test/lighten.test.js
+++ b/src/color/test/lighten.test.js
@@ -11,11 +11,11 @@ describe('lighten', () => {
   })
 
   it('should lighten an 8-digit hex color by 20%', () => {
-    expect(lighten(0.2, '#CCCD64A7')).toMatchSnapshot()
+    expect(lighten(0.2, '#6564CDB3')).toMatchSnapshot()
   })
 
   it('should lighten a color with opacity by 20%', () => {
-    expect(lighten(0.2, 'rgba(204,205,100,0.7)')).toMatchSnapshot()
+    expect(lighten(0.2, 'rgba(101,100,205,0.7)')).toMatchSnapshot()
   })
 
   it('should lighten a color but not go beyond 255', () => {

--- a/src/color/test/mix.test.js
+++ b/src/color/test/mix.test.js
@@ -10,7 +10,7 @@ describe('mix', () => {
     expect(mix(0.25, '#f00', '#00f')).toMatchSnapshot()
   })
 
-  it('should mix two colors with 8-digit hex color', () => {
+  it('should mix two colors with an 8-digit hex color', () => {
     expect(mix(0.5, '#FF00007F', '#00f')).toMatchSnapshot()
   })
 

--- a/src/color/test/opacify.test.js
+++ b/src/color/test/opacify.test.js
@@ -6,6 +6,10 @@ describe('opacify', () => {
     expect(opacify(0.1, '#fff')).toMatchSnapshot()
   })
 
+  it('should increase the opacity of an 8-digit hex color by 0.1 and still be 1', () => {
+    expect(opacify(0.1, '#444444CC')).toMatchSnapshot()
+  })
+
   it('should increase the opacity of rgba(255, 0, 0, 0.5) by 0.2', () => {
     expect(opacify(0.2, 'rgba(255, 0, 0, 0.5)')).toMatchSnapshot()
   })

--- a/src/color/test/opacify.test.js
+++ b/src/color/test/opacify.test.js
@@ -7,11 +7,11 @@ describe('opacify', () => {
   })
 
   it('should increase the opacity of an 8-digit hex color by 0.1 and still be 1', () => {
-    expect(opacify(0.1, '#444444CC')).toMatchSnapshot()
+    expect(opacify(0.1, '#6564CDB3')).toMatchSnapshot()
   })
 
-  it('should increase the opacity of rgba(255, 0, 0, 0.5) by 0.2', () => {
-    expect(opacify(0.2, 'rgba(255, 0, 0, 0.5)')).toMatchSnapshot()
+  it('should increase the opacity of rgba(255, 0, 0, 0.5) by 0.1', () => {
+    expect(opacify(0.1, 'rgba(101, 100, 205, 0.7)')).toMatchSnapshot()
   })
 
   it('should increase the opacity of rgba(255, 0, 0, .5) by 0.5', () => {

--- a/src/color/test/parseToHsl.test.js
+++ b/src/color/test/parseToHsl.test.js
@@ -5,7 +5,7 @@ describe('parseToHsl', () => {
     expect(parseToHsl('#Ff43AE')).toMatchSnapshot()
   })
 
-  it('should parse a 8-digit hex color representation', () => {
+  it('should parse an 8-digit hex color representation', () => {
     expect(parseToHsl('#Ff43AEA7')).toMatchSnapshot()
   })
 

--- a/src/color/test/parseToRgb.test.js
+++ b/src/color/test/parseToRgb.test.js
@@ -5,7 +5,7 @@ describe('parseToRgb', () => {
     expect(parseToRgb('#Ff43AE')).toMatchSnapshot()
   })
 
-  it('should parse a 8-digit hex color representation', () => {
+  it('should parse an 8-digit hex color representation', () => {
     expect(parseToRgb('#Ff43AEFF')).toMatchSnapshot()
   })
 

--- a/src/color/test/readableColor.test.js
+++ b/src/color/test/readableColor.test.js
@@ -25,8 +25,8 @@ describe('readableColor', () => {
   it('should return white given black, #0000001A', () => {
     expect(readableColor('#0000001A')).toMatchSnapshot()
   })
-  it('should return white given black, #000000BF', () => {
-    expect(readableColor('#000000BF')).toMatchSnapshot()
+  it('should return black given white, #FFFFFFBF', () => {
+    expect(readableColor('#FFFFFFBF')).toMatchSnapshot()
   })
   it('should return black given white, rgb(255,255,255)', () => {
     expect(readableColor('rgb(255,255,255)')).toMatchSnapshot()

--- a/src/color/test/saturate.test.js
+++ b/src/color/test/saturate.test.js
@@ -11,11 +11,11 @@ describe('saturate', () => {
   })
 
   it('should saturate an 8-digit hex color by 20%', () => {
-    expect(saturate(0.2, '#CCCD647F')).toMatchSnapshot()
+    expect(saturate(0.2, '#6564CDB3')).toMatchSnapshot()
   })
 
   it('should saturate a color with opacity by 20%', () => {
-    expect(saturate(0.2, 'rgba(204,205,100,0.7)')).toMatchSnapshot()
+    expect(saturate(0.2, 'rgba(101,100,205,0.7)')).toMatchSnapshot()
   })
 
   it('should saturate a color but not go beyond 255', () => {

--- a/src/color/test/saturate.test.js
+++ b/src/color/test/saturate.test.js
@@ -10,7 +10,7 @@ describe('saturate', () => {
     expect(saturate(0.2, '#CCCD64')).toMatchSnapshot()
   })
 
-  it('should saturate a 8-digit hex color by 20%', () => {
+  it('should saturate an 8-digit hex color by 20%', () => {
     expect(saturate(0.2, '#CCCD647F')).toMatchSnapshot()
   })
 

--- a/src/color/test/setHue.test.js
+++ b/src/color/test/setHue.test.js
@@ -6,6 +6,10 @@ describe('setHue', () => {
     expect(setHue(42, '#CCCD64')).toMatchSnapshot()
   })
 
+  it('should update the hue of an 8-digit hex color and return a hex color', () => {
+    expect(setHue(42, '#CCCD647F')).toMatchSnapshot()
+  })
+
   it('should update the hue and return a color with opacity', () => {
     expect(setHue(244, 'rgba(204,205,100,0.7)')).toMatchSnapshot()
   })

--- a/src/color/test/setHue.test.js
+++ b/src/color/test/setHue.test.js
@@ -7,11 +7,11 @@ describe('setHue', () => {
   })
 
   it('should update the hue of an 8-digit hex color and return a hex color', () => {
-    expect(setHue(42, '#CCCD647F')).toMatchSnapshot()
+    expect(setHue(244, '#6564CDB3')).toMatchSnapshot()
   })
 
   it('should update the hue and return a color with opacity', () => {
-    expect(setHue(244, 'rgba(204,205,100,0.7)')).toMatchSnapshot()
+    expect(setHue(244, 'rgba(101,100,205,0.7)')).toMatchSnapshot()
   })
 
   it('should update the hue when passed a string for hue', () => {

--- a/src/color/test/setLightness.test.js
+++ b/src/color/test/setLightness.test.js
@@ -6,6 +6,10 @@ describe('setLightness', () => {
     expect(setLightness(0.2, '#CCCD64')).toMatchSnapshot()
   })
 
+  it('should update the lightness of an 8-digit hex color and return a hex color', () => {
+    expect(setLightness(0.2, '#CCCD647F')).toMatchSnapshot()
+  })
+
   it('should update the lightness and return a color with opacity', () => {
     expect(setLightness(0.75, 'rgba(204,205,100,0.7)')).toMatchSnapshot()
   })

--- a/src/color/test/setLightness.test.js
+++ b/src/color/test/setLightness.test.js
@@ -7,11 +7,11 @@ describe('setLightness', () => {
   })
 
   it('should update the lightness of an 8-digit hex color and return a hex color', () => {
-    expect(setLightness(0.2, '#CCCD647F')).toMatchSnapshot()
+    expect(setLightness(0.2, '#6564CDB3')).toMatchSnapshot()
   })
 
   it('should update the lightness and return a color with opacity', () => {
-    expect(setLightness(0.75, 'rgba(204,205,100,0.7)')).toMatchSnapshot()
+    expect(setLightness(0.2, 'rgba(101,100,205,0.7)')).toMatchSnapshot()
   })
 
   it('should update the lightness when passed a string', () => {

--- a/src/color/test/setSaturation.test.js
+++ b/src/color/test/setSaturation.test.js
@@ -7,11 +7,11 @@ describe('setSaturation', () => {
   })
 
   it('should update the saturation of an 8-digit hex color and return a hex color', () => {
-    expect(setSaturation(0.2, '#CCCD647F')).toMatchSnapshot()
+    expect(setSaturation(0.2, '#6564CDB3')).toMatchSnapshot()
   })
 
   it('should update the saturation and return a color with opacity', () => {
-    expect(setSaturation(0.75, 'rgba(204,205,100,0.7)')).toMatchSnapshot()
+    expect(setSaturation(0.2, 'rgba(101,100,205,0.7)')).toMatchSnapshot()
   })
 
   it('should update the saturation when passed a string', () => {

--- a/src/color/test/setSaturation.test.js
+++ b/src/color/test/setSaturation.test.js
@@ -6,6 +6,10 @@ describe('setSaturation', () => {
     expect(setSaturation(0.2, '#CCCD64')).toMatchSnapshot()
   })
 
+  it('should update the saturation of an 8-digit hex color and return a hex color', () => {
+    expect(setSaturation(0.2, '#CCCD647F')).toMatchSnapshot()
+  })
+
   it('should update the saturation and return a color with opacity', () => {
     expect(setSaturation(0.75, 'rgba(204,205,100,0.7)')).toMatchSnapshot()
   })

--- a/src/color/test/shade.test.js
+++ b/src/color/test/shade.test.js
@@ -6,6 +6,10 @@ describe('shade', () => {
     expect(shade(0.25, '#00f')).toMatchSnapshot()
   })
 
+  it('should shade the provided 8-digit hex color with white by the given percentage', () => {
+    expect(shade(0.25, '#000fffcc')).toMatchSnapshot()
+  })
+
   it('should shade the provided color when passed a string for amount', () => {
     expect(shade('0.25', '#00f')).toMatchSnapshot()
   })

--- a/src/color/test/tint.test.js
+++ b/src/color/test/tint.test.js
@@ -5,6 +5,9 @@ describe('test', () => {
   it('should tint the provided color with white by the given percentage', () => {
     expect(tint(0.25, '#00f')).toMatchSnapshot()
   })
+  it('should tint the provided 8-digit hex color with white by the given percentage', () => {
+    expect(tint(0.25, '#000fffcc')).toMatchSnapshot()
+  })
   it('should tint the provided color when passed a string for amount', () => {
     expect(tint('0.25', '#00f')).toMatchSnapshot()
   })

--- a/src/color/test/transparentize.test.js
+++ b/src/color/test/transparentize.test.js
@@ -7,7 +7,7 @@ describe('transparentize', () => {
   })
 
   it('should reduce the opacity of an 8-digit hex color by 0.1', () => {
-    expect(transparentize(0.1, '#CCCD647F')).toMatchSnapshot()
+    expect(transparentize(0.1, '#6564CDB3')).toMatchSnapshot()
   })
 
   it('should reduce the opacity of rgb(255, 0, 255) by 0.1', () => {
@@ -15,7 +15,7 @@ describe('transparentize', () => {
   })
 
   it('should reduce the opacity of rgba(255, 0, 0, 1) by 0.1', () => {
-    expect(transparentize(0.1, 'rgba(255, 0, 0, 1)')).toMatchSnapshot()
+    expect(transparentize(0.1, 'rgba(101, 100, 205, .7)')).toMatchSnapshot()
   })
 
   it('should reduce the opacity of rgba(255, 0, 0, .5) by 0.3', () => {

--- a/src/color/test/transparentize.test.js
+++ b/src/color/test/transparentize.test.js
@@ -6,6 +6,10 @@ describe('transparentize', () => {
     expect(transparentize(0.1, '#fff')).toMatchSnapshot()
   })
 
+  it('should reduce the opacity of an 8-digit hex color by 0.1', () => {
+    expect(transparentize(0.1, '#CCCD647F')).toMatchSnapshot()
+  })
+
   it('should reduce the opacity of rgb(255, 0, 255) by 0.1', () => {
     expect(transparentize(0.1, 'rgb(255, 0, 255)')).toMatchSnapshot()
   })


### PR DESCRIPTION
#RRGGBBAA hexadecimal color notation supported by [Chrome](https://www.chromestatus.com/feature/5685348285808640), [Firefox](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#Syntax)

#306 