### PR TITLE
Fix not covered invalid input

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "eslint": "^4.17.0",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.8.0",
-    "flow-bin": "^0.64.0",
+    "flow-bin": "^0.75.0",
     "flow-copy-source": "^1.2.2",
     "flow-coverage-report": "^0.4.1",
     "github-slugger": "^1.2.0",

--- a/src/color/parseToRgb.js
+++ b/src/color/parseToRgb.js
@@ -64,7 +64,9 @@ function parseToRgb(color: string): RgbColor | RgbaColor {
     const lightness = parseInt(`${hslMatched[3]}`, 10) / 100
     const rgbColorString = `rgb(${hslToRgb(hue, saturation, lightness)})`
     const hslRgbMatched = rgbRegex.exec(rgbColorString)
-    if (!hslRgbMatched) { throw new Error(`Couldn't parse ${rgbColorString} to hsl.`) }
+    if (!hslRgbMatched) {
+      throw new Error(`Couldn't generate valid rgb string from ${normalizedColor}, it returned ${rgbColorString}.`)
+    }
     return {
       red: parseInt(`${hslRgbMatched[1]}`, 10),
       green: parseInt(`${hslRgbMatched[2]}`, 10),
@@ -78,7 +80,9 @@ function parseToRgb(color: string): RgbColor | RgbaColor {
     const lightness = parseInt(`${hslaMatched[3]}`, 10) / 100
     const rgbColorString = `rgb(${hslToRgb(hue, saturation, lightness)})`
     const hslRgbMatched = rgbRegex.exec(rgbColorString)
-    if (!hslRgbMatched) { throw new Error(`Couldn't parse ${rgbColorString} to hsl.`) }
+    if (!hslRgbMatched) {
+      throw new Error(`Couldn't generate valid rgb string from ${normalizedColor}, it returned ${rgbColorString}.`)
+    }
     return {
       red: parseInt(`${hslRgbMatched[1]}`, 10),
       green: parseInt(`${hslRgbMatched[2]}`, 10),

--- a/src/color/parseToRgb.js
+++ b/src/color/parseToRgb.js
@@ -64,6 +64,7 @@ function parseToRgb(color: string): RgbColor | RgbaColor {
     const lightness = parseInt(`${hslMatched[3]}`, 10) / 100
     const rgbColorString = `rgb(${hslToRgb(hue, saturation, lightness)})`
     const hslRgbMatched = rgbRegex.exec(rgbColorString)
+    if (!hslRgbMatched) { throw new Error(`Couldn't parse ${rgbColorString} to hsl.`) }
     return {
       red: parseInt(`${hslRgbMatched[1]}`, 10),
       green: parseInt(`${hslRgbMatched[2]}`, 10),
@@ -77,6 +78,7 @@ function parseToRgb(color: string): RgbColor | RgbaColor {
     const lightness = parseInt(`${hslaMatched[3]}`, 10) / 100
     const rgbColorString = `rgb(${hslToRgb(hue, saturation, lightness)})`
     const hslRgbMatched = rgbRegex.exec(rgbColorString)
+    if (!hslRgbMatched) { throw new Error(`Couldn't parse ${rgbColorString} to hsl.`) }
     return {
       red: parseInt(`${hslRgbMatched[1]}`, 10),
       green: parseInt(`${hslRgbMatched[2]}`, 10),

--- a/src/color/test/parseToRgb.test.js
+++ b/src/color/test/parseToRgb.test.js
@@ -40,4 +40,16 @@ describe('parseToRgb', () => {
       parseToRgb(12345)
     }).toThrow('Passed an incorrect argument to a color function, please pass a string representation of a color.')
   })
+
+  it('should throw an error if an invalid hsl string is provided', () => {
+    expect(() => {
+      parseToRgb('hsl(210,120%,4%)')
+    }).toThrow(`Couldn't generate valid rgb string from ${'hsl(210,120%,4%)'}, it returned ${'rgb(-2,10,22)'}.`)
+  })
+
+  it('should throw an error if an unparsable hsla string is provided', () => {
+    expect(() => {
+      parseToRgb('hsla(210,120%,4%,0.7)')
+    }).toThrow(`Couldn't generate valid rgb string from ${'hsla(210,120%,4%,0.7)'}, it returned ${'rgb(-2,10,22)'}.`)
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3106,9 +3106,9 @@ flow-annotation-check@1.8.0:
     glob "7.1.1"
     load-pkg "^3.0.1"
 
-flow-bin@^0.64.0:
-  version "0.64.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.64.0.tgz#ddd3fb3b183ab1ab35a5d5dec9caf5ebbcded167"
+flow-bin@^0.75.0:
+  version "0.75.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.75.0.tgz#b96d1ee99d3b446a3226be66b4013224ce9df260"
 
 flow-copy-source@^1.2.2:
   version "1.2.2"


### PR DESCRIPTION
After upgrading to flow 0.75, i discovered that there is a case of invalid input that gets through the regex of the hsl matcher but not the one extracting color values from rgb. This PR should prevent this possibility.