### PR TITLE
docs(README): color module examples incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ import { compose } from 'ramda' // Replace with any compose() function of your c
 import { lighten, desaturate } from 'polished'
 
 // Create tone() helper
-const tone = compose(lighten(10), desaturate(10))
+const tone = compose(lighten(0.1), desaturate(0.1))
 ```
 
 ### Why not `package-xyz`?


### PR DESCRIPTION
Hello,

This is a great lib I just discovered. I stumbled upon a minor in the README: the value to most functions such as `darken, desaturate, lighten...` seems to be a percentage (between 0-1) in the docs, but in this README it's a value between 0-100.