### PR TITLE
feat(Flow): Define, use & document Styles type for mixins result values

### DIFF
--- a/.documentation.json
+++ b/.documentation.json
@@ -88,6 +88,7 @@
     },
     "AnimationProperty",
     "FontFaceConfiguration",
+    "Styles",
     "HslColor",
     "HslaColor",
     "InteractionState",

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ import { compose } from 'ramda' // Replace with any compose() function of your c
 import { lighten, desaturate } from 'polished'
 
 // Create tone() helper
-const tone = compose(lighten(10), desaturate(10))
+const tone = compose(lighten(0.1), desaturate(0.1))
 ```
 
 ### Why not `package-xyz`?

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "eslint": "^4.17.0",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.8.0",
-    "flow-bin": "^0.64.0",
+    "flow-bin": "^0.75.0",
     "flow-copy-source": "^1.2.2",
     "flow-coverage-report": "^0.4.1",
     "github-slugger": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "rollup-plugin-uglify": "^3.0.0",
     "semantic-release": "^12.4.1",
     "shx": "^0.2.2",
-    "tsgen": "^1.0.0",
+    "tsgen": "^1.3",
     "typescript": "^2.7.1",
     "validate-commit-msg": "^2.14.0",
     "vinyl": "^2.1.0",

--- a/src/color/parseToRgb.js
+++ b/src/color/parseToRgb.js
@@ -64,6 +64,9 @@ function parseToRgb(color: string): RgbColor | RgbaColor {
     const lightness = parseInt(`${hslMatched[3]}`, 10) / 100
     const rgbColorString = `rgb(${hslToRgb(hue, saturation, lightness)})`
     const hslRgbMatched = rgbRegex.exec(rgbColorString)
+    if (!hslRgbMatched) {
+      throw new Error(`Couldn't generate valid rgb string from ${normalizedColor}, it returned ${rgbColorString}.`)
+    }
     return {
       red: parseInt(`${hslRgbMatched[1]}`, 10),
       green: parseInt(`${hslRgbMatched[2]}`, 10),
@@ -77,6 +80,9 @@ function parseToRgb(color: string): RgbColor | RgbaColor {
     const lightness = parseInt(`${hslaMatched[3]}`, 10) / 100
     const rgbColorString = `rgb(${hslToRgb(hue, saturation, lightness)})`
     const hslRgbMatched = rgbRegex.exec(rgbColorString)
+    if (!hslRgbMatched) {
+      throw new Error(`Couldn't generate valid rgb string from ${normalizedColor}, it returned ${rgbColorString}.`)
+    }
     return {
       red: parseInt(`${hslRgbMatched[1]}`, 10),
       green: parseInt(`${hslRgbMatched[2]}`, 10),

--- a/src/color/test/parseToRgb.test.js
+++ b/src/color/test/parseToRgb.test.js
@@ -40,4 +40,16 @@ describe('parseToRgb', () => {
       parseToRgb(12345)
     }).toThrow('Passed an incorrect argument to a color function, please pass a string representation of a color.')
   })
+
+  it('should throw an error if an invalid hsl string is provided', () => {
+    expect(() => {
+      parseToRgb('hsl(210,120%,4%)')
+    }).toThrow(`Couldn't generate valid rgb string from ${'hsl(210,120%,4%)'}, it returned ${'rgb(-2,10,22)'}.`)
+  })
+
+  it('should throw an error if an unparsable hsla string is provided', () => {
+    expect(() => {
+      parseToRgb('hsla(210,120%,4%,0.7)')
+    }).toThrow(`Couldn't generate valid rgb string from ${'hsla(210,120%,4%,0.7)'}, it returned ${'rgb(-2,10,22)'}.`)
+  })
 })

--- a/src/helpers/directionalProperty.js
+++ b/src/helpers/directionalProperty.js
@@ -1,4 +1,5 @@
 // @flow
+import type { Styles } from '../types/style'
 import capitalizeString from '../internalHelpers/_capitalizeString'
 
 const positionMap = ['Top', 'Right', 'Bottom', 'Left']
@@ -53,7 +54,7 @@ function generateStyles(
 function directionalProperty(
   property: string,
   ...values: Array<?string | ?number>
-): Object {
+): Styles {
   //  prettier-ignore
   const [firstValue, secondValue = firstValue, thirdValue = firstValue, fourthValue = secondValue] = values
   const valuesWithDefaults = [firstValue, secondValue, thirdValue, fourthValue]

--- a/src/mixins/clearFix.js
+++ b/src/mixins/clearFix.js
@@ -1,4 +1,5 @@
 // @flow
+import type { Styles } from '../types/style'
 
 /**
  * CSS to contain a float (credit to CSSMojo).
@@ -23,7 +24,7 @@
  * }
  */
 
-function clearFix(parent?: string = '&'): Object {
+function clearFix(parent?: string = '&'): Styles {
   const pseudoSelector = `${parent}::after`
   return {
     [pseudoSelector]: {

--- a/src/mixins/ellipsis.js
+++ b/src/mixins/ellipsis.js
@@ -1,4 +1,5 @@
 // @flow
+import type { Styles } from '../types/style'
 
 /**
  * CSS to represent truncated text with an ellipsis.
@@ -26,7 +27,7 @@
  * }
  */
 
-function ellipsis(width?: string | number = '100%'): Object {
+function ellipsis(width?: string | number = '100%'): Styles {
   return {
     display: 'inline-block',
     maxWidth: width,

--- a/src/mixins/fontFace.js
+++ b/src/mixins/fontFace.js
@@ -1,4 +1,5 @@
 // @flow
+import type { Styles } from '../types/style'
 
 /** */
 type FontFaceConfiguration = {
@@ -77,7 +78,7 @@ function fontFace({
   fileFormats = ['eot', 'woff2', 'woff', 'ttf', 'svg'],
   localFonts,
   unicodeRange,
-}: FontFaceConfiguration): Object {
+}: FontFaceConfiguration): Styles {
   // Error Handling
   if (!fontFamily) throw new Error('fontFace expects a name of a font-family.')
   if (!fontFilePath && !localFonts) {

--- a/src/mixins/hideVisually.js
+++ b/src/mixins/hideVisually.js
@@ -1,4 +1,5 @@
 // @flow
+import type { Styles } from '../types/style'
 
 /**
  * CSS to hide content visually but remain accessible to screen readers.
@@ -31,7 +32,7 @@
  * }
  */
 
-function hideVisually(): Object {
+function hideVisually(): Styles {
   return {
     border: '0',
     clip: 'rect(0 0 0 0)',

--- a/src/mixins/normalize.js
+++ b/src/mixins/normalize.js
@@ -250,7 +250,10 @@ const unopinionatedRules = {
   },
 }
 
-function mergeRules(baseRules: Styles, additionalRules: Styles): Styles {
+function mergeRules(
+  baseRules: Styles,
+  additionalRules: { [rule: string]: Styles },
+): Styles {
   const mergedRules = { ...baseRules }
   Object.keys(additionalRules).forEach(key => {
     if (mergedRules[key]) {

--- a/src/mixins/normalize.js
+++ b/src/mixins/normalize.js
@@ -1,4 +1,6 @@
 // @flow
+import type { Styles } from '../types/style'
+
 const opinionatedRules = {
   html: {
     fontFamily: 'sans-serif',
@@ -248,7 +250,7 @@ const unopinionatedRules = {
   },
 }
 
-function mergeRules(baseRules: Object, additionalRules: Object): Object {
+function mergeRules(baseRules: Styles, additionalRules: Styles): Styles {
   const mergedRules = { ...baseRules }
   Object.keys(additionalRules).forEach(key => {
     if (mergedRules[key]) {
@@ -285,7 +287,7 @@ function mergeRules(baseRules: Object, additionalRules: Object): Object {
  *   textSizeAdjust: 100%,
  * } ...
  */
-function normalize(excludeOpinionated?: boolean): Object {
+function normalize(excludeOpinionated?: boolean): Styles {
   if (excludeOpinionated) return unopinionatedRules
   return mergeRules(unopinionatedRules, opinionatedRules)
 }

--- a/src/mixins/placeholder.js
+++ b/src/mixins/placeholder.js
@@ -1,4 +1,5 @@
 // @flow
+import type { Styles } from '../types/style'
 
 /**
  * CSS to style the placeholder pseudo-element.
@@ -32,7 +33,7 @@
  * },
  */
 
-function placeholder(styles: Object, parent?: string = '&'): Object {
+function placeholder(styles: Styles, parent?: string = '&'): Styles {
   return {
     [`${parent}::-webkit-input-placeholder`]: {
       ...styles,

--- a/src/mixins/radialGradient.js
+++ b/src/mixins/radialGradient.js
@@ -1,4 +1,5 @@
 // @flow
+import type { Styles } from '../types/style'
 
 /** */
 type RadialGradientConfiguration = {
@@ -81,7 +82,7 @@ function radialGradient({
   fallback,
   position,
   shape,
-}: RadialGradientConfiguration): Object {
+}: RadialGradientConfiguration): Styles {
   if (!colorStops || colorStops.length < 2) {
     throw new Error('radialGradient requries at least 2 color-stops to properly render.')
   }

--- a/src/mixins/retinaImage.js
+++ b/src/mixins/retinaImage.js
@@ -1,4 +1,5 @@
 // @flow
+import type { Styles } from '../types/style'
 
 import hiDPI from './hiDPI'
 
@@ -36,7 +37,7 @@ function retinaImage(
   extension?: string = 'png',
   retinaFilename?: string,
   retinaSuffix?: string = '_2x',
-): Object {
+): Styles {
   if (!filename) {
     throw new Error('Please supply a filename to retinaImage() as the first argument.')
   }

--- a/src/mixins/selection.js
+++ b/src/mixins/selection.js
@@ -1,4 +1,5 @@
 // @flow
+import type { Styles } from '../types/style'
 
 /**
  * CSS to style the selection pseudo-element.
@@ -28,7 +29,7 @@
  * }
  */
 
-function selection(styles: Object, parent?: string = ''): Object {
+function selection(styles: Styles, parent?: string = ''): Styles {
   return {
     [`${parent}::-moz-selection`]: {
       ...styles,

--- a/src/mixins/triangle.js
+++ b/src/mixins/triangle.js
@@ -1,4 +1,5 @@
 // @flow
+import type { Styles } from '../types/style'
 
 /** */
 type PointingDirection = 'top' | 'right' | 'bottom' | 'left'
@@ -73,7 +74,7 @@ function triangle({
   width,
   foregroundColor,
   backgroundColor = 'transparent',
-}: TriangleArgs): Object {
+}: TriangleArgs): Styles {
   const unitlessHeight = parseFloat(height)
   const unitlessWidth = parseFloat(width)
   if (isNaN(unitlessHeight) || isNaN(unitlessWidth)) {

--- a/src/mixins/wordWrap.js
+++ b/src/mixins/wordWrap.js
@@ -1,4 +1,5 @@
 // @flow
+import type { Styles } from '../types/style'
 
 /**
  * Provides an easy way to change the `wordWrap` property.
@@ -23,7 +24,7 @@
  * }
  */
 
-function wordWrap(wrap?: string = 'break-word'): Object {
+function wordWrap(wrap?: string = 'break-word'): Styles {
   const wordBreak = wrap === 'break-word' ? 'break-all' : wrap
   return {
     overflowWrap: wrap,

--- a/src/shorthands/animation.js
+++ b/src/shorthands/animation.js
@@ -1,4 +1,5 @@
 // @flow
+import type { Styles } from '../types/style'
 
 /** */
 type AnimationProperty = string | number
@@ -39,7 +40,7 @@ type AnimationProperty = string | number
  *   'animation': 'rotate 1s ease-in-out'
  * }
  */
-function animation(...args: Array<Array<AnimationProperty> | AnimationProperty>): Object {
+function animation(...args: Array<Array<AnimationProperty> | AnimationProperty>): Styles {
   // Allow single or multiple animations passed
   const multiMode = Array.isArray(args[0])
   if (!multiMode && args.length > 8) {

--- a/src/shorthands/backgroundImages.js
+++ b/src/shorthands/backgroundImages.js
@@ -1,4 +1,5 @@
 // @flow
+import type { Styles } from '../types/style'
 
 /**
  * Shorthand that accepts any number of backgroundImage values as parameters for creating a single background statement.
@@ -20,7 +21,7 @@
  * }
  */
 
-function backgroundImages(...properties: Array<string>): Object {
+function backgroundImages(...properties: Array<string>): Styles {
   return {
     backgroundImage: properties.join(', '),
   }

--- a/src/shorthands/backgrounds.js
+++ b/src/shorthands/backgrounds.js
@@ -1,4 +1,5 @@
 // @flow
+import type { Styles } from '../types/style'
 
 /**
  * Shorthand that accepts any number of background values as parameters for creating a single background statement.
@@ -19,7 +20,7 @@
  *   'background': 'url("/image/background.jpg"), linear-gradient(red, green), center no-repeat'
  * }
  */
-function backgrounds(...properties: Array<string>): Object {
+function backgrounds(...properties: Array<string>): Styles {
   return {
     background: properties.join(', '),
   }

--- a/src/shorthands/borderColor.js
+++ b/src/shorthands/borderColor.js
@@ -1,4 +1,5 @@
 // @flow
+import type { Styles } from '../types/style'
 import directionalProperty from '../helpers/directionalProperty'
 
 /**
@@ -24,7 +25,7 @@ import directionalProperty from '../helpers/directionalProperty'
  * }
  */
 
-function borderColor(...values: Array<?string>): Object {
+function borderColor(...values: Array<?string>): Styles {
   return directionalProperty('borderColor', ...values)
 }
 

--- a/src/shorthands/borderRadius.js
+++ b/src/shorthands/borderRadius.js
@@ -1,4 +1,5 @@
 // @flow
+import type { Styles } from '../types/style'
 import capitalizeString from '../internalHelpers/_capitalizeString'
 
 /**
@@ -22,7 +23,7 @@ import capitalizeString from '../internalHelpers/_capitalizeString'
  * }
  */
 
-function borderRadius(side: string, radius: string | number): Object {
+function borderRadius(side: string, radius: string | number): Styles {
   const uppercaseSide = capitalizeString(side)
   if (!radius && radius !== 0) {
     throw new Error('borderRadius expects a radius value as a string or number as the second argument.')

--- a/src/shorthands/borderStyle.js
+++ b/src/shorthands/borderStyle.js
@@ -1,5 +1,6 @@
 // @flow
 import directionalProperty from '../helpers/directionalProperty'
+import type { Styles } from '../types/style'
 
 /**
  * Shorthand that accepts up to four values, including null to skip a value, and maps them to their respective directions.
@@ -24,7 +25,7 @@ import directionalProperty from '../helpers/directionalProperty'
  * }
  */
 
-function borderStyle(...values: Array<?string>): Object {
+function borderStyle(...values: Array<?string>): Styles {
   return directionalProperty('borderStyle', ...values)
 }
 

--- a/src/shorthands/borderWidth.js
+++ b/src/shorthands/borderWidth.js
@@ -1,4 +1,5 @@
 // @flow
+import type { Styles } from '../types/style'
 import directionalProperty from '../helpers/directionalProperty'
 
 /**
@@ -23,7 +24,7 @@ import directionalProperty from '../helpers/directionalProperty'
  *   'borderLeftWidth': '48px'
  * }
  */
-function borderWidth(...values: Array<?string | ?number>): Object {
+function borderWidth(...values: Array<?string | ?number>): Styles {
   return directionalProperty('borderWidth', ...values)
 }
 

--- a/src/shorthands/margin.js
+++ b/src/shorthands/margin.js
@@ -1,4 +1,5 @@
 // @flow
+import type { Styles } from '../types/style'
 import directionalProperty from '../helpers/directionalProperty'
 
 /**
@@ -24,7 +25,7 @@ import directionalProperty from '../helpers/directionalProperty'
  * }
  */
 
-function margin(...values: Array<?string | ?number>): Object {
+function margin(...values: Array<?string | ?number>): Styles {
   return directionalProperty('margin', ...values)
 }
 

--- a/src/shorthands/padding.js
+++ b/src/shorthands/padding.js
@@ -1,4 +1,5 @@
 // @flow
+import type { Styles } from '../types/style'
 import directionalProperty from '../helpers/directionalProperty'
 
 /**
@@ -24,7 +25,7 @@ import directionalProperty from '../helpers/directionalProperty'
  * }
  */
 
-function padding(...values: Array<?string | ?number>): Object {
+function padding(...values: Array<?string | ?number>): Styles {
   return directionalProperty('padding', ...values)
 }
 

--- a/src/shorthands/position.js
+++ b/src/shorthands/position.js
@@ -1,4 +1,5 @@
 // @flow
+import type { Styles } from '../types/style'
 import directionalProperty from '../helpers/directionalProperty'
 
 const positionMap = ['absolute', 'fixed', 'relative', 'static', 'sticky']
@@ -49,7 +50,7 @@ const positionMap = ['absolute', 'fixed', 'relative', 'static', 'sticky']
 function position(
   positionKeyword: string | null,
   ...values: Array<?string | ?number>
-): Object {
+): Styles {
   if (positionMap.indexOf(positionKeyword) >= 0) {
     return {
       position: positionKeyword,

--- a/src/shorthands/size.js
+++ b/src/shorthands/size.js
@@ -1,4 +1,5 @@
 // @flow
+import type { Styles } from '../types/style'
 
 /**
  * Shorthand to set the height and width properties in a single statement.
@@ -24,7 +25,7 @@
 function size(
   height: string | number,
   width?: string | number = height,
-): Object {
+): Styles {
   return {
     height,
     width,

--- a/src/shorthands/transitions.js
+++ b/src/shorthands/transitions.js
@@ -20,7 +20,7 @@
  * }
  */
 
-function transitions(...properties: Array<string>): Object {
+function transitions(...properties: Array<string>): { transition: string } {
   return {
     transition: properties.join(', '),
   }

--- a/src/types/style.js
+++ b/src/types/style.js
@@ -4,5 +4,5 @@
  * @property {number | string | Styles}  [ruleOrSelector]
  */
 export type Styles = {
-  [ruleOrSelector: string]: number | number | Styles,
+  [ruleOrSelector: string]: string | number | Styles,
 }

--- a/src/types/style.js
+++ b/src/types/style.js
@@ -1,0 +1,8 @@
+// @flow
+
+/**
+ * @property {number | string | Styles}  [ruleOrSelector]
+ */
+export type Styles = {
+  [ruleOrSelector: string]: number | number | Styles,
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -127,33 +127,33 @@
     into-stream "^3.1.0"
     lodash "^4.17.4"
 
-"@types/babel-code-frame@^6.20.1":
+"@types/babel-code-frame@*":
   version "6.20.1"
   resolved "https://registry.yarnpkg.com/@types/babel-code-frame/-/babel-code-frame-6.20.1.tgz#e79a40ea81435034df7b46b5e32e8ed638aea4dd"
 
-"@types/babel-types@*", "@types/babel-types@^6.7.16":
+"@types/babel-types@*":
   version "6.25.1"
   resolved "https://registry.yarnpkg.com/@types/babel-types/-/babel-types-6.25.1.tgz#ce8f126a4403e11e1b0033a424f11638afac7889"
 
-"@types/babylon@^6.16.1":
-  version "6.16.2"
-  resolved "https://registry.yarnpkg.com/@types/babylon/-/babylon-6.16.2.tgz#062ce63b693d9af1c246f5aedf928bc9c30589c8"
+"@types/babylon@*":
+  version "6.16.3"
+  resolved "https://registry.yarnpkg.com/@types/babylon/-/babylon-6.16.3.tgz#c2937813a89fcb5e79a00062fc4a8b143e7237bb"
   dependencies:
     "@types/babel-types" "*"
 
-"@types/micromatch@^2.3.29":
-  version "2.3.29"
-  resolved "https://registry.yarnpkg.com/@types/micromatch/-/micromatch-2.3.29.tgz#6ce0280fe96f500127f0c8c0addf2d3f207e8cec"
+"@types/braces@*":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@types/braces/-/braces-2.3.0.tgz#d00ec0a76562b2acb6f29330be33a093e33ed25c"
+
+"@types/micromatch@*":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/micromatch/-/micromatch-3.1.0.tgz#514c8a3d24b2680a9b838eeb80e6d7d724545433"
   dependencies:
-    "@types/parse-glob" "*"
+    "@types/braces" "*"
 
 "@types/node@^7.0.31":
   version "7.0.43"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.43.tgz#a187e08495a075f200ca946079c914e1a5fe962c"
-
-"@types/parse-glob@*":
-  version "3.0.29"
-  resolved "https://registry.yarnpkg.com/@types/parse-glob/-/parse-glob-3.0.29.tgz#6a40ec7ebd2418ee69ee397e48e42169268a10bf"
 
 JSONStream@^1.0.3, JSONStream@^1.0.4:
   version "1.3.1"
@@ -7455,14 +7455,14 @@ tryit@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tryit/-/tryit-1.0.3.tgz#393be730a9446fd1ead6da59a014308f36c289cb"
 
-tsgen@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/tsgen/-/tsgen-1.0.0.tgz#04632d4b78df4ba035460205b6f26930a6557ae0"
+tsgen@^1.3:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/tsgen/-/tsgen-1.3.0.tgz#2b4a9a23d7619816a191bc236b4d88dd467221e3"
   dependencies:
-    "@types/babel-code-frame" "^6.20.1"
-    "@types/babel-types" "^6.7.16"
-    "@types/babylon" "^6.16.1"
-    "@types/micromatch" "^2.3.29"
+    "@types/babel-code-frame" "*"
+    "@types/babel-types" "*"
+    "@types/babylon" "*"
+    "@types/micromatch" "*"
     babel-code-frame "^6.22.0"
     babel-types "^6.25.0"
     babylon "^6.17.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3106,9 +3106,9 @@ flow-annotation-check@1.8.0:
     glob "7.1.1"
     load-pkg "^3.0.1"
 
-flow-bin@^0.64.0:
-  version "0.64.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.64.0.tgz#ddd3fb3b183ab1ab35a5d5dec9caf5ebbcded167"
+flow-bin@^0.75.0:
+  version "0.75.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.75.0.tgz#b96d1ee99d3b446a3226be66b4013224ce9df260"
 
 flow-copy-source@^1.2.2:
   version "1.2.2"


### PR DESCRIPTION
As mentioned in #261, current usage of Object to type style objects is too permissive to be incompatible with `styled-components` type definition for interpolated values in tagged template literals. Usage of Object is also discouraged by Flow in its documentation:

> However, if you need to opt-out of the type checker, and don’t want to go all the way to any, you can instead use Object. Object is unsafe and should be avoided.
> – https://flow.org/en/docs/types/objects/#toc-object-type

In this PR, a Styles type, akin to the one declared in `styled-components`,  is implemented and used wherever relevant. It was declared as follows:
```typescript
export type Styles = {
  [ruleOrSelector: string]: string | number | Styles,
}
```

Running `yarn flow` succeeds with 0 errors and Typescript type definitions work too. The only issue with this PR that I could find is that the generated documentation for the Styles type doesn't seem quite right and I couldn't think of any way to solve it, as I couldn't find a way to declare string index properties with JSDoc:

![image](https://user-images.githubusercontent.com/357835/43202057-baeb0030-8ff0-11e8-922d-df3f2da6f04f.png)

If there are known fixes for that or further error, I would be glad to include them. I hope this can be helpful :)

Closes #261 