### PR TITLE
fix(parseToHSL): parseToHSL(A) can now handle float values for hue

### DIFF
--- a/src/color/parseToRgb.js
+++ b/src/color/parseToRgb.js
@@ -9,8 +9,8 @@ const hexRgbaRegex = /^#[a-fA-F0-9]{8}$/
 const reducedHexRegex = /^#[a-fA-F0-9]{3}$/
 const rgbRegex = /^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/
 const rgbaRegex = /^rgba\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*([-+]?[0-9]*[.]?[0-9]+)\s*\)$/
-const hslRegex = /^hsl\(\s*(\d{1,3})\s*,\s*(\d{1,3})%\s*,\s*(\d{1,3})%\s*\)$/
-const hslaRegex = /^hsla\(\s*(\d{1,3})\s*,\s*(\d{1,3})%\s*,\s*(\d{1,3})%\s*,\s*([-+]?[0-9]*[.]?[0-9]+)\s*\)$/
+const hslRegex = /^hsl\(\s*(\d{0,3}[.]?[0-9]+)\s*,\s*(\d{1,3})%\s*,\s*(\d{1,3})%\s*\)$/
+const hslaRegex = /^hsla\(\s*(\d{0,3}[.]?[0-9]+)\s*,\s*(\d{1,3})%\s*,\s*(\d{1,3})%\s*,\s*([-+]?[0-9]*[.]?[0-9]+)\s*\)$/
 
 /**
  * Returns an RgbColor or RgbaColor object. This utility function is only useful

--- a/src/color/test/__snapshots__/parseToHsl.test.js.snap
+++ b/src/color/test/__snapshots__/parseToHsl.test.js.snap
@@ -16,7 +16,24 @@ Object {
 }
 `;
 
+exports[`parseToHsl should parse a hsl color representation with a float 1`] = `
+Object {
+  "hue": 210,
+  "lightness": 0.0392156862745098,
+  "saturation": 0.1,
+}
+`;
+
 exports[`parseToHsl should parse a hsla color representation 1`] = `
+Object {
+  "alpha": 0.75,
+  "hue": 209.99999999999997,
+  "lightness": 0.4,
+  "saturation": 0.09803921568627451,
+}
+`;
+
+exports[`parseToHsl should parse a hsla color representation with a float 1`] = `
 Object {
   "alpha": 0.75,
   "hue": 209.99999999999997,

--- a/src/color/test/parseToHsl.test.js
+++ b/src/color/test/parseToHsl.test.js
@@ -25,13 +25,23 @@ describe('parseToHsl', () => {
     expect(parseToHsl('hsl(210,10%,4%)')).toMatchSnapshot()
   })
 
+  it('should parse a hsl color representation with a float', () => {
+    expect(parseToHsl('hsl(210.99,10%,4%)')).toMatchSnapshot()
+  })
+
   it('should parse a hsla color representation', () => {
     expect(parseToHsl('hsla(210,10%,40%,0.75)')).toMatchSnapshot()
+  })
+
+  it('should parse a hsla color representation with a float', () => {
+    expect(parseToHsl('hsla(210.99,10%,40%,0.75)')).toMatchSnapshot()
   })
 
   it('should throw an error if an invalid color string is provided', () => {
     expect(() => {
       parseToHsl('(174,67,255)')
-    }).toThrow("Couldn't parse the color string. Please provide the color as a string in hex, rgb, rgba, hsl or hsla notation.")
+    }).toThrow(
+      "Couldn't parse the color string. Please provide the color as a string in hex, rgb, rgba, hsl or hsla notation.",
+    )
   })
 })


### PR DESCRIPTION
Regexes updated to allow parseToHSL(a) to handle float values for hue.

fixes #343