### PR TITLE
docs: Improved docs for parseToRgb and parseToHsl

### DIFF
--- a/docs/assets/polished.js
+++ b/docs/assets/polished.js
@@ -592,7 +592,7 @@
    * // Styles as object basic usage
    * const styles = {
    *    ...fontFace({
-   *      'fontFamily': 'Sans-Pro'
+   *      'fontFamily': 'Sans-Pro',
    *      'fontFilePath': 'path/to/file'
    *    })
    * }
@@ -600,7 +600,7 @@
    * // styled-components basic usage
    * injectGlobal`${
    *   fontFace({
-   *     'fontFamily': 'Sans-Pro'
+   *     'fontFamily': 'Sans-Pro',
    *     'fontFilePath': 'path/to/file'
    *   }
    * )}`
@@ -1524,9 +1524,9 @@
    *
    * @example
    * // Assigns `{ red: 255, green: 0, blue: 0 }` to color1
-   * const color1 = 'rgb(255, 0, 0)';
+   * const color1 = parseToRgb('rgb(255, 0, 0)');
    * // Assigns `{ red: 92, green: 102, blue: 112, alpha: 0.75 }` to color2
-   * const color2 = 'hsla(210, 10%, 40%, 0.75)';
+   * const color2 = parseToRgb('hsla(210, 10%, 40%, 0.75)');
    */
   function parseToRgb(color) {
     if (typeof color !== 'string') {
@@ -1667,10 +1667,10 @@
    * can convert a HslColor or HslaColor object back to a string.
    *
    * @example
-   * // Assigns `{ red: 255, green: 0, blue: 0 }` to color1
-   * const color1 = 'rgb(255, 0, 0)';
-   * // Assigns `{ red: 92, green: 102, blue: 112, alpha: 0.75 }` to color2
-   * const color2 = 'hsla(210, 10%, 40%, 0.75)';
+   * // Assigns `{ hue: 0, saturation: 1, lightness: 0.5 }` to color1
+   * const color1 = parseToHsl('rgb(255, 0, 0)');
+   * // Assigns `{ hue: 128, saturation: 1, lightness: 0.5, alpha: 0.75 }` to color2
+   * const color2 = parseToHsl('hsla(128, 100%, 50%, 0.75)');
    */
   function parseToHsl(color) {
     // Note: At a later stage we can optimize this function as right now a hsl

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -1705,7 +1705,7 @@ div: {
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object basic usage</span>
 <span class="hljs-keyword">const</span> styles = {
    ...fontFace({
-     <span class="hljs-symbol">'fontFamily</span>': <span class="hljs-symbol">'Sans</span>-Pro'
+     <span class="hljs-symbol">'fontFamily</span>': <span class="hljs-symbol">'Sans</span>-Pro',
      <span class="hljs-symbol">'fontFilePath</span>': <span class="hljs-symbol">'path</span>/to/file'
    })
 }
@@ -1713,7 +1713,7 @@ div: {
 <span class="hljs-comment">// styled-components basic usage</span>
 injectGlobal`${
   fontFace({
-    <span class="hljs-symbol">'fontFamily</span>': <span class="hljs-symbol">'Sans</span>-Pro'
+    <span class="hljs-symbol">'fontFamily</span>': <span class="hljs-symbol">'Sans</span>-Pro',
     <span class="hljs-symbol">'fontFilePath</span>': <span class="hljs-symbol">'path</span>/to/file'
   }
 )}`
@@ -4582,10 +4582,10 @@ can convert a HslColor or HslaColor object back to a string.</p>
     <div class='py1 quiet mt1 prose-big'>Example</div>
     
       
-      <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Assigns `{ red: 255, green: 0, blue: 0 }` to color1</span>
-const color1 = 'rgb(<span class="hljs-number">255</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>)';
-<span class="hljs-comment">// Assigns `{ red: 92, green: 102, blue: 112, alpha: 0.75 }` to color2</span>
-const color2 = 'hsla(<span class="hljs-number">210</span>, <span class="hljs-number">10</span>%, <span class="hljs-number">40</span>%, <span class="hljs-number">0.75</span>)';</pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Assigns `{ hue: 0, saturation: 1, lightness: 0.5 }` to color1</span>
+const color1 = parseToHsl('rgb(<span class="hljs-number">255</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>)');
+<span class="hljs-comment">// Assigns `{ hue: 128, saturation: 1, lightness: 0.5, alpha: 0.75 }` to color2</span>
+const color2 = parseToHsl('hsla(<span class="hljs-number">128</span>, <span class="hljs-number">100</span>%, <span class="hljs-number">50</span>%, <span class="hljs-number">0.75</span>)');</pre>
     
   
 
@@ -4679,9 +4679,9 @@ can convert a RgbColor or RgbaColor object back to a string.</p>
     
       
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Assigns `{ red: 255, green: 0, blue: 0 }` to color1</span>
-const color1 = 'rgb(<span class="hljs-number">255</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>)';
+const color1 = parseToRgb('rgb(<span class="hljs-number">255</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>)');
 <span class="hljs-comment">// Assigns `{ red: 92, green: 102, blue: 112, alpha: 0.75 }` to color2</span>
-const color2 = 'hsla(<span class="hljs-number">210</span>, <span class="hljs-number">10</span>%, <span class="hljs-number">40</span>%, <span class="hljs-number">0.75</span>)';</pre>
+const color2 = parseToRgb('hsla(<span class="hljs-number">210</span>, <span class="hljs-number">10</span>%, <span class="hljs-number">40</span>%, <span class="hljs-number">0.75</span>)');</pre>
     
   
 

--- a/src/color/parseToHsl.js
+++ b/src/color/parseToHsl.js
@@ -10,10 +10,10 @@ import type { HslColor, HslaColor } from '../types/color'
  * can convert a HslColor or HslaColor object back to a string.
  *
  * @example
- * // Assigns `{ red: 255, green: 0, blue: 0 }` to color1
- * const color1 = 'rgb(255, 0, 0)';
- * // Assigns `{ red: 92, green: 102, blue: 112, alpha: 0.75 }` to color2
- * const color2 = 'hsla(210, 10%, 40%, 0.75)';
+ * // Assigns `{ hue: 0, saturation: 1, lightness: 0.5 }` to color1
+ * const color1 = parseToHsl('rgb(255, 0, 0)');
+ * // Assigns `{ hue: 128, saturation: 1, lightness: 0.5, alpha: 0.75 }` to color2
+ * const color2 = parseToHsl('hsla(128, 100%, 50%, 0.75)');
  */
 function parseToHsl(color: string): HslColor | HslaColor {
   // Note: At a later stage we can optimize this function as right now a hsl

--- a/src/color/parseToRgb.js
+++ b/src/color/parseToRgb.js
@@ -19,9 +19,9 @@ const hslaRegex = /^hsla\(\s*(\d{0,3}[.]?[0-9]+)\s*,\s*(\d{1,3})%\s*,\s*(\d{1,3}
  *
  * @example
  * // Assigns `{ red: 255, green: 0, blue: 0 }` to color1
- * const color1 = 'rgb(255, 0, 0)';
+ * const color1 = parseToRgb('rgb(255, 0, 0)');
  * // Assigns `{ red: 92, green: 102, blue: 112, alpha: 0.75 }` to color2
- * const color2 = 'hsla(210, 10%, 40%, 0.75)';
+ * const color2 = parseToRgb('hsla(210, 10%, 40%, 0.75)');
  */
 function parseToRgb(color: string): RgbColor | RgbaColor {
   if (typeof color !== 'string') {


### PR DESCRIPTION
- Adds usage of `parseToRgb` and `parseToHsl` in their code samples
- Corrects `parseToHsl` code samples to show the actual expected output