### PR TITLE
feat(color): Update tint and shade to mix a color WITH white

### DIFF
--- a/docs/assets/polished.js
+++ b/docs/assets/polished.js
@@ -2634,7 +2634,7 @@
    */
 
   function shade(percentage, color) {
-    return curriedMix(parseFloat(percentage), color, 'rgb(0, 0, 0)');
+    return curriedMix(parseFloat(percentage), 'rgb(0, 0, 0)', color);
   }
 
   var curriedShade =
@@ -2665,7 +2665,7 @@
    */
 
   function tint(percentage, color) {
-    return curriedMix(parseFloat(percentage), color, 'rgb(255, 255, 255)');
+    return curriedMix(parseFloat(percentage), 'rgb(255, 255, 255)', color);
   }
 
   var curriedTint =

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "lib/index.js",
   "module": "dist/polished.es.js",
   "types": "lib/index.d.ts",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "scripts": {
     "build": "yarn build:lib && yarn build:dist && yarn build:flow && yarn build:docs && yarn build:typescript",
     "prebuild:lib": "shx rm -rf lib/*",

--- a/src/color/shade.js
+++ b/src/color/shade.js
@@ -26,7 +26,7 @@ import mix from './mix'
  */
 
 function shade(percentage: number | string, color: string): string {
-  return mix(parseFloat(percentage), color, 'rgb(0, 0, 0)')
+  return mix(parseFloat(percentage), 'rgb(0, 0, 0)', color)
 }
 
 const curriedShade = curry(shade)

--- a/src/color/test/__snapshots__/shade.test.js.snap
+++ b/src/color/test/__snapshots__/shade.test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`shade should shade the provided 4-digit hex color with white by the given percentage 1`] = `"rgba(0,27,0,0.6475)"`;
+exports[`shade should shade the provided 4-digit hex color with white by the given percentage 1`] = `"rgba(0,132,0,0.8825000000000001)"`;
 
-exports[`shade should shade the provided 8-digit hex color with white by the given percentage 1`] = `"rgba(0,2,46,0.8500000000000001)"`;
+exports[`shade should shade the provided 8-digit hex color with white by the given percentage 1`] = `"rgba(0,10,170,0.95)"`;
 
-exports[`shade should shade the provided color when passed a string for amount 1`] = `"#00003f"`;
+exports[`shade should shade the provided color when passed a string for amount 1`] = `"#0000bf"`;
 
-exports[`shade should shade the provided color with white by the given percentage 1`] = `"#00003f"`;
+exports[`shade should shade the provided color with white by the given percentage 1`] = `"#0000bf"`;

--- a/src/color/test/__snapshots__/tint.test.js.snap
+++ b/src/color/test/__snapshots__/tint.test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`test should tint the provided 4-digit hex color with white by the given percentage 1`] = `"rgba(227,255,227,0.6475)"`;
+exports[`test should tint the provided 4-digit hex color with white by the given percentage 1`] = `"rgba(122,255,122,0.8825000000000001)"`;
 
-exports[`test should tint the provided 8-digit hex color with white by the given percentage 1`] = `"rgba(208,211,255,0.8500000000000001)"`;
+exports[`test should tint the provided 8-digit hex color with white by the given percentage 1`] = `"rgba(85,95,255,0.95)"`;
 
-exports[`test should tint the provided color when passed a string for amount 1`] = `"#bfbfff"`;
+exports[`test should tint the provided color when passed a string for amount 1`] = `"#3f3fff"`;
 
-exports[`test should tint the provided color with white by the given percentage 1`] = `"#bfbfff"`;
+exports[`test should tint the provided color with white by the given percentage 1`] = `"#3f3fff"`;

--- a/src/color/tint.js
+++ b/src/color/tint.js
@@ -26,7 +26,7 @@ import mix from './mix'
  */
 
 function tint(percentage: number | string, color: string): string {
-  return mix(parseFloat(percentage), color, 'rgb(255, 255, 255)')
+  return mix(parseFloat(percentage), 'rgb(255, 255, 255)', color)
 }
 
 const curriedTint = curry(tint)


### PR DESCRIPTION
We were accidentally mixing white WITH our color.

See these examples:

- [How tint works within sass (expected behavior)](https://www.sassmeister.com/gist/437db2a2cbb0d59fa6808b1e03151549)
- [How tint works within polished (unexpected behavior)](https://codesandbox.io/s/9q297pyn8o)

Current behavior:

```js
const tinted = tint(0.4, "#454859"); // #b4b5bc - unexpected
const mixed1 = mix(0.4, "#454859", "#ffffff"); // #b4b5bc - expected
const mixed2 = mix(0.4, "#ffffff", "#454859"); // #8f919b - expected AND how tint should work
```

New/fixed behavior:

```js
const tinted = tint(0.4, "#454859"); // #8f919b - expected
const mixed1 = mix(0.4, "#454859", "#ffffff"); // #b4b5bc - expected
const mixed2 = mix(0.4, "#ffffff", "#454859"); // #8f919b - expected
```

