### PR TITLE
updated doc examples to reflect v4 update

### DIFF
--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -28,7 +28,7 @@
   <link rel="shortcut icon" href="/favicon.png" />
 </head>
 <body class='documentation'>
-  
+
     <div class='max-width-4 mx-auto'>
   <div class='clearfix md-mxn2'>
     <div class='fixed xs-hide fix-3 overflow-auto max-height-100'>
@@ -41,837 +41,837 @@
           type='text' />
         <div id='toc'>
           <ul class='list-reset h5 py1-ul'>
-            
-              
+
+
               <li><a
                 href='#installation'
                 class="h5 bold black caps">
                 Installation
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#usage'
                 class="h5 bold black caps">
                 Usage
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#mixins'
                 class="h5 bold black caps">
                 Mixins
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#between'
                 class="">
                 between
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#clearfix'
                 class="">
                 clearFix
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#cover'
                 class="">
                 cover
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#ellipsis'
                 class="">
                 ellipsis
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#fluidrange'
                 class="">
                 fluidRange
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#fontface'
                 class="">
                 fontFace
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#hidetext'
                 class="">
                 hideText
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#hidevisually'
                 class="">
                 hideVisually
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#hidpi'
                 class="">
                 hiDPI
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#normalize'
                 class="">
                 normalize
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#placeholder'
                 class="">
                 placeholder
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#radialgradient'
                 class="">
                 radialGradient
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#retinaimage'
                 class="">
                 retinaImage
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#selection'
                 class="">
                 selection
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#timingfunctions'
                 class="">
                 timingFunctions
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#triangle'
                 class="">
                 triangle
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#wordwrap'
                 class="">
                 wordWrap
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#color'
                 class="h5 bold black caps">
                 Color
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#adjusthue'
                 class="">
                 adjustHue
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#complement'
                 class="">
                 complement
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#darken'
                 class="">
                 darken
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#desaturate'
                 class="">
                 desaturate
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#getluminance'
                 class="">
                 getLuminance
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#grayscale'
                 class="">
                 grayscale
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#hsl'
                 class="">
                 hsl
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#hsla'
                 class="">
                 hsla
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#invert'
                 class="">
                 invert
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#lighten'
                 class="">
                 lighten
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#mix'
                 class="">
                 mix
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#opacify'
                 class="">
                 opacify
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#parsetohsl'
                 class="">
                 parseToHsl
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#parsetorgb'
                 class="">
                 parseToRgb
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#readablecolor'
                 class="">
                 readableColor
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#rgb'
                 class="">
                 rgb
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#rgba'
                 class="">
                 rgba
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#saturate'
                 class="">
                 saturate
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#sethue'
                 class="">
                 setHue
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#setlightness'
                 class="">
                 setLightness
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#setsaturation'
                 class="">
                 setSaturation
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#shade'
                 class="">
                 shade
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#tint'
                 class="">
                 tint
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#tocolorstring'
                 class="">
                 toColorString
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#transparentize'
                 class="">
                 transparentize
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#shorthands'
                 class="h5 bold black caps">
                 Shorthands
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#animation'
                 class="">
                 animation
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#backgroundimages'
                 class="">
                 backgroundImages
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#backgrounds'
                 class="">
                 backgrounds
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#border'
                 class="">
                 border
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#bordercolor'
                 class="">
                 borderColor
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#borderradius'
                 class="">
                 borderRadius
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#borderstyle'
                 class="">
                 borderStyle
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#borderwidth'
                 class="">
                 borderWidth
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#buttons'
                 class="">
                 buttons
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#margin'
                 class="">
                 margin
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#padding'
                 class="">
                 padding
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#position'
                 class="">
                 position
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#size'
                 class="">
                 size
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#textinputs'
                 class="">
                 textInputs
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#transitions'
                 class="">
                 transitions
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#helpers'
                 class="h5 bold black caps">
                 Helpers
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#directionalproperty'
                 class="">
                 directionalProperty
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#em'
                 class="">
                 em
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#getvalueandunit'
                 class="">
                 getValueAndUnit
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#modularscale'
                 class="">
                 modularScale
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#rem'
                 class="">
                 rem
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#stripunit'
                 class="">
                 stripUnit
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#types'
                 class="h5 bold black caps">
                 Types
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#fluidrangeconfiguration'
                 class="">
                 FluidRangeConfiguration
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#fontfaceconfiguration'
                 class="">
                 FontFaceConfiguration
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#hslcolor'
                 class="">
                 HslColor
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#hslacolor'
                 class="">
                 HslaColor
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#interactionstate'
                 class="">
                 InteractionState
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#modularscaleratio'
                 class="">
                 ModularScaleRatio
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#radialgradientconfiguration'
                 class="">
                 RadialGradientConfiguration
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#rgbacolor'
                 class="">
                 RgbaColor
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#rgbcolor'
                 class="">
                 RgbColor
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#sidekeyword'
                 class="">
                 SideKeyword
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#styles'
                 class="">
                 Styles
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#triangleconfiguration'
                 class="">
                 TriangleConfiguration
-                
+
               </a>
-              
+
               </li>
-            
-              
+
+
               <li><a
                 href='#timingfunction'
                 class="">
                 TimingFunction
-                
+
               </a>
-              
+
               </li>
-            
+
           </ul>
         </div>
         <div class='mt1 h6 quiet'>
@@ -880,156 +880,156 @@
       </div>
     </div>
     <div class='fix-margin-3'>
-      
-        
+
+
           <div class='keyline-top-not py2'><section class='section py2 clearfix'>
 
   <h2 class="section__heading" id='installation' class='mt0'>
     Installation
   </h2>
 
-  
+
     <div class='installation'><code class='command'>npm install --save polished</code></div>
 
-  
+
 </section>
 </div>
-        
-      
-        
+
+
+
           <div class='keyline-top-not py2'><section class='section py2 clearfix'>
 
   <h2 class="section__heading" id='usage' class='mt0'>
     Usage
   </h2>
 
-  
+
     <div class='usage'><code class='javascript'>import { lighten, modularScale } from 'polished'</code></div>
 
-  
+
 </section>
 </div>
-        
-      
-        
+
+
+
           <div class='keyline-top-not py2'><section class='section py2 clearfix'>
 
   <h2 class="section__heading" id='mixins' class='mt0'>
     Mixins
   </h2>
 
-  
-    
 
-  
+
+
+
 </section>
 </div>
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='between'>
       between
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Returns a CSS calc formula for linear interpolation of a property between two values. Accepts optional minScreen (defaults to '320px') and maxScreen (defaults to '1200px').</p>
 
 
   <div class='pre p1 fill-light mt0'>between(fromSize: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, toSize: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, minScreen: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, maxScreen: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>fromSize</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>toSize</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>minScreen</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
             = <code>&#39;320px&#39;</code>)</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>maxScreen</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
             = <code>&#39;1200px&#39;</code>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 const styles = {
   fontSize: between('20px', '100px', '400px', '<span class="hljs-number">1000</span>px'),
@@ -1048,97 +1048,97 @@ h1: {
   'fontSize': 'calc(-33.<span class="hljs-number">33333333333334</span>px + 13.<span class="hljs-number">33333333333333</span>4vw)',
   'fontSize': 'calc(-9.<span class="hljs-number">09090909090909</span>3px + 9.<span class="hljs-number">09090909090909</span>2vw)'
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='clearfix'>
       clearFix
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>CSS to contain a float (credit to CSSMojo).</p>
 
 
   <div class='pre p1 fill-light mt0'>clearFix(parent: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="#styles">Styles</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>parent</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
             = <code>&#39;&amp;&#39;</code>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="#styles">Styles</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
    ...clearFix(),
@@ -1156,97 +1156,97 @@ h1: {
   <span class="hljs-string">'content'</span>: <span class="hljs-string">'""'</span>,
   <span class="hljs-string">'display'</span>: <span class="hljs-string">'table'</span>
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='cover'>
       cover
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>CSS to fully cover an area. Can optionally be passed an offset to act as a "padding".</p>
 
 
   <div class='pre p1 fill-light mt0'>cover(offset: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)): <a href="#styles">Styles</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>offset</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)
             = <code>0</code>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="#styles">Styles</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   ...cover()
@@ -1266,97 +1266,97 @@ div: {
   '</span>bottom<span class="hljs-string">': '</span><span class="hljs-number">0</span><span class="hljs-string">',
   '</span>left: <span class="hljs-string">'0'</span>
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='ellipsis'>
       ellipsis
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>CSS to represent truncated text with an ellipsis.</p>
 
 
   <div class='pre p1 fill-light mt0'>ellipsis(width: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)): <a href="#styles">Styles</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>width</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)
             = <code>&#39;100%&#39;</code>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="#styles">Styles</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 const styles = {
   ...ellipsis(<span class="hljs-string">'250px'</span>)
@@ -1377,114 +1377,114 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
   <span class="hljs-string">'whiteSpace'</span>: <span class="hljs-string">'nowrap'</span>,
   <span class="hljs-string">'wordWrap'</span>: <span class="hljs-string">'normal'</span>
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='fluidrange'>
       fluidRange
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Returns a set of media queries that resizes a property (or set of properties) between a provided fromSize and toSize. Accepts optional minScreen (defaults to '320px') and maxScreen (defaults to '1200px') to constrain the interpolation.</p>
 
 
   <div class='pre p1 fill-light mt0'>fluidRange(cssProp: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#fluidrangeconfiguration">FluidRangeConfiguration</a>> | <a href="#fluidrangeconfiguration">FluidRangeConfiguration</a>), minScreen: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, maxScreen: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="#styles">Styles</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>cssProp</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#fluidrangeconfiguration">FluidRangeConfiguration</a>> | <a href="#fluidrangeconfiguration">FluidRangeConfiguration</a>))</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>minScreen</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
             = <code>&#39;320px&#39;</code>)</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>maxScreen</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
             = <code>&#39;1200px&#39;</code>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="#styles">Styles</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'>// Styles <span class="hljs-keyword">as</span> object usage
 const styles = {
   ...fluidRange(
@@ -1522,66 +1522,66 @@ div: {
   },
   <span class="hljs-string">"padding"</span>: <span class="hljs-string">"20px"</span>,
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='fontface'>
       fontFace
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>CSS for a @font-face declaration.</p>
 
 
   <div class='pre p1 fill-light mt0'>fontFace($0: any): <a href="#styles">Styles</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>$0</span> <code class='quiet'>(any)</code>
-	    
+
           </div>
-          
+
           <table class='mt1 mb2 fixed-table h5 col-12'>
             <colgroup>
               <col width='30%' />
@@ -1594,114 +1594,114 @@ div: {
               </tr>
             </thead>
             <tbody class='mt1'>
-              
+
                 <tr>
                   <td class='break-word'><span class='code bold'>$0.fontFamily</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
-              
+
                 <tr>
                   <td class='break-word'><span class='code bold'>$0.fontFilePath</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
-              
+
                 <tr>
                   <td class='break-word'><span class='code bold'>$0.fontStretch</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
-              
+
                 <tr>
                   <td class='break-word'><span class='code bold'>$0.fontStyle</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
-              
+
                 <tr>
                   <td class='break-word'><span class='code bold'>$0.fontVariant</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
-              
+
                 <tr>
                   <td class='break-word'><span class='code bold'>$0.fontWeight</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
-              
+
                 <tr>
                   <td class='break-word'><span class='code bold'>$0.fileFormats</span> <code class='quiet'>any</code>
-                  
+
                     (default <code>[&#39;eot&#39;,&#39;woff2&#39;,&#39;woff&#39;,&#39;ttf&#39;,&#39;svg&#39;]</code>)
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
-              
+
                 <tr>
                   <td class='break-word'><span class='code bold'>$0.localFonts</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
-              
+
                 <tr>
                   <td class='break-word'><span class='code bold'>$0.unicodeRange</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
-              
+
                 <tr>
                   <td class='break-word'><span class='code bold'>$0.fontDisplay</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
-              
+
                 <tr>
                   <td class='break-word'><span class='code bold'>$0.fontVariationSettings</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
-              
+
                 <tr>
                   <td class='break-word'><span class='code bold'>$0.fontFeatureSettings</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
-              
+
             </tbody>
           </table>
-          
-        </div>
-      
-    </div>
-  
 
-  
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="#styles">Styles</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object basic usage</span>
 <span class="hljs-keyword">const</span> styles = {
    ...fontFace({
@@ -1711,7 +1711,7 @@ div: {
 }
 
 <span class="hljs-comment">// styled-components basic usage</span>
-injectGlobal`${
+createGlobalStyle`${
   fontFace({
     <span class="hljs-symbol">'fontFamily</span>': <span class="hljs-symbol">'Sans</span>-Pro',
     <span class="hljs-symbol">'fontFilePath</span>': <span class="hljs-symbol">'path</span>/to/file'
@@ -1724,88 +1724,88 @@ injectGlobal`${
   <span class="hljs-symbol">'fontFamily</span>': <span class="hljs-symbol">'Sans</span>-Pro',
   <span class="hljs-symbol">'src</span>': <span class="hljs-symbol">'url</span>(<span class="hljs-string">"path/to/file.eot"</span>), url(<span class="hljs-string">"path/to/file.woff2"</span>), url(<span class="hljs-string">"path/to/file.woff"</span>), url(<span class="hljs-string">"path/to/file.ttf"</span>), url(<span class="hljs-string">"path/to/file.svg"</span>)',
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='hidetext'>
       hideText
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>CSS to hide text to show a background image in a SEO-friendly way.</p>
 
 
   <div class='pre p1 fill-light mt0'>hideText(): <a href="#styles">Styles</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
-    </div>
-  
 
-  
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="#styles">Styles</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   <span class="hljs-string">'backgroundImage'</span>: <span class="hljs-string">'url(logo.png)'</span>,
@@ -1826,89 +1826,89 @@ injectGlobal`${
   <span class="hljs-string">'overflow'</span>: <span class="hljs-string">'hidden'</span>,
   <span class="hljs-string">'whiteSpace'</span>: <span class="hljs-string">'nowrap'</span>,
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='hidevisually'>
       hideVisually
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>CSS to hide content visually but remain accessible to screen readers.
 from <a href="https://github.com/h5bp/html5-boilerplate/blob/9a176f57af1cfe8ec70300da4621fb9b07e5fa31/src/css/main.css#L121">HTML5 Boilerplate</a></p>
 
 
   <div class='pre p1 fill-light mt0'>hideVisually(): <a href="#styles">Styles</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
-    </div>
-  
 
-  
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="#styles">Styles</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   ...hideVisually(),
@@ -1933,97 +1933,97 @@ from <a href="https://github.com/h5bp/html5-boilerplate/blob/9a176f57af1cfe8ec70
   <span class="hljs-string">'whiteSpace'</span>: <span class="hljs-string">'nowrap'</span>,
   <span class="hljs-string">'width'</span>: <span class="hljs-string">'1px'</span>,
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='hidpi'>
       hiDPI
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Generates a media query to target HiDPI devices.</p>
 
 
   <div class='pre p1 fill-light mt0'>hiDPI(ratio: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>ratio</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
             = <code>1.3</code>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 const styles = {
  [hiDPI(<span class="hljs-number">1.5</span>)]: {
@@ -2047,95 +2047,95 @@ const div = styled.div`
  only screen <span class="hljs-built_in">and</span> (<span class="hljs-built_in">min</span>-resolution: <span class="hljs-number">1.5</span>dppx)': {
   'width': '<span class="hljs-number">200</span>px',
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='normalize'>
       normalize
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>CSS to normalize abnormalities across browsers (normalize.css v8.0.0 | MIT License | github.com/necolas/normalize.css)</p>
 
 
   <div class='pre p1 fill-light mt0'>normalize(): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#styles">Styles</a>></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
-    </div>
-  
 
-  
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#styles">Styles</a>></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 const styles = {
    ...normalize(),
 }
 
 <span class="hljs-comment">// styled-components usage</span>
-injectGlobal`${normalize()}`
+createGlobalStyle`${normalize()}`
 
 <span class="hljs-comment">// CSS as JS Output</span>
 
@@ -2143,105 +2143,105 @@ html {
   lineHeight: <span class="hljs-number">1.15</span>,
   textSizeAdjust: <span class="hljs-number">100</span>%,
 } ...</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='placeholder'>
       placeholder
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>CSS to style the placeholder pseudo-element.</p>
 
 
   <div class='pre p1 fill-light mt0'>placeholder(styles: <a href="#styles">Styles</a>, parent: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="#styles">Styles</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>styles</span> <code class='quiet'>(<a href="#styles">Styles</a>)</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>parent</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
             = <code>&#39;&amp;&#39;</code>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="#styles">Styles</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'>// Styles <span class="hljs-keyword">as</span> object usage
 const styles = {
   ...placeholder({<span class="hljs-string">'color'</span>: <span class="hljs-string">'blue'</span>})
@@ -2268,66 +2268,66 @@ const div = styled.input`
     <span class="hljs-string">'color'</span>: <span class="hljs-string">'blue'</span>,
   },
 },</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='radialgradient'>
       radialGradient
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>CSS for declaring a radial gradient, including a fallback background-color. The fallback is either the first color-stop or an explicitly passed fallback color.</p>
 
 
   <div class='pre p1 fill-light mt0'>radialGradient($0: any): <a href="#styles">Styles</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>$0</span> <code class='quiet'>(any)</code>
-	    
+
           </div>
-          
+
           <table class='mt1 mb2 fixed-table h5 col-12'>
             <colgroup>
               <col width='30%' />
@@ -2340,70 +2340,70 @@ const div = styled.input`
               </tr>
             </thead>
             <tbody class='mt1'>
-              
+
                 <tr>
                   <td class='break-word'><span class='code bold'>$0.colorStops</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
-              
+
                 <tr>
                   <td class='break-word'><span class='code bold'>$0.extent</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
-              
+
                 <tr>
                   <td class='break-word'><span class='code bold'>$0.fallback</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
-              
+
                 <tr>
                   <td class='break-word'><span class='code bold'>$0.position</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
-              
+
                 <tr>
                   <td class='break-word'><span class='code bold'>$0.shape</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
-              
+
             </tbody>
           </table>
-          
-        </div>
-      
-    </div>
-  
 
-  
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="#styles">Styles</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 const styles = {
   ...radialGradient({
@@ -2430,35 +2430,35 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
   <span class="hljs-string">'backgroundColor'</span>: <span class="hljs-string">'#00FFFF'</span>,
   <span class="hljs-string">'backgroundImage'</span>: <span class="hljs-string">'radial-gradient(center ellipse farthest-corner at 45px 45px, #00FFFF 0%, rgba(0, 0, 255, 0) 50%, #0000FF 95%)'</span>,
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='retinaimage'>
       retinaImage
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>A helper to generate a retina background image and non-retina
 background image. The retina background image will output to a HiDPI media query. The mixin uses
@@ -2466,96 +2466,96 @@ a _2x.png filename suffix by default.</p>
 
 
   <div class='pre p1 fill-light mt0'>retinaImage(filename: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, backgroundSize: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, extension: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, retinaFilename: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, retinaSuffix: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="#styles">Styles</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>filename</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>backgroundSize</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>extension</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
             = <code>&#39;png&#39;</code>)</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>retinaFilename</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>retinaSuffix</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
             = <code>&#39;_2x&#39;</code>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="#styles">Styles</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'>// <span class="hljs-type">Styles</span> <span class="hljs-keyword">as</span> <span class="hljs-keyword">object</span> usage
 <span class="hljs-keyword">const</span> styles = {
  ...retinaImage('my-img')
@@ -2577,105 +2577,105 @@ a _2x.png filename suffix by default.</p>
     backgroundImage: 'url(my-img_2x.png)',
   }
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='selection'>
       selection
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>CSS to style the selection pseudo-element.</p>
 
 
   <div class='pre p1 fill-light mt0'>selection(styles: <a href="#styles">Styles</a>, parent: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="#styles">Styles</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>styles</span> <code class='quiet'>(<a href="#styles">Styles</a>)</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>parent</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
             = <code>&#39;&#39;</code>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="#styles">Styles</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'>// Styles <span class="hljs-keyword">as</span> object usage
 const styles = {
   ...selection({
@@ -2698,96 +2698,96 @@ const div = styled.div`
     <span class="hljs-string">'backgroundColor'</span>: <span class="hljs-string">'blue'</span>,
   }
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='timingfunctions'>
       timingFunctions
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>String to represent common easing functions as demonstrated here: (github.com/jaukia/easie).</p>
 
 
   <div class='pre p1 fill-light mt0'>timingFunctions(timingFunction: <a href="#timingfunction">TimingFunction</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>timingFunction</span> <code class='quiet'>(<a href="#timingfunction">TimingFunction</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   <span class="hljs-string">'transitionTimingFunction'</span>: timingFunctions(<span class="hljs-string">'easeInQuad'</span>)
@@ -2803,66 +2803,66 @@ const div = styled.div`
 <span class="hljs-string">'div'</span>: {
   <span class="hljs-string">'transitionTimingFunction'</span>: <span class="hljs-string">'cubic-bezier(0.550,  0.085, 0.680, 0.530)'</span>,
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='triangle'>
       triangle
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>CSS to represent triangle with any pointing direction with an optional background color. Accepts number or px values for height and width.</p>
 
 
   <div class='pre p1 fill-light mt0'>triangle($0: any): <a href="#styles">Styles</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>$0</span> <code class='quiet'>(any)</code>
-	    
+
           </div>
-          
+
           <table class='mt1 mb2 fixed-table h5 col-12'>
             <colgroup>
               <col width='30%' />
@@ -2875,72 +2875,72 @@ const div = styled.div`
               </tr>
             </thead>
             <tbody class='mt1'>
-              
+
                 <tr>
                   <td class='break-word'><span class='code bold'>$0.pointingDirection</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
-              
+
                 <tr>
                   <td class='break-word'><span class='code bold'>$0.height</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
-              
+
                 <tr>
                   <td class='break-word'><span class='code bold'>$0.width</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
-              
+
                 <tr>
                   <td class='break-word'><span class='code bold'>$0.foregroundColor</span> <code class='quiet'>any</code>
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
-              
+
                 <tr>
                   <td class='break-word'><span class='code bold'>$0.backgroundColor</span> <code class='quiet'>any</code>
-                  
+
                     (default <code>&#39;transparent&#39;</code>)
                   </td>
                   <td class='break-word'><span></span></td>
                 </tr>
-              
+
             </tbody>
           </table>
-          
-        </div>
-      
-    </div>
-  
 
-  
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="#styles">Styles</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 
 const styles = {
@@ -2963,97 +2963,97 @@ div:</span> {
  <span class="hljs-string">'height'</span>: <span class="hljs-string">'0'</span>,
  <span class="hljs-string">'width'</span>: <span class="hljs-string">'0'</span>,
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='wordwrap'>
       wordWrap
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Provides an easy way to change the <code>wordWrap</code> property.</p>
 
 
   <div class='pre p1 fill-light mt0'>wordWrap(wrap: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="#styles">Styles</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>wrap</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
             = <code>&#39;break-word&#39;</code>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="#styles">Styles</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   ...wordWrap(<span class="hljs-string">'break-word'</span>)
@@ -3071,50 +3071,50 @@ div:</span> {
   <span class="hljs-attr">wordWrap</span>: <span class="hljs-string">'break-word'</span>,
   <span class="hljs-attr">wordBreak</span>: <span class="hljs-string">'break-all'</span>,
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <div class='keyline-top-not py2'><section class='section py2 clearfix'>
 
   <h2 class="section__heading" id='color' class='mt0'>
     Color
   </h2>
 
-  
-    
 
-  
+
+
+
 </section>
 </div>
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='adjusthue'>
       adjustHue
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Changes the hue of the color. Hue is a number between 0 to 360. The first
 argument for adjustHue is the amount of degrees the color is rotated along
@@ -3122,70 +3122,70 @@ the color wheel.</p>
 
 
   <div class='pre p1 fill-light mt0'>adjustHue(degree: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), color: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>degree</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>))</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>color</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   <span class="hljs-built_in">background</span>: adjustHue(<span class="hljs-number">180</span>, <span class="hljs-string">'#448'</span>),
@@ -3203,96 +3203,96 @@ element {
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"#888844"</span>;
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"rgba(136,136,68,0.7)"</span>;
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='complement'>
       complement
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Returns the complement of the provided color. This is identical to adjustHue(180, <color>).</p>
 
 
   <div class='pre p1 fill-light mt0'>complement(color: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>color</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   <span class="hljs-built_in">background</span>: complement(<span class="hljs-string">'#448'</span>),
@@ -3310,104 +3310,104 @@ element {
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"#884"</span>;
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"rgba(153,153,153,0.7)"</span>;
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='darken'>
       darken
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Returns a string value for the darkened color.</p>
 
 
   <div class='pre p1 fill-light mt0'>darken(amount: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), color: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>amount</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>))</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>color</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   <span class="hljs-built_in">background</span>: darken(<span class="hljs-number">0.2</span>, <span class="hljs-string">'#FFCD64'</span>),
@@ -3426,35 +3426,35 @@ element {
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"#ffbd31"</span>;
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"rgba(255,189,49,0.7)"</span>;
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='desaturate'>
       desaturate
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Decreases the intensity of a color. Its range is between 0 to 1. The first
 argument of the desaturate function is the amount by how much the color
@@ -3462,70 +3462,70 @@ intensity should be decreased.</p>
 
 
   <div class='pre p1 fill-light mt0'>desaturate(amount: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), color: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>amount</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>))</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>color</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   <span class="hljs-built_in">background</span>: desaturate(<span class="hljs-number">0.2</span>, <span class="hljs-string">'#CCCD64'</span>),
@@ -3543,96 +3543,96 @@ element {
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"#b8b979"</span>;
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"rgba(184,185,121,0.7)"</span>;
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='getluminance'>
       getLuminance
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Returns a number (float) representing the luminance of a color.</p>
 
 
   <div class='pre p1 fill-light mt0'>getLuminance(color: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>color</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   <span class="hljs-built_in">background</span>: getLuminance(<span class="hljs-string">'#CCCD64'</span>) &gt;= getLuminance(<span class="hljs-string">'#0000ff'</span>) ? <span class="hljs-string">'#CCCD64'</span> : <span class="hljs-string">'#0000ff'</span>,
@@ -3654,96 +3654,96 @@ div {
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"#CCCD64"</span>;
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"rgba(58, 133, 255, 1)"</span>;
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='grayscale'>
       grayscale
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Converts the color to a grayscale, by reducing its saturation to 0.</p>
 
 
   <div class='pre p1 fill-light mt0'>grayscale(color: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>color</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   <span class="hljs-built_in">background</span>: grayscale(<span class="hljs-string">'#CCCD64'</span>),
@@ -3761,112 +3761,112 @@ element {
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"#999"</span>;
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"rgba(153,153,153,0.7)"</span>;
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='hsl'>
       hsl
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Returns a string value for the color. The returned result is the smallest possible hex notation.</p>
 
 
   <div class='pre p1 fill-light mt0'>hsl(value: (<a href="#hslcolor">HslColor</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>), saturation: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, lightness: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>value</span> <code class='quiet'>((<a href="#hslcolor">HslColor</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>))</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>saturation</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>lightness</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   <span class="hljs-built_in">background</span>: hsl(<span class="hljs-number">359</span>, <span class="hljs-number">0.75</span>, <span class="hljs-number">0.4</span>),
@@ -3885,120 +3885,120 @@ element {
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"#b3191c"</span>;
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"#b3191c"</span>;
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='hsla'>
       hsla
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Returns a string value for the color. The returned result is the smallest possible rgba or hex notation.</p>
 
 
   <div class='pre p1 fill-light mt0'>hsla(value: (<a href="#hslacolor">HslaColor</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>), saturation: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, lightness: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, alpha: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>value</span> <code class='quiet'>((<a href="#hslacolor">HslaColor</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>))</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>saturation</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>lightness</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>alpha</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   <span class="hljs-built_in">background</span>: hsla(<span class="hljs-number">359</span>, <span class="hljs-number">0.75</span>, <span class="hljs-number">0.4</span>, <span class="hljs-number">0.7</span>),
@@ -4020,96 +4020,96 @@ element {
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"rgba(179,25,28,0.7)"</span>;
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"#b3191c"</span>;
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='invert'>
       invert
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Inverts the red, green and blue values of a color.</p>
 
 
   <div class='pre p1 fill-light mt0'>invert(color: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>color</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   <span class="hljs-built_in">background</span>: invert(<span class="hljs-string">'#CCCD64'</span>),
@@ -4128,104 +4128,104 @@ element {
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"#33329b"</span>;
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"rgba(154,155,50,0.7)"</span>;
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='lighten'>
       lighten
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Returns a string value for the lightened color.</p>
 
 
   <div class='pre p1 fill-light mt0'>lighten(amount: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), color: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>amount</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>))</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>color</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   <span class="hljs-built_in">background</span>: lighten(<span class="hljs-number">0.2</span>, <span class="hljs-string">'#CCCD64'</span>),
@@ -4244,112 +4244,112 @@ element {
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"#e5e6b1"</span>;
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"rgba(229,230,177,0.7)"</span>;
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='mix'>
       mix
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Mixes the two provided colors together by calculating the average of each of the RGB components weighted to the first color by the provided weight.</p>
 
 
   <div class='pre p1 fill-light mt0'>mix(weight: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), color: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, otherColor: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>weight</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>))</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>color</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>otherColor</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   <span class="hljs-built_in">background</span>: mix(<span class="hljs-number">0.5</span>, <span class="hljs-string">'#f00'</span>, <span class="hljs-string">'#00f'</span>)
@@ -4371,104 +4371,104 @@ element {
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"#3f00bf"</span>;
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"rgba(63, 0, 191, 0.75)"</span>;
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='opacify'>
       opacify
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Increases the opacity of a color. Its range for the amount is between 0 to 1.</p>
 
 
   <div class='pre p1 fill-light mt0'>opacify(amount: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), color: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>amount</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>))</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>color</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   <span class="hljs-built_in">background</span>: opacify(<span class="hljs-number">0.1</span>, <span class="hljs-string">'rgba(255, 255, 255, 0.9)'</span>);
@@ -4490,35 +4490,35 @@ element {
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"rgba(255,255,255,0.7)"</span>;
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"rgba(255,0,0,0.7)"</span>;
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='parsetohsl'>
       parseToHsl
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Returns an HslColor or HslaColor object. This utility function is only useful
 if want to extract a color component. With the color util <code>toColorString</code> you
@@ -4526,95 +4526,95 @@ can convert a HslColor or HslaColor object back to a string.</p>
 
 
   <div class='pre p1 fill-light mt0'>parseToHsl(color: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): (<a href="#hslcolor">HslColor</a> | <a href="#hslacolor">HslaColor</a>)</div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>color</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code>(<a href="#hslcolor">HslColor</a> | <a href="#hslacolor">HslaColor</a>)</code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Assigns `{ hue: 0, saturation: 1, lightness: 0.5 }` to color1</span>
 const color1 = parseToHsl('rgb(<span class="hljs-number">255</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>)');
 <span class="hljs-comment">// Assigns `{ hue: 128, saturation: 1, lightness: 0.5, alpha: 0.75 }` to color2</span>
 const color2 = parseToHsl('hsla(<span class="hljs-number">128</span>, <span class="hljs-number">100</span>%, <span class="hljs-number">50</span>%, <span class="hljs-number">0.75</span>)');</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='parsetorgb'>
       parseToRgb
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Returns an RgbColor or RgbaColor object. This utility function is only useful
 if want to extract a color component. With the color util <code>toColorString</code> you
@@ -4622,157 +4622,157 @@ can convert a RgbColor or RgbaColor object back to a string.</p>
 
 
   <div class='pre p1 fill-light mt0'>parseToRgb(color: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): (<a href="#rgbcolor">RgbColor</a> | <a href="#rgbacolor">RgbaColor</a>)</div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>color</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code>(<a href="#rgbcolor">RgbColor</a> | <a href="#rgbacolor">RgbaColor</a>)</code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Assigns `{ red: 255, green: 0, blue: 0 }` to color1</span>
 const color1 = parseToRgb('rgb(<span class="hljs-number">255</span>, <span class="hljs-number">0</span>, <span class="hljs-number">0</span>)');
 <span class="hljs-comment">// Assigns `{ red: 92, green: 102, blue: 112, alpha: 0.75 }` to color2</span>
 const color2 = parseToRgb('hsla(<span class="hljs-number">210</span>, <span class="hljs-number">10</span>%, <span class="hljs-number">40</span>%, <span class="hljs-number">0.75</span>)');</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='readablecolor'>
       readableColor
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Returns black or white for best contrast depending on the luminosity of the given color.
 Follows W3C specs for readability at <a href="https://www.w3.org/TR/WCAG20-TECHS/G18.html">https://www.w3.org/TR/WCAG20-TECHS/G18.html</a></p>
 
 
   <div class='pre p1 fill-light mt0'>readableColor(color: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>color</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   <span class="hljs-built_in">color</span>: readableColor(<span class="hljs-string">'#000'</span>),
@@ -4794,112 +4794,112 @@ element {
   <span class="hljs-built_in">color</span>: <span class="hljs-string">"#fff"</span>;
   <span class="hljs-built_in">color</span>: <span class="hljs-string">"#000"</span>;
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='rgb'>
       rgb
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Returns a string value for the color. The returned result is the smallest possible hex notation.</p>
 
 
   <div class='pre p1 fill-light mt0'>rgb(value: (<a href="#rgbcolor">RgbColor</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>), green: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, blue: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>value</span> <code class='quiet'>((<a href="#rgbcolor">RgbColor</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>))</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>green</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>blue</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   <span class="hljs-built_in">background</span>: rgb(<span class="hljs-number">255</span>, <span class="hljs-number">205</span>, <span class="hljs-number">100</span>),
@@ -4918,121 +4918,121 @@ element {
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"#ffcd64"</span>;
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"#ffcd64"</span>;
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='rgba'>
       rgba
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Returns a string value for the color. The returned result is the smallest possible rgba or hex notation.</p>
 <p>Can also be used to fade a color by passing a hex value or named CSS color along with an alpha value.</p>
 
 
   <div class='pre p1 fill-light mt0'>rgba(firstValue: (<a href="#rgbacolor">RgbaColor</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), secondValue: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, thirdValue: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, fourthValue: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>firstValue</span> <code class='quiet'>((<a href="#rgbacolor">RgbaColor</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>))</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>secondValue</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>thirdValue</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>fourthValue</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   <span class="hljs-built_in">background</span>: rgba(<span class="hljs-number">255</span>, <span class="hljs-number">205</span>, <span class="hljs-number">100</span>, <span class="hljs-number">0.7</span>),
@@ -5060,35 +5060,35 @@ element {
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"rgba(255,255,255,0.4)"</span>;
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"rgba(0,0,0,0.7)"</span>;
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='saturate'>
       saturate
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Increases the intensity of a color. Its range is between 0 to 1. The first
 argument of the saturate function is the amount by how much the color
@@ -5096,70 +5096,70 @@ intensity should be increased.</p>
 
 
   <div class='pre p1 fill-light mt0'>saturate(amount: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), color: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>amount</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>))</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>color</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   <span class="hljs-built_in">background</span>: saturate(<span class="hljs-number">0.2</span>, <span class="hljs-string">'#CCCD64'</span>),
@@ -5178,105 +5178,105 @@ element {
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"#e0e250"</span>;
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"rgba(224,226,80,0.7)"</span>;
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='sethue'>
       setHue
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Sets the hue of a color to the provided value. The hue range can be
 from 0 and 359.</p>
 
 
   <div class='pre p1 fill-light mt0'>setHue(hue: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), color: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>hue</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>))</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>color</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   <span class="hljs-built_in">background</span>: setHue(<span class="hljs-number">42</span>, <span class="hljs-string">'#CCCD64'</span>),
@@ -5294,105 +5294,105 @@ element {
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"#cdae64"</span>;
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"rgba(107,100,205,0.7)"</span>;
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='setlightness'>
       setLightness
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Sets the lightness of a color to the provided value. The lightness range can be
 from 0 and 1.</p>
 
 
   <div class='pre p1 fill-light mt0'>setLightness(lightness: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), color: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>lightness</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>))</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>color</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   <span class="hljs-built_in">background</span>: setLightness(<span class="hljs-number">0.2</span>, <span class="hljs-string">'#CCCD64'</span>),
@@ -5410,105 +5410,105 @@ element {
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"#4d4d19"</span>;
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"rgba(223,224,159,0.7)"</span>;
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='setsaturation'>
       setSaturation
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Sets the saturation of a color to the provided value. The lightness range can be
 from 0 and 1.</p>
 
 
   <div class='pre p1 fill-light mt0'>setSaturation(saturation: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), color: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>saturation</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>))</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>color</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   <span class="hljs-built_in">background</span>: setSaturation(<span class="hljs-number">0.2</span>, <span class="hljs-string">'#CCCD64'</span>),
@@ -5526,35 +5526,35 @@ element {
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"#adad84"</span>;
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"rgba(228,229,76,0.7)"</span>;
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='shade'>
       shade
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Shades a color by mixing it with black. <code>shade</code> can produce
 hue shifts, where as <code>darken</code> manipulates the luminance channel and therefore
@@ -5562,70 +5562,70 @@ doesn't produce hue shifts.</p>
 
 
   <div class='pre p1 fill-light mt0'>shade(percentage: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), color: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>percentage</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>))</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>color</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   <span class="hljs-built_in">background</span>: shade(<span class="hljs-number">0.25</span>, <span class="hljs-string">'#00f'</span>)
@@ -5641,35 +5641,35 @@ doesn't produce hue shifts.</p>
 element {
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"#00003f"</span>;
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='tint'>
       tint
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Tints a color by mixing it with white. <code>tint</code> can produce
 hue shifts, where as <code>lighten</code> manipulates the luminance channel and therefore
@@ -5677,70 +5677,70 @@ doesn't produce hue shifts.</p>
 
 
   <div class='pre p1 fill-light mt0'>tint(percentage: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), color: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>percentage</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>))</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>color</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   <span class="hljs-built_in">background</span>: <span class="hljs-built_in">tint</span>(<span class="hljs-number">0.25</span>, <span class="hljs-string">'#00f'</span>)
@@ -5756,35 +5756,35 @@ doesn't produce hue shifts.</p>
 element {
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"#bfbfff"</span>;
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='tocolorstring'>
       toColorString
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Converts a RgbColor, RgbaColor, HslColor or HslaColor object to a color string.
 This util is useful in case you only know on runtime which color object is
@@ -5792,62 +5792,62 @@ used. Otherwise we recommend to rely on <code>rgb</code>, <code>rgba</code>, <co
 
 
   <div class='pre p1 fill-light mt0'>toColorString(color: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>color</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   <span class="hljs-built_in">background</span>: toColorString({ <span class="hljs-built_in">red</span>: <span class="hljs-number">255</span>, <span class="hljs-built_in">green</span>: <span class="hljs-number">205</span>, <span class="hljs-built_in">blue</span>: <span class="hljs-number">100</span> }),
@@ -5871,104 +5871,104 @@ element {
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"#00f"</span>;
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"rgba(179,25,25,0.72)"</span>;
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='transparentize'>
       transparentize
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Decreases the opacity of a color. Its range for the amount is between 0 to 1.</p>
 
 
   <div class='pre p1 fill-light mt0'>transparentize(amount: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), color: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>amount</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>))</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>color</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   <span class="hljs-built_in">background</span>: transparentize(<span class="hljs-number">0.1</span>, <span class="hljs-string">'#fff'</span>);
@@ -5990,112 +5990,112 @@ element {
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"rgba(255,255,255,0.8)"</span>;
   <span class="hljs-built_in">background</span>: <span class="hljs-string">"rgba(255,0,0,0.3)"</span>;
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <div class='keyline-top-not py2'><section class='section py2 clearfix'>
 
   <h2 class="section__heading" id='shorthands' class='mt0'>
     Shorthands
   </h2>
 
-  
-    
 
-  
+
+
+
 </section>
 </div>
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='animation'>
       animation
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Shorthand for easily setting the animation property. Allows either multiple arrays with animations
 or a single animation spread over the arguments.</p>
 
 
   <div class='pre p1 fill-light mt0'>animation(args: ...<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)>): <a href="#styles">Styles</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>args</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="#styles">Styles</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 const styles = {
   ...<span class="hljs-attribute">animation</span>([<span class="hljs-string">'rotate'</span>, <span class="hljs-string">'1s'</span>, <span class="hljs-string">'ease-in-out'</span>], [<span class="hljs-string">'colorchange'</span>, <span class="hljs-string">'2s'</span>])
@@ -6111,8 +6111,8 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
 <span class="hljs-selector-tag">div</span> {
   <span class="hljs-string">'animation'</span>: <span class="hljs-string">'rotate 1s ease-in-out, colorchange 2s'</span>
 }</pre>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 const styles = {
   ...<span class="hljs-attribute">animation</span>(<span class="hljs-string">'rotate'</span>, <span class="hljs-string">'1s'</span>, <span class="hljs-string">'ease-in-out'</span>)
@@ -6128,96 +6128,96 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
 <span class="hljs-selector-tag">div</span> {
   <span class="hljs-string">'animation'</span>: <span class="hljs-string">'rotate 1s ease-in-out'</span>
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='backgroundimages'>
       backgroundImages
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Shorthand that accepts any number of backgroundImage values as parameters for creating a single background statement.</p>
 
 
   <div class='pre p1 fill-light mt0'>backgroundImages(properties: ...<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>): <a href="#styles">Styles</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>properties</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="#styles">Styles</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   ...backgroundImages(<span class="hljs-symbol">'url</span>(<span class="hljs-string">"/image/background.jpg"</span>)', <span class="hljs-symbol">'linear</span>-gradient(red, green)')
@@ -6233,96 +6233,96 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
 div {
   <span class="hljs-symbol">'backgroundImage</span>': <span class="hljs-symbol">'url</span>(<span class="hljs-string">"/image/background.jpg"</span>), linear-gradient(red, green)'
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='backgrounds'>
       backgrounds
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Shorthand that accepts any number of background values as parameters for creating a single background statement.</p>
 
 
   <div class='pre p1 fill-light mt0'>backgrounds(properties: ...<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>): <a href="#styles">Styles</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>properties</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="#styles">Styles</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   ...backgrounds(<span class="hljs-symbol">'url</span>(<span class="hljs-string">"/image/background.jpg"</span>)', <span class="hljs-symbol">'linear</span>-gradient(red, green)', <span class="hljs-symbol">'center</span> no-repeat')
@@ -6338,104 +6338,104 @@ div {
 div {
   <span class="hljs-symbol">'background</span>': <span class="hljs-symbol">'url</span>(<span class="hljs-string">"/image/background.jpg"</span>), linear-gradient(red, green), center no-repeat'
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='border'>
       border
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Shorthand for the border property that splits out individual properties for use with tools like Fela and Styletron. A side keyword can optionally be passed to target only one side's border properties.</p>
 
 
   <div class='pre p1 fill-light mt0'>border(sideKeyword: (<a href="#sidekeyword">SideKeyword</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>), values: ...<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)>): <a href="#styles">Styles</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>sideKeyword</span> <code class='quiet'>((<a href="#sidekeyword">SideKeyword</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>))</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>values</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="#styles">Styles</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 const styles = {
   ...<span class="hljs-attribute">border</span>(<span class="hljs-string">'1px'</span>, <span class="hljs-string">'solid'</span>, <span class="hljs-string">'red'</span>)
@@ -6471,96 +6471,96 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
   <span class="hljs-string">'borderTopStyle'</span>: <span class="hljs-string">'solid'</span>,
   <span class="hljs-string">'borderTopWidth'</span>: `<span class="hljs-number">1px</span>`,
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='bordercolor'>
       borderColor
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Shorthand that accepts up to four values, including null to skip a value, and maps them to their respective directions.</p>
 
 
   <div class='pre p1 fill-light mt0'>borderColor(values: ...<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>): <a href="#styles">Styles</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>values</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="#styles">Styles</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 const styles = {
   ...borderColor(<span class="hljs-string">'red'</span>, <span class="hljs-string">'green'</span>, <span class="hljs-string">'blue'</span>, <span class="hljs-string">'yellow'</span>)
@@ -6579,104 +6579,104 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
   <span class="hljs-string">'borderBottomColor'</span>: <span class="hljs-string">'blue'</span>,
   <span class="hljs-string">'borderLeftColor'</span>: <span class="hljs-string">'yellow'</span>
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='borderradius'>
       borderRadius
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Shorthand that accepts a value for side and a value for radius and applies the radius value to both corners of the side.</p>
 
 
   <div class='pre p1 fill-light mt0'>borderRadius(side: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, radius: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)): <a href="#styles">Styles</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>side</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>radius</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>))</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="#styles">Styles</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 const styles = {
   ...borderRadius(<span class="hljs-string">'top'</span>, <span class="hljs-string">'5px'</span>)
@@ -6693,96 +6693,96 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
   <span class="hljs-string">'borderTopRightRadius'</span>: <span class="hljs-string">'5px'</span>,
   <span class="hljs-string">'borderTopLeftRadius'</span>: <span class="hljs-string">'5px'</span>,
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='borderstyle'>
       borderStyle
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Shorthand that accepts up to four values, including null to skip a value, and maps them to their respective directions.</p>
 
 
   <div class='pre p1 fill-light mt0'>borderStyle(values: ...<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>): <a href="#styles">Styles</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>values</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="#styles">Styles</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 const styles = {
   ...borderStyle(<span class="hljs-string">'solid'</span>, <span class="hljs-string">'dashed'</span>, <span class="hljs-string">'dotted'</span>, <span class="hljs-string">'double'</span>)
@@ -6801,96 +6801,96 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
   <span class="hljs-string">'borderBottomStyle'</span>: <span class="hljs-string">'dotted'</span>,
   <span class="hljs-string">'borderLeftStyle'</span>: <span class="hljs-string">'double'</span>
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='borderwidth'>
       borderWidth
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Shorthand that accepts up to four values, including null to skip a value, and maps them to their respective directions.</p>
 
 
   <div class='pre p1 fill-light mt0'>borderWidth(values: ...<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>? | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?)>): <a href="#styles">Styles</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>values</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>? | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?)>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="#styles">Styles</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 const styles = {
   ...borderWidth(<span class="hljs-string">'12px'</span>, <span class="hljs-string">'24px'</span>, <span class="hljs-string">'36px'</span>, <span class="hljs-string">'48px'</span>)
@@ -6909,96 +6909,96 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
   <span class="hljs-string">'borderBottomWidth'</span>: <span class="hljs-string">'36px'</span>,
   <span class="hljs-string">'borderLeftWidth'</span>: <span class="hljs-string">'48px'</span>
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='buttons'>
       buttons
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Populates selectors that target all buttons. You can pass optional states to append to the selectors.</p>
 
 
   <div class='pre p1 fill-light mt0'>buttons(states: ...<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#interactionstate">InteractionState</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>states</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#interactionstate">InteractionState</a>>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 const styles = {
   [buttons(<span class="hljs-symbol">'activ</span>e')]: {
@@ -7021,96 +7021,96 @@ const div = styled.div`
  <span class="hljs-symbol">'input</span>[<span class="hljs-class"><span class="hljs-keyword">type</span><span class="hljs-title">=\</span>"<span class="hljs-title">submit\</span>"]</span>:active: {
   <span class="hljs-symbol">'borde</span>r': <span class="hljs-symbol">'non</span>e'
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='margin'>
       margin
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Shorthand that accepts up to four values, including null to skip a value, and maps them to their respective directions.</p>
 
 
   <div class='pre p1 fill-light mt0'>margin(values: ...<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>? | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?)>): <a href="#styles">Styles</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>values</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>? | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?)>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="#styles">Styles</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 const styles = {
   ...<span class="hljs-attribute">margin</span>(<span class="hljs-string">'12px'</span>, <span class="hljs-string">'24px'</span>, <span class="hljs-string">'36px'</span>, <span class="hljs-string">'48px'</span>)
@@ -7129,96 +7129,96 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
   <span class="hljs-string">'marginBottom'</span>: <span class="hljs-string">'36px'</span>,
   <span class="hljs-string">'marginLeft'</span>: <span class="hljs-string">'48px'</span>
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='padding'>
       padding
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Shorthand that accepts up to four values, including null to skip a value, and maps them to their respective directions.</p>
 
 
   <div class='pre p1 fill-light mt0'>padding(values: ...<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>? | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?)>): <a href="#styles">Styles</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>values</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>? | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?)>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="#styles">Styles</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 const styles = {
   ...<span class="hljs-attribute">padding</span>(<span class="hljs-string">'12px'</span>, <span class="hljs-string">'24px'</span>, <span class="hljs-string">'36px'</span>, <span class="hljs-string">'48px'</span>)
@@ -7237,104 +7237,104 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
   <span class="hljs-string">'paddingBottom'</span>: <span class="hljs-string">'36px'</span>,
   <span class="hljs-string">'paddingLeft'</span>: <span class="hljs-string">'48px'</span>
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='position'>
       position
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Shorthand accepts up to five values, including null to skip a value, and maps them to their respective directions. The first value can optionally be a position keyword.</p>
 
 
   <div class='pre p1 fill-light mt0'>position(positionKeyword: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | null), values: ...<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>? | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?)>): <a href="#styles">Styles</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>positionKeyword</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | null))</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>values</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>? | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?)>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="#styles">Styles</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 const styles = {
   ...<span class="hljs-attribute">position</span>(<span class="hljs-string">'12px'</span>, <span class="hljs-string">'24px'</span>, <span class="hljs-string">'36px'</span>, <span class="hljs-string">'48px'</span>)
@@ -7373,105 +7373,105 @@ const <span class="hljs-selector-tag">div</span> = styled.div`
   <span class="hljs-string">'bottom'</span>: <span class="hljs-string">'36px'</span>,
   <span class="hljs-string">'left'</span>: <span class="hljs-string">'48px'</span>
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='size'>
       size
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Shorthand to set the height and width properties in a single statement.</p>
 
 
   <div class='pre p1 fill-light mt0'>size(height: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>), width: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)): <a href="#styles">Styles</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>height</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>))</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>width</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)
             = <code>height</code>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="#styles">Styles</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 const styles = {
   ...<span class="hljs-keyword">size</span>(<span class="hljs-string">'300px'</span>, <span class="hljs-string">'250px'</span>)
@@ -7488,96 +7488,96 @@ const <span class="hljs-keyword">div</span> = styled.<span class="hljs-keyword">
   <span class="hljs-string">'height'</span>: <span class="hljs-string">'300px'</span>,
   <span class="hljs-string">'width'</span>: <span class="hljs-string">'250px'</span>,
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='textinputs'>
       textInputs
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Populates selectors that target all text inputs. You can pass optional states to append to the selectors.</p>
 
 
   <div class='pre p1 fill-light mt0'>textInputs(states: ...<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#interactionstate">InteractionState</a>>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>states</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="#interactionstate">InteractionState</a>>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 const styles = {
   [textInputs(<span class="hljs-symbol">'activ</span>e')]: {
@@ -7612,96 +7612,96 @@ const div = styled.div`
  textarea:active': {
   <span class="hljs-symbol">'borde</span>r': <span class="hljs-symbol">'non</span>e'
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='transitions'>
       transitions
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Accepts any number of transition values as parameters for creating a single transition statement. You may also pass an array of properties as the first parameter that you would like to apply the same tranisition values to (second parameter).</p>
 
 
   <div class='pre p1 fill-light mt0'>transitions(properties: ...<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>)>): <a href="#styles">Styles</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>properties</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>)>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="#styles">Styles</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   ...transitions(<span class="hljs-symbol">'opacity</span> <span class="hljs-number">1.0</span>s ease-<span class="hljs-keyword">in</span> <span class="hljs-number">0</span>s', <span class="hljs-symbol">'width</span> <span class="hljs-number">2.0</span>s ease-<span class="hljs-keyword">in</span> <span class="hljs-number">2</span>s'),
@@ -7720,119 +7720,119 @@ div {
   <span class="hljs-symbol">'transition</span>': <span class="hljs-symbol">'opacity</span> <span class="hljs-number">1.0</span>s ease-<span class="hljs-keyword">in</span> <span class="hljs-number">0</span>s, width <span class="hljs-number">2.0</span>s ease-<span class="hljs-keyword">in</span> <span class="hljs-number">2</span>s'
   <span class="hljs-symbol">'transition</span>': <span class="hljs-symbol">'color</span> <span class="hljs-number">2.0</span>s ease-<span class="hljs-keyword">in</span> <span class="hljs-number">2</span>s, background-color <span class="hljs-number">2.0</span>s ease-<span class="hljs-keyword">in</span> <span class="hljs-number">2</span>s',
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <div class='keyline-top-not py2'><section class='section py2 clearfix'>
 
   <h2 class="section__heading" id='helpers' class='mt0'>
     Helpers
   </h2>
 
-  
-    
 
-  
+
+
+
 </section>
 </div>
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='directionalproperty'>
       directionalProperty
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Enables shorthand for direction-based properties. It accepts a property (hyphenated or camelCased) and up to four values that map to top, right, bottom, and left, respectively. You can optionally pass an empty string to get only the directional values as properties. You can also optionally pass a null argument for a directional value to ignore it.</p>
 
 
   <div class='pre p1 fill-light mt0'>directionalProperty(property: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, values: ...<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>? | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?)>): <a href="#styles">Styles</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>property</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>values</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>? | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?)>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="#styles">Styles</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 const styles = {
   ...directionalProperty(<span class="hljs-string">'padding'</span>, <span class="hljs-string">'12px'</span>, <span class="hljs-string">'24px'</span>, <span class="hljs-string">'36px'</span>, <span class="hljs-string">'48px'</span>)
@@ -7851,108 +7851,108 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
   <span class="hljs-string">'paddingBottom'</span>: <span class="hljs-string">'36px'</span>,
   <span class="hljs-string">'paddingLeft'</span>: <span class="hljs-string">'48px'</span>
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='em'>
       em
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Convert pixel value to ems. The default base value is 16px, but can be changed by passing a
 second argument to the function.</p>
 
 
   <div class='pre p1 fill-light mt0'>em(pxval: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>), base: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>))</div>
-  
+
     <p>
       Type:
       function (value: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>), base: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     </p>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>pxval</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>))</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>base</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)
             = <code>&#39;16px&#39;</code>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
+
     </div>
-  
 
-  
-    
-  
 
-  
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   <span class="hljs-string">'height'</span>: em(<span class="hljs-string">'16px'</span>)
@@ -7968,96 +7968,96 @@ second argument to the function.</p>
 element {
   <span class="hljs-string">'height'</span>: <span class="hljs-string">'1em'</span>
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='getvalueandunit'>
       getValueAndUnit
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Returns a given CSS value and its unit as elements of an array.</p>
 
 
   <div class='pre p1 fill-light mt0'>getValueAndUnit(value: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): [(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | void)]</div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>value</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code>[(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | void)]</code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   <span class="hljs-string">'--dimension'</span>: getValueAndUnit(<span class="hljs-string">'100px'</span>)[<span class="hljs-number">0</span>]
@@ -8076,114 +8076,114 @@ element {
   <span class="hljs-string">'--dimension'</span>: <span class="hljs-number">100</span>
   <span class="hljs-string">'--unit'</span>: <span class="hljs-string">'px'</span>
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='modularscale'>
       modularScale
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Establish consistent measurements and spacial relationships throughout your projects by incrementing up or down a defined scale. We provide a list of commonly used scales as pre-defined variables.</p>
 
 
   <div class='pre p1 fill-light mt0'>modularScale(steps: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, base: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), ratio: <a href="#modularscaleratio">ModularScaleRatio</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>steps</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>base</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)
             = <code>&#39;1em&#39;</code>)</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>ratio</span> <code class='quiet'>(<a href="#modularscaleratio">ModularScaleRatio</a>
             = <code>&#39;perfectFourth&#39;</code>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code><a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 const styles = {
    <span class="hljs-comment">// Increment two steps up the default scale</span>
@@ -8201,108 +8201,108 @@ const <span class="hljs-built-in">div</span> = styled.<span class="hljs-built-in
 element {
   <span class="hljs-string">'fontSize'</span>: <span class="hljs-string">'1.77689em'</span>
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='rem'>
       rem
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Convert pixel value to rems. The default base value is 16px, but can be changed by passing a
 second argument to the function.</p>
 
 
   <div class='pre p1 fill-light mt0'>rem(pxval: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>), base: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>))</div>
-  
+
     <p>
       Type:
       function (value: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>), base: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
     </p>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>pxval</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>))</code>
-	    
+
           </div>
-          
+
         </div>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>base</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)
             = <code>&#39;16px&#39;</code>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
+
     </div>
-  
 
-  
-    
-  
 
-  
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   <span class="hljs-string">'height'</span>: rem(<span class="hljs-string">'16px'</span>)
@@ -8318,96 +8318,96 @@ second argument to the function.</p>
 element {
   <span class="hljs-string">'height'</span>: <span class="hljs-string">'1rem'</span>
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='stripunit'>
       stripUnit
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
+
   </div>
-  
+
 
   <p>Returns a given CSS value minus its unit (or the original value if an invalid string is passed).</p>
 
 
   <div class='pre p1 fill-light mt0'>stripUnit(value: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</div>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
+
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>value</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    
-          </div>
-          
-        </div>
-      
-    </div>
-  
 
-  
+          </div>
+
+        </div>
+
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
-    </div>
-  
 
-  
-    
+    </div>
+
+
+
+
       <div class='py1 quiet mt1 prose-big'>Returns</div>
       <code>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-    
-  
 
-  
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
-    </ul>
-  
 
-  
+    </ul>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-      
+
+
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
   <span class="hljs-string">'--dimension'</span>: stripUnit(<span class="hljs-string">'100px'</span>)
@@ -8423,1569 +8423,1569 @@ element {
 element {
   <span class="hljs-string">'--dimension'</span>: <span class="hljs-number">100</span>
 }</pre>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <div class='keyline-top-not py2'><section class='section py2 clearfix'>
 
   <h2 class="section__heading" id='types' class='mt0'>
     Types
   </h2>
 
-  
-    
 
-  
+
+
+
 </section>
 </div>
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='fluidrangeconfiguration'>
       FluidRangeConfiguration
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
-  </div>
-  
 
-  
+  </div>
+
+
+
 
   <div class='pre p1 fill-light mt0'>FluidRangeConfiguration</div>
-  
+
     <p>
       Type:
       {prop: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, fromSize: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, toSize: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>}
     </p>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
-    </div>
-  
 
-  
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>prop</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>fromSize</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>toSize</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>prop</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>fromSize</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>toSize</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-          
-          
+
+
         </div>
-      
+
     </div>
-  
 
-  
-    
-  
 
-  
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
+
     </ul>
-  
 
-  
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='fontfaceconfiguration'>
       FontFaceConfiguration
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
-  </div>
-  
 
-  
+  </div>
+
+
+
 
   <div class='pre p1 fill-light mt0'>FontFaceConfiguration</div>
-  
+
     <p>
       Type:
       {fontFamily: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, fontFilePath: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?, fontStretch: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?, fontStyle: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?, fontVariant: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?, fontWeight: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?, fileFormats: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>?, localFonts: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>?, unicodeRange: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?, fontDisplay: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?, fontVariationSettings: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?, fontFeatureSettings: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?}
     </p>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
-    </div>
-  
 
-  
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>fontFamily</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>fontFilePath</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>fontStretch</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>fontStyle</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>fontVariant</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>fontWeight</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>fileFormats</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>?)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>localFonts</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>?)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>unicodeRange</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>fontDisplay</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>fontVariationSettings</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>fontFeatureSettings</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>fontFamily</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>fontFilePath</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>fontStretch</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>fontStyle</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>fontVariant</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>fontWeight</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>fileFormats</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>?)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>localFonts</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>?)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>unicodeRange</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>fontDisplay</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>fontVariationSettings</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>fontFeatureSettings</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
-          
-          
+
+
         </div>
-      
+
     </div>
-  
 
-  
-    
-  
 
-  
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
+
     </ul>
-  
 
-  
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='hslcolor'>
       HslColor
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
-  </div>
-  
 
-  
+  </div>
+
+
+
 
   <div class='pre p1 fill-light mt0'>HslColor</div>
-  
+
     <p>
       Type:
       {hue: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, saturation: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, lightness: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>}
     </p>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
-    </div>
-  
 
-  
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>hue</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>saturation</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>lightness</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>hue</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>saturation</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>lightness</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
     </div>
-  
 
-  
-    
-  
 
-  
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
+
     </ul>
-  
 
-  
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='hslacolor'>
       HslaColor
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
-  </div>
-  
 
-  
+  </div>
+
+
+
 
   <div class='pre p1 fill-light mt0'>HslaColor</div>
-  
+
     <p>
       Type:
       {hue: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, saturation: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, lightness: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, alpha: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>}
     </p>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
-    </div>
-  
 
-  
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>hue</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>saturation</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>lightness</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>alpha</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>hue</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>saturation</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>lightness</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>alpha</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
     </div>
-  
 
-  
-    
-  
 
-  
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
+
     </ul>
-  
 
-  
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='interactionstate'>
       InteractionState
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
-  </div>
-  
 
-  
+  </div>
+
+
+
 
   <div class='pre p1 fill-light mt0'>InteractionState</div>
-  
+
     <p>
       Type:
       (any | null | <code>"active"</code> | <code>"focus"</code> | <code>"hover"</code>)
     </p>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
-    </div>
-  
 
-  
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
+
     </div>
-  
 
-  
-    
-  
 
-  
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
+
     </ul>
-  
 
-  
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='modularscaleratio'>
       ModularScaleRatio
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
-  </div>
-  
 
-  
+  </div>
+
+
+
 
   <div class='pre p1 fill-light mt0'>ModularScaleRatio</div>
-  
+
     <p>
       Type:
       (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <code>"minorSecond"</code> | <code>"majorSecond"</code> | <code>"minorThird"</code> | <code>"majorThird"</code> | <code>"perfectFourth"</code> | <code>"augFourth"</code> | <code>"perfectFifth"</code> | <code>"minorSixth"</code> | <code>"goldenSection"</code> | <code>"majorSixth"</code> | <code>"minorSeventh"</code> | <code>"majorSeventh"</code> | <code>"octave"</code> | <code>"majorTenth"</code> | <code>"majorEleventh"</code> | <code>"majorTwelfth"</code> | <code>"doubleOctave"</code>)
     </p>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
-    </div>
-  
 
-  
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
+
     </div>
-  
 
-  
-    
-  
 
-  
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
+
     </ul>
-  
 
-  
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='radialgradientconfiguration'>
       RadialGradientConfiguration
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
-  </div>
-  
 
-  
+  </div>
+
+
+
 
   <div class='pre p1 fill-light mt0'>RadialGradientConfiguration</div>
-  
+
     <p>
       Type:
       {colorStops: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>, extent: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?, fallback: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?, position: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?, shape: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?}
     </p>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
-    </div>
-  
 
-  
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>colorStops</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>extent</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>fallback</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>position</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>shape</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>colorStops</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>extent</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>fallback</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>position</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>shape</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
-          
-          
+
+
         </div>
-      
+
     </div>
-  
 
-  
-    
-  
 
-  
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
+
     </ul>
-  
 
-  
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='rgbacolor'>
       RgbaColor
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
-  </div>
-  
 
-  
+  </div>
+
+
+
 
   <div class='pre p1 fill-light mt0'>RgbaColor</div>
-  
+
     <p>
       Type:
       {red: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, green: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, blue: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, alpha: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>}
     </p>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
-    </div>
-  
 
-  
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>red</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>green</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>blue</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>alpha</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>red</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>green</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>blue</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>alpha</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
     </div>
-  
 
-  
-    
-  
 
-  
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
+
     </ul>
-  
 
-  
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='rgbcolor'>
       RgbColor
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
-  </div>
-  
 
-  
+  </div>
+
+
+
 
   <div class='pre p1 fill-light mt0'>RgbColor</div>
-  
+
     <p>
       Type:
       {red: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, green: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>, blue: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>}
     </p>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
-    </div>
-  
 
-  
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>red</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>green</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>blue</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>red</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>green</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>blue</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
     </div>
-  
 
-  
-    
-  
 
-  
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
+
     </ul>
-  
 
-  
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='sidekeyword'>
       SideKeyword
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
-  </div>
-  
 
-  
+  </div>
+
+
+
 
   <div class='pre p1 fill-light mt0'>SideKeyword</div>
-  
+
     <p>
       Type:
       (<code>"top"</code> | <code>"right"</code> | <code>"bottom"</code> | <code>"left"</code>)
     </p>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
-    </div>
-  
 
-  
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
+
     </div>
-  
 
-  
-    
-  
 
-  
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
+
     </ul>
-  
 
-  
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='styles'>
       Styles
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
-  </div>
-  
 
-  
+  </div>
+
+
+
 
   <div class='pre p1 fill-light mt0'>Styles</div>
-  
+
     <p>
       Type:
       {}
     </p>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
-    </div>
-  
 
-  
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>ruleOrSelector</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="#styles">Styles</a>)?)</code>
-          
-          
+
+
         </div>
-      
+
     </div>
-  
 
-  
-    
-  
 
-  
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
+
     </ul>
-  
 
-  
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='triangleconfiguration'>
       TriangleConfiguration
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
-  </div>
-  
 
-  
+  </div>
+
+
+
 
   <div class='pre p1 fill-light mt0'>TriangleConfiguration</div>
-  
+
     <p>
       Type:
       {backgroundColor: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?, foregroundColor: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, height: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), width: (<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), pointingDirection: <a href="#sidekeyword">SideKeyword</a>}
     </p>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
-    </div>
-  
 
-  
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>backgroundColor</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>foregroundColor</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>height</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>height</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>height</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>backgroundColor</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>?)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>foregroundColor</span> <code class='quiet'>(<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>height</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>))</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>width</span> <code class='quiet'>((<a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> | <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>))</code>
-          
-          
+
+
         </div>
-      
+
         <div class='space-bottom0'>
           <span class='code bold'>pointingDirection</span> <code class='quiet'>(<a href="#sidekeyword">SideKeyword</a>)</code>
-          
-          
+
+
         </div>
-      
+
     </div>
-  
 
-  
-    
-  
 
-  
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
+
     </ul>
-  
 
-  
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
-        
+
+
+
           <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  
+
   <div class='clearfix'>
-    
+
     <h3 class='fl m0' id='timingfunction'>
       TimingFunction
     </h3>
-    
-    
+
+
       <a class='fr fill-darken0 round round pad1x quiet h5' href='[object Object]'>
       <span></span>
       </a>
-    
-  </div>
-  
 
-  
+  </div>
+
+
+
 
   <div class='pre p1 fill-light mt0'>TimingFunction</div>
-  
+
     <p>
       Type:
       (<code>"easeInBack"</code> | <code>"easeInCirc"</code> | <code>"easeInCubic"</code> | <code>"easeInExpo"</code> | <code>"easeInQuad"</code> | <code>"easeInQuart"</code> | <code>"easeInQuint"</code> | <code>"easeInSine"</code> | <code>"easeOutBack"</code> | <code>"easeOutCubic"</code> | <code>"easeOutCirc"</code> | <code>"easeOutExpo"</code> | <code>"easeOutQuad"</code> | <code>"easeOutQuart"</code> | <code>"easeOutQuint"</code> | <code>"easeOutSine"</code> | <code>"easeInOutBack"</code> | <code>"easeInOutCirc"</code> | <code>"easeInOutCubic"</code> | <code>"easeInOutExpo"</code> | <code>"easeInOutQuad"</code> | <code>"easeInOutQuart"</code> | <code>"easeInOutQuint"</code> | <code>"easeInOutSine"</code>)
     </p>
-  
-  
+
+
     <p>
       Extends
-      
-        
-      
+
+
+
     </p>
-  
 
-  
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Parameters</div>
     <div class='prose'>
-      
-    </div>
-  
 
-  
+    </div>
+
+
+
     <div class='py1 quiet mt1 prose-big'>Properties</div>
     <div>
-      
+
     </div>
-  
 
-  
-    
-  
 
-  
+
+
+
+
+
     <div class='py1 quiet mt1 prose-big'>Throws</div>
     <ul>
-      
+
     </ul>
-  
 
-  
+
+
     <div class='py1 quiet mt1 prose-big'>Example</div>
-    
-  
 
-  
 
-  
 
-  
+
+
+
+
+
 </section>
 
-        
-      
+
+
     </div>
   </div>
 </div>
 
-  
-  
+
+
     <script src='/assets/anchor.js'></script>
     <script src='/assets/docs.js'></script>
-  
+
   <script defer src="/assets/polished.js"></script>
   <script defer src="/assets/script.js"></script>
 </body>


### PR DESCRIPTION
changed doc examples from `injectGlobal` to `createGlobalStyle` referencing issue [#364](https://github.com/styled-components/polished/issues/364)