### PR TITLE
docs: fix typo in setSaturation function

### DIFF
--- a/src/color/setSaturation.js
+++ b/src/color/setSaturation.js
@@ -4,7 +4,7 @@ import parseToHsl from './parseToHsl'
 import toColorString from './toColorString'
 
 /**
- * Sets the saturation of a color to the provided value. The lightness range can be
+ * Sets the saturation of a color to the provided value. The saturation range can be
  * from 0 and 1.
  *
  * @example


### PR DESCRIPTION
It says 'The lightness range...' where it should say 'The saturation range...'. 😊