### PR TITLE
feat(math): adds round symbol

### DIFF
--- a/src/math/defaultMathSymbols.js
+++ b/src/math/defaultMathSymbols.js
@@ -49,6 +49,10 @@ function min(...a: Array<number>): number {
   return Math.min(...a)
 }
 
+function round(a: number): number {
+  return Math.round(a)
+}
+
 function comma(...a: Array<number | string>): Array<number | string> {
   return Array.of(...a)
 }
@@ -202,6 +206,18 @@ const defaultMathSymbols = {
       },
       symbol: 'max',
       regSymbol: 'max\\b',
+    },
+    round: {
+      func: {
+        symbol: 'round',
+        f: round,
+        notation: 'func',
+        precedence: 0,
+        rightToLeft: 0,
+        argCount: 1,
+      },
+      symbol: 'round',
+      regSymbol: 'round\\b',
     },
     sqrt: {
       func: {

--- a/src/math/test/math.test.js
+++ b/src/math/test/math.test.js
@@ -75,6 +75,18 @@ describe('math', () => {
     expect(math('sqrt(4em - 2 / 5em)')).toEqual(`${Math.sqrt(4 - 2 / 5)}em`)
   })
 
+  it('should be able to round', () => {
+    expect(math('round(1.23em)')).toEqual(`${Math.round(1.23)}em`)
+    expect(math('round(4.3em + 2.9em)')).toEqual(`${Math.round(4.3 + 2.9)}em`)
+    expect(math('round(1em + 2em)')).toEqual(`${Math.round(1 + 2)}em`)
+    expect(math('round(1.2em + 1.3em) * 1')).toEqual(
+      `${Math.round(1.2 + 1.3)}em`,
+    )
+    expect(math('round(-23.44em)')).toEqual(`${Math.round(-23.44)}em`)
+    expect(math('round(3.1px + 2.2px)')).toEqual(`${Math.round(3.1 + 2.2)}px`)
+    expect(math('round(3em / 2)')).toEqual(`${Math.round(3 / 2)}em`)
+  })
+
   it('should be able to process exponent power', () => {
     expect(math('2em^3')).toEqual(`${2 ** 3}em`)
   })


### PR DESCRIPTION
This adds the ability to use `round()` in the `math` helper, with tests. 

I'm not totally sure what the process is for adding functionality here, and what math functions are going to be supported or not, so I though I'd just put a PR up for.