### PR TITLE
feat(hsla): enable decimal values in hsla

### DIFF
--- a/src/color/parseToRgb.js
+++ b/src/color/parseToRgb.js
@@ -12,7 +12,7 @@ const reducedRgbaHexRegex = /^#[a-fA-F0-9]{4}$/
 const rgbRegex = /^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/i
 const rgbaRegex = /^rgba\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*([-+]?[0-9]*[.]?[0-9]+)\s*\)$/i
 const hslRegex = /^hsl\(\s*(\d{0,3}[.]?[0-9]+)\s*,\s*(\d{1,3})%\s*,\s*(\d{1,3})%\s*\)$/i
-const hslaRegex = /^hsla\(\s*(\d{0,3}[.]?[0-9]+)\s*,\s*(\d{1,3})%\s*,\s*(\d{1,3})%\s*,\s*([-+]?[0-9]*[.]?[0-9]+)\s*\)$/i
+const hslaRegex = /^hsla\(\s*(\d{0,3}[.]?[0-9]+)\s*,\s*(\d{1,3}[.]?[0-9]?)%\s*,\s*(\d{1,3}[.]?[0-9]?)%\s*,\s*([-+]?[0-9]*[.]?[0-9]+)\s*\)$/i
 
 /**
  * Returns an RgbColor or RgbaColor object. This utility function is only useful

--- a/src/color/parseToRgb.js
+++ b/src/color/parseToRgb.js
@@ -11,7 +11,7 @@ const reducedHexRegex = /^#[a-fA-F0-9]{3}$/
 const reducedRgbaHexRegex = /^#[a-fA-F0-9]{4}$/
 const rgbRegex = /^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/i
 const rgbaRegex = /^rgba\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*([-+]?[0-9]*[.]?[0-9]+)\s*\)$/i
-const hslRegex = /^hsl\(\s*(\d{0,3}[.]?[0-9]+)\s*,\s*(\d{1,3})%\s*,\s*(\d{1,3})%\s*\)$/i
+const hslRegex = /^hsl\(\s*(\d{0,3}[.]?[0-9]+)\s*,\s*(\d{1,3}[.]?[0-9]?)%\s*,\s*(\d{1,3}[.]?[0-9]?)%\s*\)$/i
 const hslaRegex = /^hsla\(\s*(\d{0,3}[.]?[0-9]+)\s*,\s*(\d{1,3}[.]?[0-9]?)%\s*,\s*(\d{1,3}[.]?[0-9]?)%\s*,\s*([-+]?[0-9]*[.]?[0-9]+)\s*\)$/i
 
 /**

--- a/src/color/test/__snapshots__/parseToRgb.test.js.snap
+++ b/src/color/test/__snapshots__/parseToRgb.test.js.snap
@@ -42,6 +42,24 @@ Object {
 }
 `;
 
+exports[`parseToRgb should parse a hsla color representation with decimal values 1`] = `
+Object {
+  "alpha": 1,
+  "blue": 0,
+  "green": 0,
+  "red": 0,
+}
+`;
+
+exports[`parseToRgb should parse a hsla color representation with decimal values 2`] = `
+Object {
+  "alpha": 1,
+  "blue": 0,
+  "green": 0,
+  "red": 0,
+}
+`;
+
 exports[`parseToRgb should parse a reduced hex color representation 1`] = `
 Object {
   "blue": 170,

--- a/src/color/test/__snapshots__/parseToRgb.test.js.snap
+++ b/src/color/test/__snapshots__/parseToRgb.test.js.snap
@@ -24,6 +24,22 @@ Object {
 }
 `;
 
+exports[`parseToRgb should parse a hsl color representation with decimal values 1`] = `
+Object {
+  "blue": 38,
+  "green": 33,
+  "red": 28,
+}
+`;
+
+exports[`parseToRgb should parse a hsl color representation with decimal values 2`] = `
+Object {
+  "blue": 38,
+  "green": 33,
+  "red": 28,
+}
+`;
+
 exports[`parseToRgb should parse a hsla color representation 1`] = `
 Object {
   "alpha": 0.75,

--- a/src/color/test/__snapshots__/transparentize.test.js.snap
+++ b/src/color/test/__snapshots__/transparentize.test.js.snap
@@ -14,6 +14,8 @@ exports[`transparentize should reduce the opacity of hsl(0, 0%, 100%) by 0.2 1`]
 
 exports[`transparentize should reduce the opacity of hsla(0, 0%, 100%, .8) by 0.5 1`] = `"rgba(255,255,255,0.3)"`;
 
+exports[`transparentize should reduce the opacity of hsla(0, 0.5%, 0.5%, .1) by 0.4 1`] = `"rgba(0,0,0,0)"`;
+
 exports[`transparentize should reduce the opacity of rgb(255, 0, 255) by 0.1 1`] = `"rgba(255,0,255,0.9)"`;
 
 exports[`transparentize should reduce the opacity of rgba(255, 0, 0, .5) by 0.3 1`] = `"rgba(255,0,0,0.2)"`;

--- a/src/color/test/__snapshots__/transparentize.test.js.snap
+++ b/src/color/test/__snapshots__/transparentize.test.js.snap
@@ -12,6 +12,8 @@ exports[`transparentize should reduce the opacity of hex #fff by 0.1 1`] = `"rgb
 
 exports[`transparentize should reduce the opacity of hsl(0, 0%, 100%) by 0.2 1`] = `"rgba(255,255,255,0.8)"`;
 
+exports[`transparentize should reduce the opacity of hsl(0, 0.5%, 0.5%) by 0.1 1`] = `"rgba(0,0,0,0.9)"`;
+
 exports[`transparentize should reduce the opacity of hsla(0, 0%, 100%, .8) by 0.5 1`] = `"rgba(255,255,255,0.3)"`;
 
 exports[`transparentize should reduce the opacity of hsla(0, 0.5%, 0.5%, .1) by 0.4 1`] = `"rgba(0,0,0,0)"`;

--- a/src/color/test/parseToRgb.test.js
+++ b/src/color/test/parseToRgb.test.js
@@ -53,6 +53,11 @@ describe('parseToRgb', () => {
     )
   })
 
+  it('should parse a hsla color representation with decimal values', () => {
+    expect(parseToRgb('hsla(210,0.5%,0.5%,1.0)')).toMatchSnapshot()
+    expect(parseToRgb('hsla( 210 , 0.5% , 0.5% , 1.0 )')).toMatchSnapshot()
+  })
+
   it('should throw an error if an invalid hsl string is provided', () => {
     expect(() => {
       parseToRgb('hsl(210,120%,4%)')

--- a/src/color/test/parseToRgb.test.js
+++ b/src/color/test/parseToRgb.test.js
@@ -32,9 +32,19 @@ describe('parseToRgb', () => {
     expect(parseToRgb('hsl( 210 , 10% , 4% )')).toMatchSnapshot()
   })
 
+  it('should parse a hsl color representation with decimal values', () => {
+    expect(parseToRgb('hsl(210,16.4%,13.2%)')).toMatchSnapshot()
+    expect(parseToRgb('hsl( 210 , 16.4%, 13.2% )')).toMatchSnapshot()
+  })
+
   it('should parse a hsla color representation', () => {
     expect(parseToRgb('hsla(210,10%,40%,0.75)')).toMatchSnapshot()
     expect(parseToRgb('hsla( 210 , 10% , 40% , 0.75 )')).toMatchSnapshot()
+  })
+
+  it('should parse a hsla color representation with decimal values', () => {
+    expect(parseToRgb('hsla(210,0.5%,0.5%,1.0)')).toMatchSnapshot()
+    expect(parseToRgb('hsla( 210 , 0.5% , 0.5% , 1.0 )')).toMatchSnapshot()
   })
 
   it('should throw an error if an invalid color string is provided', () => {
@@ -51,11 +61,6 @@ describe('parseToRgb', () => {
     }).toThrow(
       'Passed an incorrect argument to a color function, please pass a string representation of a color.',
     )
-  })
-
-  it('should parse a hsla color representation with decimal values', () => {
-    expect(parseToRgb('hsla(210,0.5%,0.5%,1.0)')).toMatchSnapshot()
-    expect(parseToRgb('hsla( 210 , 0.5% , 0.5% , 1.0 )')).toMatchSnapshot()
   })
 
   it('should throw an error if an invalid hsl string is provided', () => {

--- a/src/color/test/transparentize.test.js
+++ b/src/color/test/transparentize.test.js
@@ -38,6 +38,10 @@ describe('transparentize', () => {
     expect(transparentize(0.5, 'hsla(0, 0%, 100%, .8)')).toMatchSnapshot()
   })
 
+  it('should reduce the opacity of hsla(0, 0.5%, 0.5%, .1) by 0.4', () => {
+    expect(transparentize(0.4, 'hsla(0, 0.5%, 0.5%, 0.4)')).toMatchSnapshot()
+  })
+
   it('should not reduce the opacity below 0', () => {
     expect(transparentize(0.5, 'rgba(255, 0, 0, .2)')).toMatchSnapshot()
   })

--- a/src/color/test/transparentize.test.js
+++ b/src/color/test/transparentize.test.js
@@ -34,6 +34,10 @@ describe('transparentize', () => {
     expect(transparentize(0.2, 'hsl(0, 0%, 100%)')).toMatchSnapshot()
   })
 
+  it('should reduce the opacity of hsl(0, 0.5%, 0.5%) by 0.1', () => {
+    expect(transparentize(0.1, 'hsl(0, 0.5%, 0.5%)')).toMatchSnapshot()
+  })
+
   it('should reduce the opacity of hsla(0, 0%, 100%, .8) by 0.5', () => {
     expect(transparentize(0.5, 'hsla(0, 0%, 100%, .8)')).toMatchSnapshot()
   })


### PR DESCRIPTION
Issue: 
parseToRgb's hslaRegex did not allow for decimals in the Saturation and Lightness values.

```
../node_modules/polished/lib/color/parseToRgb.js:156
  throw new _errors["default"](5);
        ^
Error: Couldn't parse the color string. Please provide the color as a string in hex, rgb, rgba, hsl or hsla notation.
```
Caused by: `"hsla(218, 36.4%, 95.7%, 1.0)"`

Explanation:
In our repo we recently changed to using hsla over hex values.  A designer then realised that the colours we translated to were not exact to those in the design system so we are now using a new conversion site (https://www.ginifab.com/feeds/pms/rgb_to_hsv_hsl.html) and this has given us decimal values in saturation and lightness

More test results from regex101 for HSLA:
<img width="600" alt="Screenshot 2019-10-04 at 11 54 21" src="https://user-images.githubusercontent.com/23168778/66203171-92e23e80-e69f-11e9-861d-53cf3162d408.png">

I'm guessing this would affect HSL as well, but feedback on whether this is a feature you would welcome is wanted before it can be added to the hslRegex.

HSL regex tests:
<img width="596" alt="Screenshot 2019-10-09 at 14 01 50" src="https://user-images.githubusercontent.com/23168778/66484574-20a69b00-ea9f-11e9-8758-75af2864345e.png">

If this is not something you want to allow in the library it's understandable, feedback is welcome!