### PR TITLE
chore(stripunit): mark stripUnit optional return for deprecation

### DIFF
--- a/src/helpers/getValueAndUnit.js
+++ b/src/helpers/getValueAndUnit.js
@@ -4,8 +4,6 @@ const cssRegex = /^([+-]?(?:\d+|\d*\.\d+))([a-z]*|%)$/
 /**
  * Returns a given CSS value and its unit as elements of an array.
  *
- * @deprecated - getValueAndUnit has been marked for deprecation in polished 3.0 and will be fully deprecated in 4.0. It's functionality has been been moved to stripUnit as an optional return.
- *
  * @example
  * // Styles as object usage
  * const styles = {
@@ -29,10 +27,6 @@ const cssRegex = /^([+-]?(?:\d+|\d*\.\d+))([a-z]*|%)$/
 export default function getValueAndUnit(
   value: string,
 ): [number | string, string | void] {
-  // eslint-disable-next-line no-console
-  console.warn(
-    "getValueAndUnit has been marked for deprecation in polished 3.0 and will be fully deprecated in 4.0. It's functionality has been been moved to stripUnit as an optional return.",
-  )
   if (typeof value !== 'string') return [value, '']
   const matchedValue = value.match(cssRegex)
   if (matchedValue) return [parseFloat(value), matchedValue[2]]

--- a/src/helpers/stripUnit.js
+++ b/src/helpers/stripUnit.js
@@ -3,7 +3,9 @@
 const cssRegex = /^([+-]?(?:\d+|\d*\.\d+))([a-z]*|%)$/
 
 /**
- * Returns a given CSS value minus its unit (or the original value if an invalid string is passed). Optionally returns an array containing the stripped value and the original unit of measure.
+ * Returns a given CSS value minus its unit.
+ *
+ * @deprecated - stripUnit's unitReturn functionality has been marked for deprecation in polished 4.0. It's functionality has been been moved to getUnitAndValue.
  *
  * @example
  * // Styles as object usage
@@ -33,6 +35,9 @@ export default function stripUnit(
   const matchedValue = value.match(cssRegex)
 
   if (unitReturn) {
+    console.warn(
+      "stripUnit's unitReturn functionality has been marked for deprecation in polished 4.0. It's functionality has been been moved to getUnitAndValue.",
+    )
     if (matchedValue) return [parseFloat(value), matchedValue[2]]
     return [value, undefined]
   }


### PR DESCRIPTION
Mark stripUnit's optional return for deprecation in favor of keeping getValueAndUnit.