### PR TITLE
fix(rgbtostring): fix issue with 0 alpha rgb colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polished",
-  "version": "3.6.3",
+  "version": "3.6.4",
   "description": "A lightweight toolset for writing styles in Javascript.",
   "license": "MIT",
   "author": "Brian Hough <hello@brianhough.net> (https://polished.js.org)",

--- a/src/color/rgbToColorString.js
+++ b/src/color/rgbToColorString.js
@@ -36,7 +36,7 @@ export default function rgbToColorString(color: RgbColor | RgbaColor): string {
     && typeof color.green === 'number'
     && typeof color.blue === 'number'
   ) {
-    if (color.alpha && typeof color.alpha === 'number') {
+    if (typeof color.alpha === 'number') {
       return rgba({
         red: color.red,
         green: color.green,

--- a/src/color/test/__snapshots__/rgbToColorString.test.js.snap
+++ b/src/color/test/__snapshots__/rgbToColorString.test.js.snap
@@ -17,3 +17,9 @@ Object {
   "background": "rgba(255,205,100,0.72)",
 }
 `;
+
+exports[`rgbToColorString should convert a RgbaColor with 0 alpha to a rgba string 1`] = `
+Object {
+  "background": "rgba(255,205,100,0)",
+}
+`;

--- a/src/color/test/rgbToColorString.test.js
+++ b/src/color/test/rgbToColorString.test.js
@@ -25,6 +25,17 @@ describe('rgbToColorString', () => {
     }).toMatchSnapshot()
   })
 
+  it('should convert a RgbaColor with 0 alpha to a rgba string', () => {
+    expect({
+      background: rgbToColorString({
+        red: 255,
+        green: 205,
+        blue: 100,
+        alpha: 0.0,
+      }),
+    }).toMatchSnapshot()
+  })
+
   it('should throw an error if anything else than a RgbColor or RgbaColor is provided', () => {
     // $FlowFixMe
     expect(() => rgbToColorString({ red: 255, green: 1, hue: 240 })).toThrow(


### PR DESCRIPTION
Fixes issue where passing 0 alpha improperly returned a non-transparent hex color.

fix #515