### PR TITLE
fix(cssvar): properly error when there is no document

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polished",
-  "version": "3.6.4",
+  "version": "3.6.5",
   "description": "A lightweight toolset for writing styles in Javascript.",
   "license": "MIT",
   "author": "Brian Hough <hello@brianhough.net> (https://polished.js.org)",

--- a/src/helpers/cssVar.js
+++ b/src/helpers/cssVar.js
@@ -38,7 +38,7 @@ export default function cssVar(
 
   /* eslint-disable */
   /* istanbul ignore next */
-  if (document.documentElement !== null) {
+  if (typeof document !== 'undefined' && document.documentElement !== null) {
     variableValue = getComputedStyle(document.documentElement).getPropertyValue(
       cssVariable,
     )


### PR DESCRIPTION
cssVar properly errors when no document object is present in non-browser environments.

fix #518