### PR TITLE
fix(ellipsis): fix invalid styles in multi-line

### DIFF
--- a/src/mixins/ellipsis.js
+++ b/src/mixins/ellipsis.js
@@ -39,9 +39,10 @@ export default function ellipsis(width?: ?string | ?number, lines?: number = 1):
   return lines > 1
     ? {
       ...styles,
+      WebkitBoxOrient: 'vertical',
+      WebkitLineClamp: lines,
       display: '-webkit-box',
-      webkitLineClamp: lines,
-      webkitBoxOrient: 'vertical',
+      whiteSpace: 'normal',
     }
     : styles
 }

--- a/src/mixins/test/ellipsis.test.js
+++ b/src/mixins/test/ellipsis.test.js
@@ -37,26 +37,26 @@ describe('ellipsis', () => {
 
   it('should truncate text after 3 lines', () => {
     expect(ellipsis(null, 3)).toEqual({
+      WebkitBoxOrient: 'vertical',
+      WebkitLineClamp: 3,
       display: '-webkit-box',
       maxWidth: '100%',
       overflow: 'hidden',
       textOverflow: 'ellipsis',
-      webkitBoxOrient: 'vertical',
-      webkitLineClamp: 3,
-      whiteSpace: 'nowrap',
+      whiteSpace: 'normal',
       wordWrap: 'normal',
     })
   })
 
   it('should truncate text after 3 lines and 500px max-width', () => {
     expect(ellipsis('500px', 3)).toEqual({
+      WebkitBoxOrient: 'vertical',
+      WebkitLineClamp: 3,
       display: '-webkit-box',
       maxWidth: '500px',
       overflow: 'hidden',
       textOverflow: 'ellipsis',
-      webkitBoxOrient: 'vertical',
-      webkitLineClamp: 3,
-      whiteSpace: 'nowrap',
+      whiteSpace: 'normal',
       wordWrap: 'normal',
     })
   })


### PR DESCRIPTION
`ellipsis` in v4 with `lines` parameter is returning invalid styles.

```tsx
const Ellipsis = styled.div`
  ${ellipsis("250px", 3)}
`;

const App = () => (
  <Ellipsis>
    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque
    accumsan nunc lectus, quis maximus mauris pharetra ut. Nullam cursus
    ullamcorper sem vitae convallis. Pellentesque tempor sit amet nisl id
    dapibus. Curabitur non eleifend velit, ac varius nibh. Etiam leo urna,
    ullamcorper sed turpis a, maximus tristique orci. Quisque eleifend augue
    molestie luctus accumsan. Suspendisse finibus risus vitae ornare
    porttitor. In nisl magna, egestas et blandit ut, imperdiet vel augue.
    Etiam vel risus et leo egestas convallis id vitae lorem. Pellentesque
    maximus elit velit, finibus viverra diam mollis eu. Duis eu dui eget
    dolor tincidunt scelerisque. Phasellus imperdiet scelerisque purus, at
    aliquet erat laoreet et.
  </Ellipsis>
);
```

|Result|Styles|
|------|------|
|![image](https://user-images.githubusercontent.com/11497500/95468402-71561a00-09b9-11eb-8632-02a8ccde57b9.png)|![image](https://user-images.githubusercontent.com/11497500/95468114-263c0700-09b9-11eb-9d8e-75ed1d76f1c9.png)|

The problems and fixes are:

1. `-webkit` vendor prefix must be started with uppercase in object notation. Otherwise it turns into just `webkit` which is incorrect.

2. When `lines > 1`, `white-space` value must be `normal`. Lines are always considered as `1` if it keeps to `nowrap`.

|Result|Styles|
|------|------|
|![image](https://user-images.githubusercontent.com/11497500/95470699-12de6b00-09bc-11eb-88f2-1c4723decbc1.png)|![image](https://user-images.githubusercontent.com/11497500/95470722-1a9e0f80-09bc-11eb-9c74-673f4b51dce3.png)|


