### PR TITLE
fix: Add additional files and folders to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,6 +10,12 @@
 .gitignore
 .npmignore
 .travis.yml
+.browserlistrc
+.prettierignore
+.prettierrc
+.vscode
+babel.config.js
+CODEOWNERS
 
 # folders
 coverage
@@ -17,12 +23,16 @@ docs-theme
 src
 test
 flow-typed
+docs
 
 # markdown files
 CONTRIBUTING.md
+CODE_OF_CONDUCT.md
 
 # misc.
 CNAME
 rollup.config.js
 travis_after_all.py
 yarn.lock
+.yarn
+typescript-test.ts

--- a/.npmignore
+++ b/.npmignore
@@ -23,7 +23,6 @@ docs-theme
 src
 test
 flow-typed
-docs
 
 # markdown files
 CONTRIBUTING.md


### PR DESCRIPTION
Currently, this module is 9mb on disk. Added a bunch of stuff to .npmignore so that they aren't published.

Can check unpacked size via npm https://www.npmjs.com/package/polished
![image](https://user-images.githubusercontent.com/1400464/99754220-cdbe5600-2a9c-11eb-95ce-10fe1a90dbef.png)
