### PR TITLE
Ignore docs and .husky from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -23,6 +23,8 @@ docs-theme
 src
 test
 flow-typed
+.husky/
+docs/
 
 # markdown files
 CONTRIBUTING.md


### PR DESCRIPTION
This reduces npm package size by `1.9MB` and these ignored files are not necessary