### PR TITLE
remove unnecessary division by 1

### DIFF
--- a/src/color/mix.js
+++ b/src/color/mix.js
@@ -59,7 +59,7 @@ function mix(weight: number | string, color: string, otherColor: string): string
     green: Math.floor(color1.green * weight1 + color2.green * weight2),
     blue: Math.floor(color1.blue * weight1 + color2.blue * weight2),
     alpha:
-      color1.alpha * (parseFloat(weight) / 1.0) + color2.alpha * (1 - parseFloat(weight) / 1.0),
+      color1.alpha * parseFloat(weight) + color2.alpha * (1 - parseFloat(weight)),
   }
 
   return rgba(mixedColor)


### PR DESCRIPTION
These were probably remnants from taking the sass formula, where it describes the weight in a value of 0 to 100, and it was divided by 100.