### PR TITLE
docs(transparentize): fix trailing comma and semicolon in example code

### DIFF
--- a/docs/assets/polished.js
+++ b/docs/assets/polished.js
@@ -3576,7 +3576,7 @@
    * @example
    * // Styles as object usage
    * const styles = {
-   *   background: transparentize(0.1, '#fff');
+   *   background: transparentize(0.1, '#fff'),
    *   background: transparentize(0.2, 'hsl(0, 0%, 100%)'),
    *   background: transparentize('0.5', 'rgba(255, 0, 0, 0.8)'),
    * }
@@ -3584,8 +3584,8 @@
    * // styled-components usage
    * const div = styled.div`
    *   background: ${transparentize(0.1, '#fff')};
-   *   background: ${transparentize(0.2, 'hsl(0, 0%, 100%)')},
-   *   background: ${transparentize('0.5', 'rgba(255, 0, 0, 0.8)')},
+   *   background: ${transparentize(0.2, 'hsl(0, 0%, 100%)')};
+   *   background: ${transparentize('0.5', 'rgba(255, 0, 0, 0.8)')};
    * `
    *
    * // CSS in JS Output

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -6489,7 +6489,7 @@ used. Otherwise we recommend to rely on <code>rgb</code>, <code>rgba</code>, <co
       
       <pre class='p1 overflow-auto round fill-light'><span class="hljs-comment">// Styles as object usage</span>
 <span class="hljs-keyword">const</span> styles = {
-  <span class="hljs-built_in">background</span>: transparentize(<span class="hljs-number">0.1</span>, <span class="hljs-string">'#fff'</span>);
+  <span class="hljs-built_in">background</span>: transparentize(<span class="hljs-number">0.1</span>, <span class="hljs-string">'#fff'</span>),
   <span class="hljs-built_in">background</span>: transparentize(<span class="hljs-number">0.2</span>, <span class="hljs-string">'hsl(0, 0%, 100%)'</span>),
   <span class="hljs-built_in">background</span>: transparentize(<span class="hljs-string">'0.5'</span>, <span class="hljs-string">'rgba(255, 0, 0, 0.8)'</span>),
 }
@@ -6497,8 +6497,8 @@ used. Otherwise we recommend to rely on <code>rgb</code>, <code>rgba</code>, <co
 <span class="hljs-comment">// styled-components usage</span>
 <span class="hljs-keyword">const</span> div = styled.div`
   <span class="hljs-built_in">background</span>: ${transparentize(<span class="hljs-number">0.1</span>, <span class="hljs-string">'#fff'</span>)};
-  <span class="hljs-built_in">background</span>: ${transparentize(<span class="hljs-number">0.2</span>, <span class="hljs-string">'hsl(0, 0%, 100%)'</span>)},
-  <span class="hljs-built_in">background</span>: ${transparentize(<span class="hljs-string">'0.5'</span>, <span class="hljs-string">'rgba(255, 0, 0, 0.8)'</span>)},
+  <span class="hljs-built_in">background</span>: ${transparentize(<span class="hljs-number">0.2</span>, <span class="hljs-string">'hsl(0, 0%, 100%)'</span>)};
+  <span class="hljs-built_in">background</span>: ${transparentize(<span class="hljs-string">'0.5'</span>, <span class="hljs-string">'rgba(255, 0, 0, 0.8)'</span>)};
 `
 
 <span class="hljs-comment">// CSS in JS Output</span>

--- a/src/color/transparentize.js
+++ b/src/color/transparentize.js
@@ -11,7 +11,7 @@ import parseToRgb from './parseToRgb'
  * @example
  * // Styles as object usage
  * const styles = {
- *   background: transparentize(0.1, '#fff');
+ *   background: transparentize(0.1, '#fff'),
  *   background: transparentize(0.2, 'hsl(0, 0%, 100%)'),
  *   background: transparentize('0.5', 'rgba(255, 0, 0, 0.8)'),
  * }
@@ -19,8 +19,8 @@ import parseToRgb from './parseToRgb'
  * // styled-components usage
  * const div = styled.div`
  *   background: ${transparentize(0.1, '#fff')};
- *   background: ${transparentize(0.2, 'hsl(0, 0%, 100%)')},
- *   background: ${transparentize('0.5', 'rgba(255, 0, 0, 0.8)')},
+ *   background: ${transparentize(0.2, 'hsl(0, 0%, 100%)')};
+ *   background: ${transparentize('0.5', 'rgba(255, 0, 0, 0.8)')};
  * `
  *
  * // CSS in JS Output


### PR DESCRIPTION
This is a really tiny fix 🙃 There's an incorrect use of trailing comma and semicolon in example code for `transparentize`, so I fixed it.

I edited only `src/color/transparentize.js`. The other changes under `docs/` are generated automatically.

This is my first contribution to this repository. Feel free to let me know if you have any problem.