### PR TITLE
Refactor triangle to use calc()

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-lint-staged --debug
+yarn lint-staged --debug

--- a/docs/assets/polished.js
+++ b/docs/assets/polished.js
@@ -1928,10 +1928,10 @@
   }
 
   var getBorderWidth = function getBorderWidth(pointingDirection, height, width) {
-    var fullWidth = "" + width[0] + (width[1] || '');
-    var halfWidth = "" + width[0] / 2 + (width[1] || '');
-    var fullHeight = "" + height[0] + (height[1] || '');
-    var halfHeight = "" + height[0] / 2 + (height[1] || '');
+    var fullWidth = width;
+    var halfWidth = "calc(" + width + " / 2)";
+    var fullHeight = height;
+    var halfHeight = "calc(" + height + " / 2)";
 
     switch (pointingDirection) {
       case 'top':
@@ -2026,20 +2026,13 @@
         foregroundColor = _ref.foregroundColor,
         _ref$backgroundColor = _ref.backgroundColor,
         backgroundColor = _ref$backgroundColor === void 0 ? 'transparent' : _ref$backgroundColor;
-    var widthAndUnit = getValueAndUnit(width);
-    var heightAndUnit = getValueAndUnit(height);
-
-    if (isNaN(heightAndUnit[0]) || isNaN(widthAndUnit[0])) {
-      throw new PolishedError(60);
-    }
-
     return _extends__default["default"]({
       width: '0',
       height: '0',
       borderColor: backgroundColor
     }, getBorderColor(pointingDirection, foregroundColor), {
       borderStyle: 'solid',
-      borderWidth: getBorderWidth(pointingDirection, heightAndUnit, widthAndUnit)
+      borderWidth: getBorderWidth(pointingDirection, typeof height === 'number' ? height + "px" : height, typeof width === 'number' ? width + "px" : width)
     });
   }
 

--- a/src/mixins/test/triangle.test.js
+++ b/src/mixins/test/triangle.test.js
@@ -15,7 +15,7 @@ describe('triangle', () => {
       borderColor: 'black',
       borderLeftColor: 'red',
       borderStyle: 'solid',
-      borderWidth: '5 0 5 20',
+      borderWidth: 'calc(10px / 2) 0 calc(10px / 2) 20px',
       height: '0',
       width: '0',
     })
@@ -34,7 +34,7 @@ describe('triangle', () => {
       borderColor: 'black',
       borderLeftColor: 'red',
       borderStyle: 'solid',
-      borderWidth: '5em 0 5em 20em',
+      borderWidth: 'calc(10em / 2) 0 calc(10em / 2) 20em',
       height: '0',
       width: '0',
     })
@@ -53,7 +53,7 @@ describe('triangle', () => {
       borderColor: 'black',
       borderLeftColor: 'red',
       borderStyle: 'solid',
-      borderWidth: '5.25em 0 5.25em 20.5em',
+      borderWidth: 'calc(10.5em / 2) 0 calc(10.5em / 2) 20.5em',
       height: '0',
       width: '0',
     })
@@ -71,7 +71,7 @@ describe('triangle', () => {
       borderColor: 'transparent',
       borderLeftColor: 'red',
       borderStyle: 'solid',
-      borderWidth: '5px 0 5px 20px',
+      borderWidth: 'calc(10px / 2) 0 calc(10px / 2) 20px',
       height: '0',
       width: '0',
     })
@@ -90,7 +90,7 @@ describe('triangle', () => {
       borderColor: 'black',
       borderLeftColor: 'red',
       borderStyle: 'solid',
-      borderWidth: '5px 0 5px 20px',
+      borderWidth: 'calc(10px / 2) 0 calc(10px / 2) 20px',
       height: '0',
       width: '0',
     })
@@ -108,7 +108,7 @@ describe('triangle', () => {
       borderBottomColor: 'green',
       borderColor: 'transparent',
       borderStyle: 'solid',
-      borderWidth: '0 10px 20px 10px',
+      borderWidth: '0 calc(20px / 2) 20px calc(20px / 2)',
       height: '0',
       width: '0',
     })
@@ -126,7 +126,7 @@ describe('triangle', () => {
       borderColor: 'transparent',
       borderLeftColor: 'red',
       borderStyle: 'solid',
-      borderWidth: '5px 0 5px 20px',
+      borderWidth: 'calc(10px / 2) 0 calc(10px / 2) 20px',
       height: '0',
       width: '0',
     })
@@ -144,7 +144,7 @@ describe('triangle', () => {
       borderColor: 'transparent',
       borderStyle: 'solid',
       borderTopColor: 'red',
-      borderWidth: '20px 5px 0 5px',
+      borderWidth: '20px calc(10px / 2) 0 calc(10px / 2)',
       height: '0',
       width: '0',
     })
@@ -162,7 +162,7 @@ describe('triangle', () => {
       borderColor: 'transparent',
       borderRightColor: 'blue',
       borderStyle: 'solid',
-      borderWidth: '10px 10px 10px 0',
+      borderWidth: 'calc(20px / 2) 10px calc(20px / 2) 0',
       height: '0',
       width: '0',
     })
@@ -267,7 +267,7 @@ describe('triangle', () => {
     )
   })
 
-  it('should throw an error when height or width is not a unit based value.', () => {
+  it.skip('should throw an error when height or width is not a unit based value.', () => {
     expect(() => {
       triangle({
         foregroundColor: 'blue',

--- a/src/mixins/triangle.js
+++ b/src/mixins/triangle.js
@@ -1,5 +1,4 @@
 // @flow
-import getValueAndUnit from '../helpers/getValueAndUnit'
 import PolishedError from '../internalHelpers/_errors'
 
 import type { SideKeyword } from '../types/sideKeyword'
@@ -8,13 +7,13 @@ import type { TriangleConfiguration } from '../types/triangleConfiguration'
 
 const getBorderWidth = (
   pointingDirection: SideKeyword,
-  height: [number, string],
-  width: [number, string],
+  height: number | string,
+  width: number | string,
 ): string => {
-  const fullWidth = `${width[0]}${width[1] || ''}`
-  const halfWidth = `${width[0] / 2}${width[1] || ''}`
-  const fullHeight = `${height[0]}${height[1] || ''}`
-  const halfHeight = `${height[0] / 2}${height[1] || ''}`
+  const fullWidth = width
+  const halfWidth = `calc(${width} / 2)`
+  const fullHeight = height
+  const halfHeight = `calc(${height} / 2)`
 
   switch (pointingDirection) {
     case 'top':
@@ -90,19 +89,16 @@ export default function triangle({
   foregroundColor,
   backgroundColor = 'transparent',
 }: TriangleConfiguration): Styles {
-  const widthAndUnit = getValueAndUnit(width)
-  const heightAndUnit = getValueAndUnit(height)
-
-  if (isNaN(heightAndUnit[0]) || isNaN(widthAndUnit[0])) {
-    throw new PolishedError(60)
-  }
-
   return {
     width: '0',
     height: '0',
     borderColor: backgroundColor,
     ...getBorderColor(pointingDirection, foregroundColor),
     borderStyle: 'solid',
-    borderWidth: getBorderWidth(pointingDirection, heightAndUnit, widthAndUnit),
+    borderWidth: getBorderWidth(
+      pointingDirection,
+      typeof height === 'number' ? `${height}px` : height,
+      typeof width === 'number' ? `${width}px` : width,
+    ),
   }
 }


### PR DESCRIPTION
`triangle()` currently expects height and width values that are a string value with a unit (e.g. `'12px'`) or a number (`12`). It throws an error otherwise.

This prevents the use of CSS custom variables. However, if we change from using JS arithmetic to CSS `calc()`, we can support CSS variables, in addition to number of unit values, without having to do any unit stripping in strings. 