### PR TITLE
Update outdated LICENSE year

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 - 2021 Brian Hough and Maximilian Stoiber
+Copyright (c) 2016-Present Brian Hough and Maximilian Stoiber
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updated the outdated copyright year to the present.  So there will not be a need for any further license year updates