### PR TITLE
[Performance] Improve tint and shade performance

### DIFF
--- a/src/color/shade.js
+++ b/src/color/shade.js
@@ -27,7 +27,7 @@ import mix from './mix'
 
 function shade(percentage: number | string, color: string): string {
   if (color === 'transparent') return color
-  return mix(parseFloat(percentage), 'rgb(0, 0, 0)', color)
+  return mix(parseFloat(percentage), '#000000', color)
 }
 
 // prettier-ignore

--- a/src/color/tint.js
+++ b/src/color/tint.js
@@ -27,7 +27,7 @@ import mix from './mix'
 
 function tint(percentage: number | string, color: string): string {
   if (color === 'transparent') return color
-  return mix(parseFloat(percentage), 'rgb(255, 255, 255)', color)
+  return mix(parseFloat(percentage), '#FFFFFF', color)
 }
 
 // prettier-ignore


### PR DESCRIPTION
Improve the performance of the `tint` and `shade` functions.

It is a tiny performance improvement and lib size reduction, but it does not degrade in any shape or form the quality of the code, so I believe it is a welcome change.

The improvement is achieved by exiting the `parseToRgb` function in the first `IF` that checks for `HEX Colors`, this way not testing or matching the default color unnecessarily. 