### PR TITLE
build(.npmignore): ignore `.husky` folder

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -18,6 +18,7 @@ babel.config.js
 CODEOWNERS
 
 # folders
+.husky
 coverage
 docs-theme
 src


### PR DESCRIPTION
Husky scripts are only used during development, but are published with the package.