### PR TITLE
docs(easing): adding a list of valid function names to easing functions documentation

### DIFF
--- a/docs/assets/polished.js
+++ b/docs/assets/polished.js
@@ -944,7 +944,8 @@
     sine: 'cubic-bezier(0.470,  0.000, 0.745, 0.715)'
   };
   /**
-   * String to represent common easing functions as demonstrated here: (github.com/jaukia/easie).
+   * String to represent common easing functions as demonstrated here: https://easings.net/.
+   * Valid function names are: back, circ, cubic, expo, quad, quart, quint, sine.
    *
    * @example
    * // Styles as object usage
@@ -979,7 +980,8 @@
     sine: 'cubic-bezier(0.445,  0.050, 0.550, 0.950)'
   };
   /**
-   * String to represent common easing functions as demonstrated here: (github.com/jaukia/easie).
+   * String to represent common easing functions as demonstrated here: https://easings.net/.
+   * Valid function names are: back, circ, cubic, expo, quad, quart, quint, sine.
    *
    * @example
    * // Styles as object usage
@@ -1014,7 +1016,8 @@
     sine: 'cubic-bezier(0.390,  0.575, 0.565, 1.000)'
   };
   /**
-   * String to represent common easing functions as demonstrated here: (github.com/jaukia/easie).
+   * String to represent common easing functions as demonstrated here: https://easings.net/.
+   * Valid function names are: back, circ, cubic, expo, quad, quart, quint, sine.
    *
    * @example
    * // Styles as object usage

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -2795,7 +2795,7 @@ div {
   </div>
   
 
-  <p>String to represent common easing functions as demonstrated here: (github.com/jaukia/easie).</p>
+  <p>String to represent common easing functions as demonstrated here: (<a href="https://easings.net/">https://easings.net/</a>).</p>
 
 
   <div class='pre p1 fill-light mt0'>timingFunctions(timingFunction: <a href="#timingfunction">TimingFunction</a>): <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></div>
@@ -9468,7 +9468,8 @@ element {
   </div>
   
 
-  <p>String to represent common easing functions as demonstrated here: (github.com/jaukia/easie).</p>
+  <p>String to represent common easing functions as demonstrated here: (<a href="https://easings.net/">https://easings.net/</a>).</p>
+<p>Valid function names are: back, circ, cubic, expo, quad, quart, quint, sine.</p>
 
 
   <div class='pre p1 fill-light mt0'>easeIn(functionName: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="#timingfunction">TimingFunction</a></div>
@@ -9573,7 +9574,8 @@ element {
   </div>
   
 
-  <p>String to represent common easing functions as demonstrated here: (github.com/jaukia/easie).</p>
+  <p>String to represent common easing functions as demonstrated here: (<a href="https://easings.net/">https://easings.net/</a>).</p>
+<p>Valid function names are: back, circ, cubic, expo, quad, quart, quint, sine.</p>
 
 
   <div class='pre p1 fill-light mt0'>easeInOut(functionName: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="#timingfunction">TimingFunction</a></div>
@@ -9678,7 +9680,8 @@ element {
   </div>
   
 
-  <p>String to represent common easing functions as demonstrated here: (github.com/jaukia/easie).</p>
+  <p>String to represent common easing functions as demonstrated here: (<a href="https://easings.net/">https://easings.net/</a>).</p>
+<p>Valid function names are: back, circ, cubic, expo, quad, quart, quint, sine.</p>
 
 
   <div class='pre p1 fill-light mt0'>easeOut(functionName: <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>): <a href="#timingfunction">TimingFunction</a></div>

--- a/src/easings/easeIn.js
+++ b/src/easings/easeIn.js
@@ -13,7 +13,9 @@ const functionsMap = {
 }
 
 /**
- * String to represent common easing functions as demonstrated here: (github.com/jaukia/easie).
+ * String to represent common easing functions as demonstrated here: (https://easings.net/).
+ *
+ * Valid function names are: back, circ, cubic, expo, quad, quart, quint, sine.
  *
  * @example
  * // Styles as object usage

--- a/src/easings/easeInOut.js
+++ b/src/easings/easeInOut.js
@@ -13,7 +13,9 @@ const functionsMap = {
 }
 
 /**
- * String to represent common easing functions as demonstrated here: (github.com/jaukia/easie).
+ * String to represent common easing functions as demonstrated here: (https://easings.net/).
+ *
+ * Valid function names are: back, circ, cubic, expo, quad, quart, quint, sine.
  *
  * @example
  * // Styles as object usage

--- a/src/easings/easeOut.js
+++ b/src/easings/easeOut.js
@@ -13,7 +13,9 @@ const functionsMap = {
 }
 
 /**
- * String to represent common easing functions as demonstrated here: (github.com/jaukia/easie).
+ * String to represent common easing functions as demonstrated here: (https://easings.net/).
+ *
+ * Valid function names are: back, circ, cubic, expo, quad, quart, quint, sine.
  *
  * @example
  * // Styles as object usage

--- a/src/mixins/timingFunctions.js
+++ b/src/mixins/timingFunctions.js
@@ -37,7 +37,7 @@ function getTimingFunction(functionName: string): string {
 }
 
 /**
- * String to represent common easing functions as demonstrated here: (github.com/jaukia/easie).
+ * String to represent common easing functions as demonstrated here: (https://easings.net/).
  *
  * @deprecated - This will be deprecated in v5 in favor of `easeIn`, `easeOut`, `easeInOut`.
  *


### PR DESCRIPTION
Some minor documentation updates to:
- List all available easing functions explicitly in the docs
- Change sample link to a popular reference site for how the Penner easing functions look

I also thought it would be nice if the TypeScript [type for `functionName`](https://github.com/styled-components/polished/blob/main/src/easings/easeIn.js#L35) was narrowed from just a generic `string` to string literal type of just the valid names (e.g. `'back' | 'circ' | ...`), but figured it might be a breaking change and I can see some updates are in the works. Happy to open a PR for that change though if it's useful and not on the roadmap?