### PR TITLE
fix: support for more than one digit after . for hsl colors in parseToRgb

### DIFF
--- a/src/color/parseToRgb.js
+++ b/src/color/parseToRgb.js
@@ -11,8 +11,8 @@ const reducedHexRegex = /^#[a-fA-F0-9]{3}$/
 const reducedRgbaHexRegex = /^#[a-fA-F0-9]{4}$/
 const rgbRegex = /^rgb\(\s*(\d{1,3})\s*(?:,)?\s*(\d{1,3})\s*(?:,)?\s*(\d{1,3})\s*\)$/i
 const rgbaRegex = /^rgb(?:a)?\(\s*(\d{1,3})\s*(?:,)?\s*(\d{1,3})\s*(?:,)?\s*(\d{1,3})\s*(?:,|\/)\s*([-+]?\d*[.]?\d+[%]?)\s*\)$/i
-const hslRegex = /^hsl\(\s*(\d{0,3}[.]?[0-9]+(?:deg)?)\s*(?:,)?\s*(\d{1,3}[.]?[0-9]?)%\s*(?:,)?\s*(\d{1,3}[.]?[0-9]?)%\s*\)$/i
-const hslaRegex = /^hsl(?:a)?\(\s*(\d{0,3}[.]?[0-9]+(?:deg)?)\s*(?:,)?\s*(\d{1,3}[.]?[0-9]?)%\s*(?:,)?\s*(\d{1,3}[.]?[0-9]?)%\s*(?:,|\/)\s*([-+]?\d*[.]?\d+[%]?)\s*\)$/i
+const hslRegex = /^hsl\(\s*(\d{0,3}[.]?[0-9]+(?:deg)?)\s*(?:,)?\s*(\d{1,3}[.]?[0-9]+)%\s*(?:,)?\s*(\d{1,3}[.]?[0-9]+)%\s*\)$/i
+const hslaRegex = /^hsl(?:a)?\(\s*(\d{0,3}[.]?[0-9]+(?:deg)?)\s*(?:,)?\s*(\d{1,3}[.]?[0-9]+)%\s*(?:,)?\s*(\d{1,3}[.]?[0-9]+)%\s*(?:,|\/)\s*([-+]?\d*[.]?\d+[%]?)\s*\)$/i
 
 /**
  * Returns an RgbColor or RgbaColor object. This utility function is only useful


### PR DESCRIPTION
both S and L parts are <percentage>  values [see](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl#s)



> The <percentage> data type consists of a <number> followed by the percentage sign (%). [see](https://developer.mozilla.org/en-US/docs/Web/CSS/percentage)



>The syntax of <number> extends the syntax of <integer>. A fractional value is represented by a . followed by **one or more** decimal digits, and may be appended to an integer [see](https://developer.mozilla.org/en-US/docs/Web/CSS/number)


current regex only allowed for. 0 or 1 digit after `.`