### PR TITLE
Fix colorToHex conversion

### DIFF
--- a/src/internalHelpers/_hslToHex.js
+++ b/src/internalHelpers/_hslToHex.js
@@ -4,7 +4,7 @@ import reduceHexValue from './_reduceHexValue'
 import toHex from './_numberToHex'
 
 function colorToHex(color: number): string {
-  return toHex(Math.round(color * 255))
+  return toHex(Math.round(color / 255))
 }
 
 function convertToHex(red: number, green: number, blue: number): string {


### PR DESCRIPTION
The number should be divided by 255 instead of multiplying.
This assumes the value of color will be 0-255 (which is the case with the `hslToRgb` fn), and not 0-1.